### PR TITLE
Visual V10: alinhar menu, HUD e contratos ao formato aprovado

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Este arquivo orienta Codex, Manus, agentes locais e qualquer assistente automati
 
 ## Missão
 
-Construir **Cria do Tatame – Pressão**, jogo Godot 4.2+ para Android, PC e Web, com combate tático de Jiu-Jitsu Brasileiro, carreira, reputação, mundo vivo do Baixo Sul da Bahia e identidade visual preto/dourado premium.
+Construir **Cria do Tatame – Pressão**, jogo Godot 4.3+ para Android ARM64 e Windows x86_64, com combate tático de Jiu-Jitsu Brasileiro, carreira, reputação, mundo vivo do Baixo Sul da Bahia e identidade visual preto/dourado premium.
 
 ## Fonte única de verdade
 
@@ -13,7 +13,7 @@ Construir **Cria do Tatame – Pressão**, jogo Godot 4.2+ para Android, PC e We
 - Não criar outro repositório para protótipo, APK, arte, lore ou versão alternativa.
 - Protótipos devem viver em branches ou pastas explicitamente delimitadas.
 - Documentos antigos não podem substituir dados e bíblias canônicas atuais.
-- Antes de criar algo, procure implementação equivalente neste repositório.
+- Antes de criar algo, procurar implementação equivalente neste repositório.
 
 ## Regra de ouro
 
@@ -28,17 +28,45 @@ Não transformar o projeto em galeria de arte. Primeiro deve abrir, rodar, salva
 - Poder: Silverback Grip.
 - Frase eixo: Ser forte é ser gentil.
 
-Qualquer referência antiga a Caio Ravel ou Ruan “Cria” é legado e não deve ir para UI, campanha principal ou dados finais.
+Qualquer referência antiga a Caio Ravel, Rafa do Tatame ou Ruan “Cria” é legado e não deve ir para UI, campanha principal ou dados finais.
+
+## Contratos visuais obrigatórios
+
+Antes de alterar UI, sprites, mapas, arenas ou VFX, ler:
+
+- `docs/art/VISUAL_TARGET_V10.md`;
+- `data/ui/ui_design_tokens_v01.json`;
+- `data/visual/screen_contracts_v01.json`;
+- `data/visual/production_manifest_v02.json`;
+- `docs/production/VISUAL_IMPLEMENTATION_BACKLOG_V10.md`.
+
+Regras:
+
+- HD Pixel Art 2.5D Regional Premium.
+- Resolução-base 1280×720.
+- Grade 16 px.
+- Sprite de combate com 72 px de altura-base.
+- Sprite de hub em célula 64×64 e oito direções.
+- Filtro nearest.
+- Centro da luta sempre limpo.
+- Botão Android com 80 px mínimos na resolução-base.
+- Safe area Android de 7%.
+- Cria Live e Skill Tree devem usar abas no Android; não reduzir dashboard desktop inteiro.
+- Não incorporar texto longo em imagens de runtime.
+- Não usar marcas, logos institucionais ou símbolos culturais sem autorização/revisão.
+- Concept art, infográfico e ficha técnica não entram diretamente na build.
 
 ## Ordem técnica obrigatória
 
 1. Executar `npm run quality`.
-2. Garantir que `project.godot` abre no Godot 4.2+.
+2. Garantir que `project.godot` abre no Godot 4.3+ e mantém compatibilidade auditada.
 3. Ligar e validar autoloads.
 4. Preservar o fluxo Main Menu → Terreiro → Combate → Resultado → Save.
 5. Implementar combate por estados relativos de BJJ.
 6. Integrar carreira semanal, reputação, Cria Live, facções e patrocinadores.
-7. Só depois polir sprites, áudio, VFX e cutscenes.
+7. Aplicar os contratos visuais às telas principais.
+8. Produzir sprites, arenas, áudio e VFX com metadata e QA.
+9. Exportar e testar Android/Windows.
 
 ## Contratos de arquitetura
 
@@ -47,6 +75,26 @@ Qualquer referência antiga a Caio Ravel ou Ruan “Cria” é legado e não dev
 - Dados em `data/` precisam manter IDs estáveis e referências válidas.
 - Sistemas novos devem possuir ponto de entrada claro, teste ou checklist de validação e documentação mínima.
 - Código temporário deve conter prazo ou condição objetiva de remoção.
+- UI reage a sinais e estado; não deve controlar regras centrais diretamente.
+- Conteúdo de personagem, técnica, arena e missão deve ser data-driven.
+
+## Pipeline de asset
+
+Nenhum asset é aceito sem:
+
+- `raw_sheet.png`;
+- `clean_sheet.png`;
+- `spritesheet.png`;
+- `frames/`;
+- `preview.gif`;
+- `contact_sheet.png`;
+- `metadata.json`;
+- `import_notes.md`;
+- `qa_report.md`.
+
+Técnicas pareadas também exigem atacante, defensor, `sync_map.json` e `hitbox.json`.
+Arenas exigem layers, props, `collision.json`, `camera_bounds.json` e `arena.tscn`.
+Áudio exige master WAV, runtime OGG e metadata.
 
 ## Restrições
 
@@ -57,6 +105,19 @@ Qualquer referência antiga a Caio Ravel ou Ruan “Cria” é legado e não dev
 - Não apagar arquivos úteis sem relatório de migração.
 - Não introduzir segunda engine, segundo canon ou segundo backend de conteúdo.
 - Não versionar segredos, chaves, tokens, keystores ou credenciais.
+- Não usar nomes de arquivo finais como `image1.png`, `final_final.png` ou equivalentes.
+
+## Quality gates
+
+Uma alteração só pode ser descrita como pronta se:
+
+1. JSON e referências passam nos validadores;
+2. parser/import headless passa;
+3. smoke test passa;
+4. a cena pode ser navegada no fluxo real;
+5. a UI permanece legível em 1280×720 e Android;
+6. assets possuem metadata e QA;
+7. bugs e limitações são declarados.
 
 ## Saída esperada de cada agente
 
@@ -67,4 +128,5 @@ Todo agente deve entregar:
 3. testes executados;
 4. erros encontrados;
 5. riscos ou dívidas técnicas;
-6. próximo passo recomendado.
+6. evidências de validação;
+7. próximo passo recomendado.

--- a/data/ui/ui_design_tokens_v01.json
+++ b/data/ui/ui_design_tokens_v01.json
@@ -1,0 +1,98 @@
+{
+  "schema_version": 1,
+  "id": "cria_ui_tokens_v01",
+  "target_resolution": [1280, 720],
+  "safe_area_percent": {
+    "desktop": 5,
+    "android": 7
+  },
+  "grid_px": 8,
+  "pixel_grid_px": 16,
+  "colors": {
+    "black_ocean": "#080A0D",
+    "black_matte": "#11151B",
+    "charcoal_warm": "#201B14",
+    "gold_burned": "#B8860B",
+    "honor_yellow": "#F2C230",
+    "dirty_white": "#E8DFD0",
+    "river_blue": "#1E3A5F",
+    "mangrove_green": "#2D5016",
+    "conflict_red": "#D92323",
+    "shadow_purple": "#4B0082",
+    "control_cyan": "#09A8C8",
+    "success_green": "#55C95A",
+    "disabled_gray": "#5B6068"
+  },
+  "semantic_colors": {
+    "hp": "conflict_red",
+    "gas": "river_blue",
+    "focus": "honor_yellow",
+    "moral": "shadow_purple",
+    "control": "control_cyan",
+    "grip": "dirty_white",
+    "honra": "honor_yellow",
+    "hype": "shadow_purple",
+    "sombra": "conflict_red",
+    "raiz": "mangrove_green",
+    "dupla_face": "shadow_purple"
+  },
+  "spacing": {
+    "xs": 4,
+    "sm": 8,
+    "md": 12,
+    "lg": 16,
+    "xl": 24,
+    "xxl": 32
+  },
+  "corner_radius": {
+    "small": 2,
+    "medium": 4,
+    "large": 8
+  },
+  "borders": {
+    "thin": 1,
+    "normal": 2,
+    "emphasis": 3
+  },
+  "font_sizes": {
+    "caption": 14,
+    "body": 16,
+    "button": 18,
+    "section": 22,
+    "screen_title": 32,
+    "hero_title": 44,
+    "combat_timer": 38
+  },
+  "touch": {
+    "action_button_min_px": 80,
+    "technique_icon_min_px": 48,
+    "joystick_min_px": 120,
+    "interaction_radius_px": 56,
+    "hold_duration_seconds": 0.35
+  },
+  "animation": {
+    "ui_fast_seconds": 0.08,
+    "ui_normal_seconds": 0.16,
+    "ui_slow_seconds": 0.28,
+    "screen_transition_seconds": 0.35,
+    "hitstop_light_seconds": 0.03,
+    "hitstop_heavy_seconds": 0.07,
+    "perfect_defense_flash_seconds": 0.09
+  },
+  "screen_density": {
+    "max_primary_actions_visible": 5,
+    "max_resource_bars_combat": 7,
+    "max_active_missions_hub": 3,
+    "max_dashboard_columns_android": 1,
+    "max_dashboard_columns_desktop": 4
+  },
+  "runtime_rules": [
+    "no_text_baked_into_runtime_images",
+    "no_real_brands",
+    "no_console_button_glyphs_on_touch_layout",
+    "combat_center_must_remain_clear",
+    "all_critical_values_have_icon_and_text_or_colorblind_safe_pattern",
+    "android_layout_uses_tabs_for_cria_live_and_skill_tree",
+    "nearest_filter_for_pixel_assets"
+  ]
+}

--- a/data/visual/screen_contracts_v01.json
+++ b/data/visual/screen_contracts_v01.json
@@ -1,0 +1,84 @@
+{
+  "schema_version": 1,
+  "project": "cria_do_tatame_pressao",
+  "screens": [
+    {
+      "id": "main_menu",
+      "scene": "res://scenes/main_menu/MainMenu.tscn",
+      "layout": "brand_left_actions_right_or_centered",
+      "required_regions": ["brand", "canon_badge", "primary_actions", "version", "accessibility_hint"],
+      "primary_actions": ["new_game", "continue", "options"],
+      "visual_tags": ["gorila_silverback", "black_gold", "bahia_mangrove_silhouette"],
+      "android_rules": ["buttons_min_80px", "safe_area_7_percent", "single_column_actions"]
+    },
+    {
+      "id": "world_map",
+      "scene": "res://scenes/map/WorldMap.tscn",
+      "layout": "left_objective_center_map_right_location",
+      "required_regions": ["player_header", "objective_panel", "map_canvas", "location_detail", "legend", "bottom_actions"],
+      "required_data": ["locations", "routes", "travel_cost", "faction_control", "danger_level", "mission_state"],
+      "route_types": ["terrestrial", "maritime", "blocked", "secret"],
+      "node_status": ["locked", "available", "active", "completed", "boss"],
+      "android_rules": ["pan_zoom_gestures", "tap_node_to_open_sheet", "confirm_travel_modal"]
+    },
+    {
+      "id": "terreiro_hub",
+      "scene": "res://scenes/hubs/TerreiroDaLuta.tscn",
+      "layout": "playfield_with_edge_hud",
+      "required_regions": ["player_status", "active_missions", "minimap", "location_clock", "touch_actions", "interaction_markers"],
+      "world_interactions": ["train", "talk", "rest", "missions", "shop", "cria_live", "travel"],
+      "environment_states": ["morning", "afternoon", "night", "rain"],
+      "android_rules": ["touch_cluster_lower_right", "mission_list_collapsible", "center_playfield_clear"]
+    },
+    {
+      "id": "combat_hud_mobile",
+      "scene": "res://scenes/ui/CombatHUD.tscn",
+      "layout": "mirrored_top_context_bottom",
+      "required_regions": ["player_resources", "opponent_resources", "round_timer", "state_label", "control_panel", "grip_panel", "command_bar", "corner_message"],
+      "resources": ["hp", "gas", "guard", "focus", "moral", "control", "grip_integrity"],
+      "combat_contexts": ["standing", "clinch", "ground_top", "ground_bottom", "submission_attack", "submission_defense"],
+      "command_slots": 5,
+      "android_rules": ["buttons_min_80px", "contextual_labels", "no_gamepad_glyphs", "haptic_feedback_optional"]
+    },
+    {
+      "id": "cria_live",
+      "scene": "res://scenes/ui/CriaLive.tscn",
+      "desktop_layout": "feed_left_dashboard_center_factions_right",
+      "android_layout": "tabbed_single_column",
+      "tabs": ["feed", "contracts", "factions", "skills", "crises"],
+      "required_data": ["posts", "comments", "followers", "contracts", "crises", "faction_influence", "skill_points", "reputation"],
+      "reputation_axes": ["honra", "hype", "sombra", "dupla_face"],
+      "android_rules": ["one_tab_visible", "sticky_bottom_navigation", "cards_min_height_96px"]
+    },
+    {
+      "id": "skill_tree",
+      "scene": "res://scenes/ui/SkillTree.tscn",
+      "layout": "four_branch_graph",
+      "branches": [
+        {"id": "technique", "color": "river_blue"},
+        {"id": "pressure", "color": "conflict_red"},
+        {"id": "cold_blood", "color": "control_cyan"},
+        {"id": "legacy", "color": "gold_burned"}
+      ],
+      "required_node_fields": ["id", "icon", "cost", "belt_required", "dependencies", "effect", "state"],
+      "node_states": ["locked", "available", "unlocked", "equipped"],
+      "android_rules": ["one_branch_filter_available", "pinch_zoom_optional", "selected_skill_sheet_bottom"]
+    },
+    {
+      "id": "arena_reference_sheet",
+      "runtime": false,
+      "layout": "main_view_gameplay_details_mechanics_lighting_npcs",
+      "required_sections": ["hero_view", "gameplay_mockup", "detail_crops", "mechanics", "lighting_variants", "npc_groups", "palette", "audio_notes"],
+      "required_runtime_exports": ["layers", "props", "collision.json", "camera_bounds.json", "arena.tscn", "qa_report.md"]
+    }
+  ],
+  "global_rules": [
+    "Ruan Macacao Silva is the only protagonist name in final UI",
+    "concept sheets are not runtime textures",
+    "all screens use the same black gold frame language",
+    "critical gameplay text must remain editable and localized",
+    "mobile layouts are redesigned rather than scaled desktop dashboards",
+    "real brands and government logos are replaced by fictional equivalents",
+    "geography must be reviewed before release"
+  ]
+}

--- a/docs/art/VISUAL_TARGET_V10.md
+++ b/docs/art/VISUAL_TARGET_V10.md
@@ -1,0 +1,339 @@
+# Cria do Tatame — Visual Target V10
+
+## Status
+
+Este documento transforma as referências visuais aprovadas em contrato de produção para Godot 4.3+, Android ARM64 e Windows x86_64.
+
+A referência final não é uma imagem isolada. É um sistema coerente com seis famílias de tela:
+
+1. mapa mundial interativo;
+2. hub explorável 2.5D;
+3. combate lateral tático;
+4. Cria Live + facções + árvore de habilidades;
+5. fichas técnicas de arenas/personagens;
+6. marca Gorila Silverback preto/dourado.
+
+## 1. Diagnóstico do material atual
+
+### Pontos fortes aprovados
+
+- Identidade imediatamente reconhecível: preto, dourado queimado, branco sujo, azul profundo e acentos de facção.
+- Mapa do Baixo Sul funciona como tela de decisão, não apenas ilustração.
+- Combate mostra posição, controle, pegada, gás, foco, moral e contexto de comandos.
+- Hub de Ituberá comunica vida cotidiana, comércio, academia, missões e conexão com o mangue.
+- Cria Live conecta reputação, patrocinadores, facções, crises e skill tree em uma camada social única.
+- Arenas possuem modificadores visuais e mecânicos próprios.
+- A marca do Gorila Silverback cria unidade entre HUD, roupas, logo, menus e progressão.
+
+### Problemas a eliminar
+
+- Textos pequenos demais para Android.
+- Excesso de informação simultânea sem hierarquia.
+- Mockups com marcas reais, nomes institucionais reais ou geografias inconsistentes.
+- Alternância indevida entre “Ruan Cria”, “Ruan Macacão”, “Rafa do Tatame” e outros placeholders.
+- Imagens conceituais tratadas como se já fossem sprites, tiles ou cenas jogáveis.
+- Ilustrações muito pintadas sem grade, pivô e recorte técnico.
+- Controles de console exibidos em telas mobile.
+
+## 2. Canon visual obrigatório
+
+| Item | Contrato |
+|---|---|
+| Protagonista | Ruan “Macacão” Silva |
+| Símbolo | Gorila Silverback coroado |
+| Frase | Ser forte é ser gentil. |
+| Engine | Godot 4.3+ |
+| Plataformas | Android ARM64 e Windows x86_64 |
+| Estilo | HD Pixel Art 2.5D Regional Premium |
+| Resolução-base | 1280×720, escala responsiva |
+| Grade | 16 px |
+| Sprite de combate | 72 px de altura-base |
+| Sprite de hub | célula 64×64, oito direções |
+| Filtro | nearest |
+| Contorno | 1 px externo escuro |
+| Rim light | 1 px interno colorido |
+
+## 3. Linguagem visual
+
+### Paleta central
+
+- `#080A0D` — preto oceânico, fundo principal.
+- `#11151B` — preto fosco, painéis.
+- `#201B14` — carvão quente, madeira e cards.
+- `#B8860B` — dourado queimado, molduras.
+- `#F2C230` — amarelo honra, seleção e vitória.
+- `#E8DFD0` — branco sujo, texto principal.
+- `#1E3A5F` — azul rio profundo, água e circuito oficial.
+- `#2D5016` — verde mangue, raiz e recuperação.
+- `#D92323` — vermelho conflito, dano e crise.
+- `#4B0082` — roxo sombra, dualidade e Kuroi Mizu.
+- `#09A8C8` — ciano técnico, controle e UI de posição.
+
+### Materiais
+
+- metal escovado e ferrugem nas arenas clandestinas;
+- madeira gasta e tecido de gi no Terreiro;
+- água, lama e reflexos no mangue;
+- concreto, cartazes e luz urbana nos hubs;
+- moldura preta com filete dourado em todas as telas sistêmicas;
+- ruído e pincel seco apenas como textura de apoio, nunca prejudicando leitura.
+
+### Tipografia
+
+- Títulos: condensada, pesada, esportiva.
+- Dados e HUD: sans-serif estreita e altamente legível.
+- Corpo: sans-serif simples.
+- Em runtime, não embutir texto em imagens.
+- Tamanho mínimo Android: 16 px para texto principal e 18–22 px para valores críticos.
+
+## 4. Família 1 — Mapa mundial
+
+### Estrutura
+
+- mapa isométrico/top-down ocupa 65–72% da largura;
+- painel de objetivo à esquerda;
+- ficha do local selecionado à direita;
+- barra superior com personagem, nível, XP, dinheiro, energia, fadiga e reputação;
+- barra inferior com ações;
+- rotas terrestres, marítimas e bloqueadas visualmente distintas;
+- ícones de risco, torneio, missão, treino e boss.
+
+### Regras de gameplay
+
+- Ituberá permanece hub central.
+- Cada viagem mostra custo em tempo, energia e risco antes da confirmação.
+- Fog of war esconde locais sem quebrar a geografia.
+- Facção dominante muda cor de borda, NPCs, eventos e recompensas.
+- O mapa nunca usa cidades ou rios em posição falsa apenas para “ficar bonito”.
+
+## 5. Família 2 — Hub explorável
+
+### Câmera
+
+- top-down/2.5D com personagens proporcionais;
+- leitura clara dos caminhos;
+- minimapa no canto superior direito;
+- câmera acompanha o jogador com suavização curta;
+- interiores podem aproximar a câmera sem mudar a escala do personagem.
+
+### HUD
+
+- retrato, nível e três recursos principais no topo esquerdo;
+- missão ativa abaixo;
+- localização, horário e clima no topo direito;
+- botões touch no canto inferior direito;
+- textos e marcadores nunca cobrem NPCs importantes.
+
+### Ituberá
+
+- academia, mercado, cais, bar, clínica/recuperação e quadro de missões;
+- casas coloridas, vegetação tropical, drenagem, madeira, mangue e rio;
+- moradores com rotinas;
+- ciclos manhã/tarde/noite/chuva;
+- o Terreiro evolui visualmente conforme o Legado.
+
+## 6. Família 3 — Combate lateral tático
+
+### Composição
+
+- lutadores ocupam o centro e permanecem sem obstrução;
+- HUD espelhado no topo;
+- timer e round no centro;
+- controle e grip nas laterais inferiores;
+- comandos contextuais no rodapé;
+- estado posicional sempre visível.
+
+### Recursos visuais
+
+- HP: verde/vermelho conforme risco;
+- Gás: azul;
+- Foco: amarelo/roxo;
+- Moral: ícone + texto curto;
+- Controle: ciano com escala percentual;
+- Grip Integrity: branco/cinza com alerta dourado/vermelho;
+- Guarda/Postura: escudo e segmentos.
+
+### Contexto de comandos
+
+O comando muda pela posição:
+
+- em pé: medir, jab, defesa, clinch, queda;
+- clinch: pummeling, quebra de postura, defesa de pegada, projeção;
+- chão por cima: pressão, passagem, montada, costas, finalização;
+- chão por baixo: guarda, raspagem, recomposição, escape, finalização;
+- encerramento: setup, lock, finish, ajuste, soltar.
+
+### Feedback
+
+- hitstop curto apenas em quedas, defesas perfeitas e transições críticas;
+- câmera aproxima em finalizações sem perder a leitura do corpo;
+- partículas separadas por layer;
+- vibração mobile configurável;
+- instruções descrevem função de jogo, não dano real.
+
+## 7. Família 4 — Cria Live, facções e skill tree
+
+### Layout desktop/tablet
+
+- coluna esquerda: feed e personagens;
+- topo central: patrocinadores e contratos;
+- topo direito: crises e mapa de influência;
+- centro inferior: Ruan e quatro ramos da árvore;
+- rodapé: navegação principal.
+
+### Layout Android
+
+A tela deve ser dividida em abas:
+
+1. Feed;
+2. Contratos;
+3. Facções;
+4. Habilidades;
+5. Crises.
+
+Nunca reproduzir todo o dashboard desktop em uma tela pequena.
+
+### Ramos da árvore
+
+- Técnica — azul.
+- Pressão — vermelho.
+- Frieza — verde/ciano.
+- Legado — roxo/dourado.
+
+Cada nó exibe ícone, custo, faixa requerida, efeito e conexão. Nós bloqueados ficam dessaturados, sem perder contraste.
+
+## 8. Família 5 — Fichas técnicas de arena
+
+As fichas ilustradas são documentos internos, não telas de runtime.
+
+Cada arena deve possuir:
+
+- vista principal;
+- mockup de gameplay;
+- detalhes de piso, props, luz e público;
+- quatro variações de iluminação quando aplicável;
+- grupos de NPC;
+- modificadores;
+- risco de lesão gamificado;
+- paleta;
+- mapa de colisão;
+- limites de câmera;
+- layers de parallax;
+- pacote de áudio.
+
+## 9. Família 6 — Marca Gorila Silverback
+
+### Usos corretos
+
+- tela inicial;
+- ícone do aplicativo;
+- patch do gi/rashguard;
+- indicador de habilidade Silverback Grip;
+- troféu e emblema de legado;
+- elementos de moldura.
+
+### Limites
+
+- o gorila é símbolo, não personagem jogável;
+- evitar aparência infantil ou de mascote cômico;
+- não usar óculos/marca comercial real;
+- criar design próprio de óculos dourados;
+- não inserir kanji sem revisão cultural.
+
+## 10. Arquitetura de assets
+
+```text
+assets/
+├── brand/
+├── characters/
+│   └── <character_id>/
+│       ├── concept/
+│       ├── raw/
+│       ├── clean/
+│       ├── frames/
+│       ├── sheets/
+│       ├── previews/
+│       └── metadata/
+├── arenas/
+│   └── <arena_id>/
+│       ├── layers/
+│       ├── props/
+│       ├── tiles/
+│       ├── collision/
+│       ├── lighting/
+│       └── previews/
+├── ui/
+│   ├── icons/
+│   ├── panels/
+│   ├── buttons/
+│   ├── portraits/
+│   └── themes/
+├── vfx/
+└── audio/
+```
+
+## 11. Quality gates
+
+### Visual
+
+- silhueta legível a 25% da escala;
+- nenhuma borda borrada;
+- nenhuma mudança de altura entre frames;
+- pivô estável;
+- cores dentro da paleta;
+- sem texto gerado por IA em sprites;
+- sem marcas reais;
+- sem geografia inventada tratada como oficial.
+
+### Runtime
+
+- tela legível em 1280×720;
+- safe area de 7% no Android;
+- botões touch com 80 px mínimos na resolução-base;
+- UI não cobre o corpo dos lutadores;
+- 30 FPS mínimo em aparelho de entrada;
+- 60 FPS alvo em aparelho intermediário/PC;
+- queda de qualidade automática para partículas, luzes e parallax.
+
+### Entrega por asset
+
+Obrigatório:
+
+- `raw_sheet.png`;
+- `clean_sheet.png`;
+- `spritesheet.png`;
+- `frames/`;
+- `preview.gif`;
+- `contact_sheet.png`;
+- `metadata.json`;
+- `import_notes.md`;
+- `qa_report.md`.
+
+Técnica pareada também exige atacante, defensor, `sync_map.json` e `hitbox.json`.
+
+## 12. Ordem de implementação
+
+1. design tokens e temas;
+2. Main Menu;
+3. HUD de combate;
+4. World Map;
+5. Hub Ituberá/Terreiro;
+6. Cria Live mobile;
+7. Skill Tree;
+8. Arena Dique final;
+9. Ruan e Davi finalizados;
+10. expansão para demais personagens e arenas.
+
+## 13. Definition of Done visual V10
+
+A direção V10 só está implantada quando:
+
+- as cinco telas principais usam o mesmo design system;
+- o protagonista aparece somente como Ruan “Macacão” Silva;
+- o mapa é navegável e data-driven;
+- o hub é explorável;
+- o combate mostra recursos e comandos contextuais;
+- o Cria Live funciona em abas no Android;
+- ao menos Ruan, Davi, Terreiro e Arena do Dique possuem assets finais importados;
+- todos os assets possuem metadata e QA;
+- build Android foi testada em aparelho físico.

--- a/docs/production/VISUAL_IMPLEMENTATION_BACKLOG_V10.md
+++ b/docs/production/VISUAL_IMPLEMENTATION_BACKLOG_V10.md
@@ -1,0 +1,241 @@
+# Visual Implementation Backlog V10
+
+## Objetivo
+
+Converter o runtime funcional atual para o formato visual aprovado sem quebrar combate, save/load, carreira, Android ou contratos de dados.
+
+## Veredito do estado atual
+
+| Área | Estado atual | Estado-alvo |
+|---|---|---|
+| Main Menu | Estrutura funcional com fundo plano e botões genéricos | Marca Silverback, preto/dourado, hierarquia premium e safe area |
+| Combat HUD | Barras básicas e mensagem | HUD espelhado, timer central, controle/grip laterais e cinco comandos contextuais |
+| World Map | Sistema existente/documentado | Mapa regional com objetivo, rotas, riscos, facções e ficha do local |
+| Terreiro | Hub funcional/placeholder | Hub vivo 2.5D, NPCs, missões, minimapa, clima e evolução visual |
+| Cria Live | Sistemas de reputação disponíveis | Feed, contratos, crises, facções e skill tree em abas mobile |
+| Personagens | Manifesto de produção | Spritesheets finais sincronizados e QA por ação |
+| Arenas | Dados e referências | Cinco layers, props, colisão, clima, público e áudio |
+| Áudio | Pacotes definidos | Masters WAV, runtime OGG, buses e mix adaptativo |
+
+## Sprint V10.0 — Contratos
+
+- [x] Criar `docs/art/VISUAL_TARGET_V10.md`.
+- [x] Criar `data/ui/ui_design_tokens_v01.json`.
+- [x] Criar `data/visual/screen_contracts_v01.json`.
+- [ ] Adicionar validação de schema para os dois JSON.
+- [ ] Registrar os contratos em `DataRegistry`.
+- [ ] Adicionar testes que bloqueiem nomes legados na UI.
+
+## Sprint V10.1 — Main Menu
+
+- [x] Reconstruir estrutura visual preto/dourado.
+- [x] Preservar Novo Jogo, Continuar, Opções e áudio.
+- [ ] Importar logo final sem texto rasterizado ilegível.
+- [ ] Criar background em cinco layers: céu, mangue, água, Terreiro e partículas.
+- [ ] Adicionar transição curta para o hub.
+- [ ] Testar 1280×720, 1920×1080 e proporções mobile.
+
+## Sprint V10.2 — Combat HUD
+
+- [x] Criar moldura espelhada e barra superior.
+- [x] Adicionar regiões de Controle, Pegada e comandos.
+- [x] Manter paths esperados pelo script atual.
+- [ ] Conectar timer e round ao `CombatManager`.
+- [ ] Atualizar Controle e Grip em tempo real.
+- [ ] Popular cinco botões a partir das técnicas válidas.
+- [ ] Alternar labels por estado.
+- [ ] Criar layout touch sem glyphs de controle físico.
+- [ ] Criar modo acessível para daltonismo e texto ampliado.
+
+## Sprint V10.3 — World Map
+
+Arquivos-alvo:
+
+```text
+scenes/map/WorldMap.tscn
+scenes/map/WorldMap.gd
+data/world/locations.json
+data/world/routes.json
+data/world/faction_territories.json
+```
+
+Entregas:
+
+- [ ] mapa com zoom/pan;
+- [ ] Ituberá como hub central;
+- [ ] rotas terrestres, marítimas, secretas e bloqueadas;
+- [ ] objetivo atual à esquerda;
+- [ ] ficha do local à direita;
+- [ ] custo de viagem em dia, energia e dinheiro;
+- [ ] status de missão, boss, torneio e facção;
+- [ ] confirmação antes de viajar;
+- [ ] revisão geográfica.
+
+## Sprint V10.4 — Hub Ituberá/Terreiro
+
+- [ ] reconstruir o playfield em camadas 2.5D;
+- [ ] implementar minimapa;
+- [ ] adicionar marcadores de Academia, Mercado, Doca, Quadro e Clínica;
+- [ ] exibir até três missões ativas;
+- [ ] adicionar ciclo manhã/tarde/noite/chuva;
+- [ ] NPCs com rotinas simples;
+- [ ] sistema de interação touch;
+- [ ] evolução visual do Terreiro por nível de Legado.
+
+## Sprint V10.5 — Cria Live + Skill Tree
+
+- [ ] criar layout desktop de referência;
+- [ ] criar layout Android em cinco abas;
+- [ ] feed com posts e respostas;
+- [ ] contratos com progresso e risco;
+- [ ] crises com temporizador narrativo;
+- [ ] mapa de influência de facções;
+- [ ] árvore com Técnica, Pressão, Frieza e Legado;
+- [ ] tooltips com custo, faixa e efeito;
+- [ ] nenhuma ação social sem consequência sistêmica.
+
+## Sprint V10.6 — Personagens
+
+Prioridade:
+
+1. Ruan “Macacão” Silva;
+2. Davi Relâmpago;
+3. Mestre Dendê;
+4. Tinker Bell;
+5. Leoa Quilombola;
+6. Jacaré do Mangue;
+7. Oni da Lapa;
+8. Cássio Molho;
+9. Kenzo Kuroi;
+10. Mestre Guigo;
+11. Delegado Montenegro.
+
+Para cada lutador:
+
+- turnaround;
+- escala de combate e hub;
+- portrait;
+- core animation profile;
+- técnicas assinatura;
+- reações;
+- hitboxes/hurtboxes;
+- metadata;
+- QA.
+
+## Sprint V10.7 — Técnicas pareadas
+
+Ordem recomendada:
+
+1. jab setup;
+2. clinch entry;
+3. pummeling;
+4. baiana/single leg;
+5. sprawl;
+6. raspagem tesoura;
+7. knee cut;
+8. mount transition;
+9. bridge escape;
+10. armbar;
+11. triângulo;
+12. mata-leão.
+
+Cada técnica exige:
+
+```text
+attacker/
+defender/
+sync_map.json
+hitbox.json
+preview.gif
+contact_sheet.png
+qa_report.md
+```
+
+## Sprint V10.8 — Arenas
+
+Ordem:
+
+1. Terreiro da Luta;
+2. Arena do Dique;
+3. Manguezal Profundo;
+4. Praia de Pratigi;
+5. Ferro Velho da Lapa;
+6. Ponte do Saici;
+7. Zambiapunga;
+8. Mirante da Gamboa;
+9. Pancada Grande;
+10. Budokan das Águas;
+11. Itacaré;
+12. Sede do Circuito Final.
+
+Pacote por arena:
+
+- `bg_far.png`;
+- `bg_mid.png`;
+- `play_area.png`;
+- `foreground.png`;
+- `overlay_particles.png`;
+- `props/`;
+- `collision.json`;
+- `camera_bounds.json`;
+- `arena.tscn`;
+- variações de clima/luz;
+- pacote de áudio;
+- QA.
+
+## Sprint V10.9 — Android
+
+- [ ] botões 80 px mínimos em 1280×720;
+- [ ] joystick 120 px;
+- [ ] safe area 7%;
+- [ ] layout adaptativo para 16:9, 18:9, 19.5:9 e 20:9;
+- [ ] vibração configurável;
+- [ ] qualidade baixa/média/alta;
+- [ ] redução automática de partículas e luzes;
+- [ ] teste em aparelho ARM64 físico;
+- [ ] captura de FPS e memória;
+- [ ] APK debug com SHA-256.
+
+## Gates de aprovação
+
+### Gate A — estrutura
+
+- JSON válido;
+- paths `res://` válidos;
+- cenas abrem em headless;
+- nenhum conflito de autoload/class_name.
+
+### Gate B — jogabilidade
+
+- Main Menu → Terreiro → Combate → Resultado → Hub;
+- save roundtrip;
+- estado de combate governa comandos;
+- carreira avança uma semana.
+
+### Gate C — visual
+
+- mesmo design system nas telas principais;
+- centro da luta limpo;
+- texto legível;
+- nenhuma marca real;
+- protagonista canônico correto;
+- concept art não usado como asset final.
+
+### Gate D — audiovisual
+
+- sprites, arenas e áudio com metadata;
+- previews e QA presentes;
+- sincronização atacante/defensor validada;
+- buses e volumes normalizados.
+
+### Gate E — release
+
+- build Windows;
+- APK debug;
+- teste físico;
+- performance registrada;
+- bugs conhecidos documentados.
+
+## Regra de fechamento
+
+O projeto não pode ser chamado de “jogo completo” enquanto apenas mockups reproduzem o visual aprovado. Conclusão exige cenas, sprites, áudio, controles, saves, testes e builds reais.

--- a/scenes/main_menu/MainMenu.gd
+++ b/scenes/main_menu/MainMenu.gd
@@ -2,13 +2,13 @@ extends Control
 
 const HUB_SCENE := "res://scenes/hubs/TerreiroDaLuta.tscn"
 
-@onready var menu_buttons: VBoxContainer = $Content/MenuButtons
-@onready var options_panel: VBoxContainer = $Content/OptionsPanel
-@onready var new_game_button: Button = $Content/MenuButtons/NewGame
-@onready var continue_button: Button = $Content/MenuButtons/Continue
-@onready var options_button: Button = $Content/MenuButtons/Options
-@onready var audio_toggle_button: Button = $Content/OptionsPanel/AudioToggle
-@onready var options_back_button: Button = $Content/OptionsPanel/Back
+@onready var menu_buttons: VBoxContainer = $ContentPanel/Content/MenuButtons
+@onready var options_panel: VBoxContainer = $ContentPanel/Content/OptionsPanel
+@onready var new_game_button: Button = $ContentPanel/Content/MenuButtons/NewGame
+@onready var continue_button: Button = $ContentPanel/Content/MenuButtons/Continue
+@onready var options_button: Button = $ContentPanel/Content/MenuButtons/Options
+@onready var audio_toggle_button: Button = $ContentPanel/Content/OptionsPanel/AudioToggle
+@onready var options_back_button: Button = $ContentPanel/Content/OptionsPanel/Back
 
 var _transitioning := false
 
@@ -41,7 +41,7 @@ func _on_continue_pressed() -> void:
 	_transitioning = true
 	if SaveManager.has_save(1):
 		if not SaveManager.load_game(1):
-			push_warning("[MainMenu] Save invalido. Iniciando novo jogo.")
+			push_warning("[MainMenu] Save inválido. Iniciando novo jogo.")
 			WorldState.reset_new_game()
 			GameFlowManager.start_new_run()
 	else:
@@ -70,4 +70,4 @@ func _on_audio_toggle_pressed() -> void:
 
 func _update_audio_label() -> void:
 	if audio_toggle_button != null:
-		audio_toggle_button.text = "AUDIO: %s" % ("LIGADO" if AudioManager.enabled else "DESLIGADO")
+		audio_toggle_button.text = "ÁUDIO: %s" % ("LIGADO" if AudioManager.enabled else "DESLIGADO")

--- a/scenes/main_menu/MainMenu.tscn
+++ b/scenes/main_menu/MainMenu.tscn
@@ -1,6 +1,68 @@
-[gd_scene load_steps=2 format=3]
+[gd_scene load_steps=7 format=3]
 
 [ext_resource type="Script" path="res://scenes/main_menu/MainMenu.gd" id="1_mainmenu"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBox_card"]
+bg_color = Color(0.043, 0.055, 0.071, 0.96)
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color(0.722, 0.525, 0.043, 0.92)
+corner_radius_top_left = 6
+corner_radius_top_right = 6
+corner_radius_bottom_right = 6
+corner_radius_bottom_left = 6
+shadow_color = Color(0, 0, 0, 0.55)
+shadow_size = 12
+
+[sub_resource type="StyleBoxFlat" id="StyleBox_button_normal"]
+bg_color = Color(0.067, 0.082, 0.106, 0.98)
+border_width_left = 2
+border_width_top = 1
+border_width_right = 2
+border_width_bottom = 1
+border_color = Color(0.722, 0.525, 0.043, 0.72)
+corner_radius_top_left = 4
+corner_radius_top_right = 4
+corner_radius_bottom_right = 4
+corner_radius_bottom_left = 4
+
+[sub_resource type="StyleBoxFlat" id="StyleBox_button_hover"]
+bg_color = Color(0.122, 0.102, 0.063, 1)
+border_width_left = 4
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color(0.949, 0.761, 0.188, 1)
+corner_radius_top_left = 4
+corner_radius_top_right = 4
+corner_radius_bottom_right = 4
+corner_radius_bottom_left = 4
+
+[sub_resource type="StyleBoxFlat" id="StyleBox_button_pressed"]
+bg_color = Color(0.722, 0.525, 0.043, 1)
+border_width_left = 4
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color(0.949, 0.761, 0.188, 1)
+corner_radius_top_left = 4
+corner_radius_top_right = 4
+corner_radius_bottom_right = 4
+corner_radius_bottom_left = 4
+
+[sub_resource type="StyleBoxFlat" id="StyleBox_button_disabled"]
+bg_color = Color(0.075, 0.082, 0.094, 0.72)
+border_width_left = 1
+border_width_top = 1
+border_width_right = 1
+border_width_bottom = 1
+border_color = Color(0.357, 0.376, 0.408, 0.55)
+corner_radius_top_left = 4
+corner_radius_top_right = 4
+corner_radius_bottom_right = 4
+corner_radius_bottom_left = 4
 
 [node name="MainMenu" type="Control"]
 layout_mode = 3
@@ -18,82 +80,246 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
-color = Color(0.027, 0.031, 0.039, 1)
+color = Color(0.015, 0.02, 0.027, 1)
 mouse_filter = 2
 
-[node name="Content" type="VBoxContainer" parent="."]
-custom_minimum_size = Vector2(520, 0)
+[node name="RiverGlow" type="ColorRect" parent="."]
 layout_mode = 1
-anchors_preset = 8
-anchor_left = 0.5
-anchor_top = 0.5
-anchor_right = 0.5
-anchor_bottom = 0.5
-offset_left = -260.0
-offset_top = -250.0
-offset_right = 260.0
-offset_bottom = 250.0
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
-theme_override_constants/separation = 14
+color = Color(0.02, 0.085, 0.13, 0.34)
+mouse_filter = 2
 
-[node name="Title" type="Label" parent="Content"]
+[node name="GoldHorizon" type="ColorRect" parent="."]
+layout_mode = 1
+anchors_preset = 12
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_top = -170.0
+grow_horizontal = 2
+grow_vertical = 0
+color = Color(0.31, 0.208, 0.035, 0.22)
+mouse_filter = 2
+
+[node name="TopRule" type="ColorRect" parent="."]
+layout_mode = 1
+anchors_preset = 10
+anchor_right = 1.0
+offset_bottom = 4.0
+grow_horizontal = 2
+color = Color(0.949, 0.761, 0.188, 0.9)
+mouse_filter = 2
+
+[node name="BrandMark" type="VBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 4
+anchor_top = 0.5
+anchor_bottom = 0.5
+offset_left = 72.0
+offset_top = -205.0
+offset_right = 500.0
+offset_bottom = 205.0
+grow_vertical = 2
+theme_override_constants/separation = 10
+
+[node name="Crown" type="Label" parent="BrandMark"]
 layout_mode = 2
-theme_override_colors/font_color = Color(1, 0.756, 0.027, 1)
-theme_override_font_sizes/font_size = 36
+theme_override_colors/font_color = Color(0.949, 0.761, 0.188, 1)
+theme_override_font_sizes/font_size = 30
+text = "♛  GORILA SILVERBACK"
+
+[node name="BrandTitle" type="Label" parent="BrandMark"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.91, 0.875, 0.816, 1)
+theme_override_font_sizes/font_size = 54
+text = "CRIA DO"
+
+[node name="BrandTitleGold" type="Label" parent="BrandMark"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.949, 0.761, 0.188, 1)
+theme_override_font_sizes/font_size = 68
+text = "TATAME"
+
+[node name="BrandRule" type="ColorRect" parent="BrandMark"]
+custom_minimum_size = Vector2(0, 4)
+layout_mode = 2
+color = Color(0.722, 0.525, 0.043, 1)
+
+[node name="BrandCopy" type="Label" parent="BrandMark"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.82, 0.82, 0.79, 1)
+theme_override_font_sizes/font_size = 18
+text = "BAIXO SUL DA BAHIA  •  JIU-JITSU POSICIONAL"
+autowrap_mode = 2
+
+[node name="BrandPillars" type="Label" parent="BrandMark"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.949, 0.761, 0.188, 0.92)
+theme_override_font_sizes/font_size = 16
+text = "POSIÇÃO > FORÇA   •   O MUNDO REAGE   •   ESCOLHAS IMPORTAM"
+autowrap_mode = 2
+
+[node name="ContentPanel" type="PanelContainer" parent="."]
+custom_minimum_size = Vector2(520, 0)
+layout_mode = 1
+anchors_preset = 6
+anchor_left = 1.0
+anchor_top = 0.5
+anchor_right = 1.0
+anchor_bottom = 0.5
+offset_left = -600.0
+offset_top = -290.0
+offset_right = -72.0
+offset_bottom = 290.0
+grow_horizontal = 0
+grow_vertical = 2
+theme_override_styles/panel = SubResource("StyleBox_card")
+
+[node name="Content" type="VBoxContainer" parent="ContentPanel"]
+custom_minimum_size = Vector2(480, 0)
+layout_mode = 2
+theme_override_constants/separation = 13
+
+[node name="Eyebrow" type="Label" parent="ContentPanel/Content"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.722, 0.525, 0.043, 1)
+theme_override_font_sizes/font_size = 16
+text = "ACTION RPG DE CARREIRA • GODOT 4.3+"
+horizontal_alignment = 1
+
+[node name="Title" type="Label" parent="ContentPanel/Content"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.949, 0.761, 0.188, 1)
+theme_override_font_sizes/font_size = 38
 text = "CRIA DO TATAME"
 horizontal_alignment = 1
 
-[node name="Subtitle" type="Label" parent="Content"]
+[node name="Subtitle" type="Label" parent="ContentPanel/Content"]
 layout_mode = 2
-text = "PRESSAO • ITUBERA • JIU-JITSU POSICIONAL"
+theme_override_colors/font_color = Color(0.91, 0.875, 0.816, 1)
+theme_override_font_sizes/font_size = 17
+text = "PRESSÃO • ITUBERÁ • JIU-JITSU POSICIONAL"
 horizontal_alignment = 1
 
-[node name="Quote" type="Label" parent="Content"]
+[node name="Quote" type="Label" parent="ContentPanel/Content"]
 layout_mode = 2
-text = "Ser forte e ser gentil."
+theme_override_colors/font_color = Color(0.8, 0.82, 0.84, 1)
+theme_override_font_sizes/font_size = 20
+text = "“Ser forte é ser gentil.”"
 horizontal_alignment = 1
 
-[node name="MenuButtons" type="VBoxContainer" parent="Content"]
+[node name="CanonBadge" type="PanelContainer" parent="ContentPanel/Content"]
+layout_mode = 2
+theme_override_styles/panel = SubResource("StyleBox_button_normal")
+
+[node name="CanonText" type="Label" parent="ContentPanel/Content/CanonBadge"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.91, 0.875, 0.816, 1)
+theme_override_font_sizes/font_size = 16
+text = "RUAN “MACACÃO” SILVA  •  SILVERBACK GRIP"
+horizontal_alignment = 1
+
+[node name="MenuButtons" type="VBoxContainer" parent="ContentPanel/Content"]
 layout_mode = 2
 theme_override_constants/separation = 10
 
-[node name="NewGame" type="Button" parent="Content/MenuButtons"]
-custom_minimum_size = Vector2(0, 58)
+[node name="NewGame" type="Button" parent="ContentPanel/Content/MenuButtons"]
+custom_minimum_size = Vector2(0, 64)
 layout_mode = 2
+theme_override_colors/font_color = Color(0.91, 0.875, 0.816, 1)
+theme_override_colors/font_hover_color = Color(1, 0.93, 0.66, 1)
+theme_override_colors/font_pressed_color = Color(0.03, 0.035, 0.04, 1)
+theme_override_font_sizes/font_size = 20
+theme_override_styles/normal = SubResource("StyleBox_button_normal")
+theme_override_styles/hover = SubResource("StyleBox_button_hover")
+theme_override_styles/pressed = SubResource("StyleBox_button_pressed")
 text = "NOVO JOGO"
 
-[node name="Continue" type="Button" parent="Content/MenuButtons"]
-custom_minimum_size = Vector2(0, 58)
+[node name="Continue" type="Button" parent="ContentPanel/Content/MenuButtons"]
+custom_minimum_size = Vector2(0, 64)
 layout_mode = 2
+theme_override_colors/font_color = Color(0.91, 0.875, 0.816, 1)
+theme_override_colors/font_hover_color = Color(1, 0.93, 0.66, 1)
+theme_override_colors/font_pressed_color = Color(0.03, 0.035, 0.04, 1)
+theme_override_colors/font_disabled_color = Color(0.42, 0.44, 0.48, 1)
+theme_override_font_sizes/font_size = 20
+theme_override_styles/normal = SubResource("StyleBox_button_normal")
+theme_override_styles/hover = SubResource("StyleBox_button_hover")
+theme_override_styles/pressed = SubResource("StyleBox_button_pressed")
+theme_override_styles/disabled = SubResource("StyleBox_button_disabled")
 text = "CONTINUAR"
 
-[node name="Options" type="Button" parent="Content/MenuButtons"]
-custom_minimum_size = Vector2(0, 58)
+[node name="Options" type="Button" parent="ContentPanel/Content/MenuButtons"]
+custom_minimum_size = Vector2(0, 64)
 layout_mode = 2
-text = "OPCOES"
+theme_override_colors/font_color = Color(0.91, 0.875, 0.816, 1)
+theme_override_colors/font_hover_color = Color(1, 0.93, 0.66, 1)
+theme_override_colors/font_pressed_color = Color(0.03, 0.035, 0.04, 1)
+theme_override_font_sizes/font_size = 20
+theme_override_styles/normal = SubResource("StyleBox_button_normal")
+theme_override_styles/hover = SubResource("StyleBox_button_hover")
+theme_override_styles/pressed = SubResource("StyleBox_button_pressed")
+text = "OPÇÕES"
 
-[node name="OptionsPanel" type="VBoxContainer" parent="Content"]
+[node name="OptionsPanel" type="VBoxContainer" parent="ContentPanel/Content"]
 visible = false
 layout_mode = 2
 theme_override_constants/separation = 10
 
-[node name="OptionsTitle" type="Label" parent="Content/OptionsPanel"]
+[node name="OptionsTitle" type="Label" parent="ContentPanel/Content/OptionsPanel"]
 layout_mode = 2
-text = "OPCOES RAPIDAS"
+theme_override_colors/font_color = Color(0.949, 0.761, 0.188, 1)
+theme_override_font_sizes/font_size = 22
+text = "OPÇÕES RÁPIDAS"
 horizontal_alignment = 1
 
-[node name="AudioToggle" type="Button" parent="Content/OptionsPanel"]
-custom_minimum_size = Vector2(0, 54)
+[node name="AudioToggle" type="Button" parent="ContentPanel/Content/OptionsPanel"]
+custom_minimum_size = Vector2(0, 60)
 layout_mode = 2
-text = "AUDIO: LIGADO"
+theme_override_colors/font_color = Color(0.91, 0.875, 0.816, 1)
+theme_override_font_sizes/font_size = 18
+theme_override_styles/normal = SubResource("StyleBox_button_normal")
+theme_override_styles/hover = SubResource("StyleBox_button_hover")
+theme_override_styles/pressed = SubResource("StyleBox_button_pressed")
+text = "ÁUDIO: LIGADO"
 
-[node name="Version" type="Label" parent="Content/OptionsPanel"]
+[node name="Version" type="Label" parent="ContentPanel/Content/OptionsPanel"]
 layout_mode = 2
-text = "Vertical Slice Runtime v0.8"
+theme_override_colors/font_color = Color(0.62, 0.65, 0.7, 1)
+theme_override_font_sizes/font_size = 14
+text = "Visual Runtime V10 • Vertical Slice V0.8"
 horizontal_alignment = 1
 
-[node name="Back" type="Button" parent="Content/OptionsPanel"]
-custom_minimum_size = Vector2(0, 54)
+[node name="Back" type="Button" parent="ContentPanel/Content/OptionsPanel"]
+custom_minimum_size = Vector2(0, 60)
 layout_mode = 2
+theme_override_colors/font_color = Color(0.91, 0.875, 0.816, 1)
+theme_override_font_sizes/font_size = 18
+theme_override_styles/normal = SubResource("StyleBox_button_normal")
+theme_override_styles/hover = SubResource("StyleBox_button_hover")
+theme_override_styles/pressed = SubResource("StyleBox_button_pressed")
 text = "VOLTAR"
+
+[node name="BottomBar" type="HBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 12
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 40.0
+offset_top = -52.0
+offset_right = -40.0
+offset_bottom = -18.0
+grow_horizontal = 2
+grow_vertical = 0
+alignment = 1
+
+[node name="Footer" type="Label" parent="BottomBar"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.72, 0.65, 0.45, 1)
+theme_override_font_sizes/font_size = 14
+text = "DE CRIA PRA CRIA  •  LUTA  •  DISCIPLINA  •  EVOLUÇÃO"

--- a/scenes/ui/CombatHUD.gd
+++ b/scenes/ui/CombatHUD.gd
@@ -1,32 +1,41 @@
 extends CanvasLayer
 
 var estados_ptbr := {
-	"PLAYER_STANDING_NEUTRAL": "EM PE - NEUTRO",
-	"PLAYER_TOP_CLINCH": "CLINCH - POR CIMA",
-	"PLAYER_BOTTOM_CLINCH": "CLINCH - POR BAIXO",
-	"PLAYER_TOP_GUARD": "GUARDA - POR CIMA",
-	"PLAYER_BOTTOM_GUARD": "GUARDA - POR BAIXO",
-	"PLAYER_TOP_SIDE": "LATERAL - POR CIMA",
-	"PLAYER_BOTTOM_SIDE": "LATERAL - POR BAIXO",
-	"PLAYER_TOP_MOUNT": "MONTADA - POR CIMA",
-	"PLAYER_BOTTOM_MOUNT": "MONTADA - POR BAIXO",
-	"PLAYER_BACK_ATTACK": "COSTAS - ATACANDO",
-	"PLAYER_BACK_DEFENSE": "COSTAS - DEFENDENDO",
-	"PLAYER_SUBMISSION_ATTACK": "ENCERRAMENTO - ATACANDO",
-	"PLAYER_SUBMISSION_DEFENSE": "ENCERRAMENTO - DEFENDENDO",
+	"PLAYER_STANDING_NEUTRAL": "EM PÉ • NEUTRO",
+	"PLAYER_TOP_CLINCH": "CLINCH • POR CIMA",
+	"PLAYER_BOTTOM_CLINCH": "CLINCH • POR BAIXO",
+	"PLAYER_TOP_GUARD": "GUARDA • POR CIMA",
+	"PLAYER_BOTTOM_GUARD": "GUARDA • POR BAIXO",
+	"PLAYER_TOP_SIDE": "LATERAL • POR CIMA",
+	"PLAYER_BOTTOM_SIDE": "LATERAL • POR BAIXO",
+	"PLAYER_TOP_MOUNT": "MONTADA • POR CIMA",
+	"PLAYER_BOTTOM_MOUNT": "MONTADA • POR BAIXO",
+	"PLAYER_BACK_ATTACK": "COSTAS • ATACANDO",
+	"PLAYER_BACK_DEFENSE": "COSTAS • DEFENDENDO",
+	"PLAYER_SUBMISSION_ATTACK": "FINALIZAÇÃO • ATACANDO",
+	"PLAYER_SUBMISSION_DEFENSE": "FINALIZAÇÃO • DEFENDENDO",
 	"RESET": "REINICIANDO"
 }
 
 var barras_dinamicas := {}
 var estado_label: Label
 var mensagem_label: Label
+var action_buttons: Array[Button] = []
 
 func _ready() -> void:
 	_build_fallback_ui_if_needed()
+	_cache_action_buttons()
 	if not SignalBus.resources_changed.is_connected(_on_resources_changed):
 		SignalBus.resources_changed.connect(_on_resources_changed)
 	if not SignalBus.combat_state_changed.is_connected(_on_combat_state_changed):
 		SignalBus.combat_state_changed.connect(_on_combat_state_changed)
+
+func _cache_action_buttons() -> void:
+	action_buttons.clear()
+	for index in range(1, 6):
+		var button := get_node_or_null("CommandPlate/CommandBar/Action%d" % index) as Button
+		if button != null:
+			action_buttons.append(button)
 
 func _build_fallback_ui_if_needed() -> void:
 	if has_node("TopBar"):
@@ -40,7 +49,7 @@ func _build_fallback_ui_if_needed() -> void:
 	add_child(top_bar)
 	estado_label = Label.new()
 	estado_label.name = "StateLabel"
-	estado_label.text = "EM PE - NEUTRO"
+	estado_label.text = "EM PÉ • NEUTRO"
 	estado_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
 	top_bar.add_child(estado_label)
 	var grid := GridContainer.new()
@@ -68,28 +77,65 @@ func _build_fallback_ui_if_needed() -> void:
 	add_child(mensagem_label)
 
 func update_state(state_name: String) -> void:
+	var translated := estados_ptbr.get(state_name, state_name.replace("_", " "))
 	if has_node("TopBar/StateLabel"):
-		$TopBar/StateLabel.text = estados_ptbr.get(state_name, state_name)
+		$TopBar/StateLabel.text = translated
 	elif estado_label != null:
-		estado_label.text = estados_ptbr.get(state_name, state_name)
+		estado_label.text = translated
+	_update_control_hint(translated)
 
 func update_player_resources(resources: Dictionary) -> void:
-	_update_bar("TopBar/PlayerPanel/PlayerHP", resources.get("health", resources.get("hp", 100)), 100)
-	_update_bar("TopBar/PlayerPanel/PlayerGas", resources.get("gas", 100), 100)
-	_update_bar("TopBar/PlayerPanel/PlayerGuarda", resources.get("guard", resources.get("guarda", 100)), 100)
-	_update_bar("TopBar/PlayerPanel/PlayerFoco", resources.get("focus", resources.get("foco", 100)), 100)
-	_update_bar("TopBar/PlayerPanel/PlayerMoral", resources.get("moral", 100), 100)
-	_set_dynamic("HP", resources.get("health", resources.get("hp", 100)))
-	_set_dynamic("Gás", resources.get("gas", 100))
-	_set_dynamic("Guarda", resources.get("guard", resources.get("guarda", 100)))
-	_set_dynamic("Foco", resources.get("focus", resources.get("foco", 100)))
-	_set_dynamic("Moral", resources.get("moral", 100))
-	_set_dynamic("Controle", resources.get("control", resources.get("control_meter", 0)))
-	_set_dynamic("Pegada", resources.get("grip_integrity", resources.get("integridade_pegada", 100)))
+	var hp := float(resources.get("health", resources.get("hp", 100)))
+	var gas := float(resources.get("gas", 100))
+	var guard_value := float(resources.get("guard", resources.get("guarda", 100)))
+	var focus_value := float(resources.get("focus", resources.get("foco", 100)))
+	var moral_value := float(resources.get("moral", 100))
+	var control_value := float(resources.get("control", resources.get("control_meter", 0)))
+	var grip_value := float(resources.get("grip_integrity", resources.get("integridade_pegada", 100)))
+
+	_update_bar("TopBar/PlayerPanel/PlayerHP", hp, 100)
+	_update_bar("TopBar/PlayerPanel/PlayerGas", gas, 100)
+	_update_bar("TopBar/PlayerPanel/PlayerGuarda", guard_value, 100)
+	_update_bar("TopBar/PlayerPanel/PlayerFoco", focus_value, 100)
+	_update_bar("TopBar/PlayerPanel/PlayerMoral", moral_value, 100)
+	_set_dynamic("HP", hp)
+	_set_dynamic("Gás", gas)
+	_set_dynamic("Guarda", guard_value)
+	_set_dynamic("Foco", focus_value)
+	_set_dynamic("Moral", moral_value)
+	_set_dynamic("Controle", control_value)
+	_set_dynamic("Pegada", grip_value)
+	_set_label_text("ControlPanel/ControlStack/ControlValue", "%d%%" % roundi(abs(control_value)))
+	_set_label_text("GripPanel/GripStack/GripValue", _grip_word(grip_value))
+	_set_label_text("GripPanel/GripStack/GripHint", "INTEGRIDADE %d%%" % roundi(grip_value))
 
 func update_opponent_resources(resources: Dictionary) -> void:
 	_update_bar("TopBar/OpponentPanel/OpponentHP", resources.get("health", resources.get("hp", 100)), 100)
 	_update_bar("TopBar/OpponentPanel/OpponentGas", resources.get("gas", 100), 100)
+
+func update_round_timer(seconds_remaining: int, round_index: int, round_total: int = 3) -> void:
+	var minutes := maxi(seconds_remaining, 0) / 60
+	var seconds := maxi(seconds_remaining, 0) % 60
+	_set_label_text("TopBar/TimerLabel", "%02d:%02d" % [minutes, seconds])
+	_set_label_text("TopBar/OpponentPanel/RoundValue", "%d / %d" % [round_index, round_total])
+
+func update_fighter_names(player_name: String, opponent_name: String, opponent_archetype: String = "RIVAL") -> void:
+	_set_label_text("TopBar/PlayerPanel/PlayerName", player_name)
+	_set_label_text("TopBar/OpponentPanel/OpponentName", opponent_name)
+	_set_label_text("TopBar/OpponentPanel/OpponentStatus", opponent_archetype)
+
+func update_context_actions(actions: Array) -> void:
+	for index in range(action_buttons.size()):
+		var button := action_buttons[index]
+		if index >= actions.size():
+			button.visible = false
+			button.disabled = true
+			continue
+		var action_data = actions[index]
+		button.visible = true
+		button.disabled = not bool(action_data.get("enabled", true))
+		button.text = _format_action_label(action_data)
+		button.tooltip_text = str(action_data.get("description", ""))
 
 func show_message(msg: String, duration: float = 2.0) -> void:
 	var label := get_node_or_null("MessageLabel")
@@ -112,10 +158,34 @@ func _on_combat_state_changed(_old_state, new_state) -> void:
 
 func _update_bar(path: String, value: float, max_value: float) -> void:
 	if has_node(path):
-		var bar = get_node(path)
+		var bar := get_node(path) as ProgressBar
 		bar.max_value = max_value
-		bar.value = value
+		bar.value = clampf(value, 0.0, max_value)
 
 func _set_dynamic(label: String, value) -> void:
 	if barras_dinamicas.has(label):
 		barras_dinamicas[label].value = float(value)
+
+func _set_label_text(path: String, value: String) -> void:
+	var label := get_node_or_null(path) as Label
+	if label != null:
+		label.text = value
+
+func _update_control_hint(state_text: String) -> void:
+	_set_label_text("ControlPanel/ControlStack/ControlHint", state_text)
+
+func _grip_word(value: float) -> String:
+	if value >= 70.0:
+		return "FORTE"
+	if value >= 40.0:
+		return "ESTÁVEL"
+	if value >= 20.0:
+		return "FRACA"
+	return "QUEBRANDO"
+
+func _format_action_label(action_data: Dictionary) -> String:
+	var label := str(action_data.get("label", action_data.get("name", "AÇÃO"))).to_upper()
+	var gas_cost := int(action_data.get("gas_cost", action_data.get("gas", 0)))
+	if gas_cost > 0:
+		return "%s\nGÁS %d" % [label, gas_cost]
+	return label

--- a/scenes/ui/CombatHUD.gd
+++ b/scenes/ui/CombatHUD.gd
@@ -114,8 +114,9 @@ func update_opponent_resources(resources: Dictionary) -> void:
 	_update_bar("TopBar/OpponentPanel/OpponentGas", resources.get("gas", 100), 100)
 
 func update_round_timer(seconds_remaining: int, round_index: int, round_total: int = 3) -> void:
-	var minutes := maxi(seconds_remaining, 0) / 60
-	var seconds := maxi(seconds_remaining, 0) % 60
+	var safe_seconds := maxi(seconds_remaining, 0)
+	var minutes := int(safe_seconds / 60)
+	var seconds := safe_seconds % 60
 	_set_label_text("TopBar/TimerLabel", "%02d:%02d" % [minutes, seconds])
 	_set_label_text("TopBar/OpponentPanel/RoundValue", "%d / %d" % [round_index, round_total])
 
@@ -131,14 +132,14 @@ func update_context_actions(actions: Array) -> void:
 			button.visible = false
 			button.disabled = true
 			continue
-		var action_data = actions[index]
+		var action_data: Dictionary = actions[index]
 		button.visible = true
 		button.disabled = not bool(action_data.get("enabled", true))
 		button.text = _format_action_label(action_data)
 		button.tooltip_text = str(action_data.get("description", ""))
 
 func show_message(msg: String, duration: float = 2.0) -> void:
-	var label := get_node_or_null("MessageLabel")
+	var label := get_node_or_null("MessageLabel") as Label
 	if label == null:
 		label = mensagem_label
 	if label == null:

--- a/scenes/ui/CombatHUD.tscn
+++ b/scenes/ui/CombatHUD.tscn
@@ -1,81 +1,440 @@
-[gd_scene load_steps=2 format=3]
+[gd_scene load_steps=11 format=3]
 
 [ext_resource type="Script" path="res://scenes/ui/CombatHUD.gd" id="1"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBox_panel"]
+bg_color = Color(0.035, 0.047, 0.063, 0.94)
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color(0.722, 0.525, 0.043, 0.92)
+corner_radius_top_left = 4
+corner_radius_top_right = 4
+corner_radius_bottom_right = 4
+corner_radius_bottom_left = 4
+shadow_color = Color(0, 0, 0, 0.48)
+shadow_size = 8
+
+[sub_resource type="StyleBoxFlat" id="StyleBox_bar_bg"]
+bg_color = Color(0.035, 0.043, 0.055, 0.95)
+border_width_left = 1
+border_width_top = 1
+border_width_right = 1
+border_width_bottom = 1
+border_color = Color(0.42, 0.44, 0.48, 0.8)
+corner_radius_top_left = 2
+corner_radius_top_right = 2
+corner_radius_bottom_right = 2
+corner_radius_bottom_left = 2
+
+[sub_resource type="StyleBoxFlat" id="StyleBox_hp"]
+bg_color = Color(0.85, 0.137, 0.137, 1)
+corner_radius_top_left = 2
+corner_radius_top_right = 2
+corner_radius_bottom_right = 2
+corner_radius_bottom_left = 2
+
+[sub_resource type="StyleBoxFlat" id="StyleBox_gas"]
+bg_color = Color(0.039, 0.52, 0.78, 1)
+corner_radius_top_left = 2
+corner_radius_top_right = 2
+corner_radius_bottom_right = 2
+corner_radius_bottom_left = 2
+
+[sub_resource type="StyleBoxFlat" id="StyleBox_guard"]
+bg_color = Color(0.333, 0.788, 0.353, 1)
+corner_radius_top_left = 2
+corner_radius_top_right = 2
+corner_radius_bottom_right = 2
+corner_radius_bottom_left = 2
+
+[sub_resource type="StyleBoxFlat" id="StyleBox_focus"]
+bg_color = Color(0.949, 0.761, 0.188, 1)
+corner_radius_top_left = 2
+corner_radius_top_right = 2
+corner_radius_bottom_right = 2
+corner_radius_bottom_left = 2
+
+[sub_resource type="StyleBoxFlat" id="StyleBox_moral"]
+bg_color = Color(0.48, 0.12, 0.72, 1)
+corner_radius_top_left = 2
+corner_radius_top_right = 2
+corner_radius_bottom_right = 2
+corner_radius_bottom_left = 2
+
+[sub_resource type="StyleBoxFlat" id="StyleBox_command"]
+bg_color = Color(0.055, 0.067, 0.086, 0.96)
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color(0.15, 0.64, 0.78, 0.8)
+corner_radius_top_left = 4
+corner_radius_top_right = 4
+corner_radius_bottom_right = 4
+corner_radius_bottom_left = 4
+
+[sub_resource type="StyleBoxFlat" id="StyleBox_danger"]
+bg_color = Color(0.16, 0.035, 0.035, 0.94)
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color(0.85, 0.137, 0.137, 0.9)
+corner_radius_top_left = 4
+corner_radius_top_right = 4
+corner_radius_bottom_right = 4
+corner_radius_bottom_left = 4
 
 [node name="CombatHUD" type="CanvasLayer"]
 script = ExtResource("1")
 
-[node name="TopBar" type="VBoxContainer" parent="."]
+[node name="BackdropShade" type="ColorRect" parent="."]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0, 0, 0, 0.05)
+mouse_filter = 2
+
+[node name="TopPlate" type="PanelContainer" parent="."]
 anchors_preset = 10
 anchor_right = 1.0
-offset_left = 24.0
-offset_top = 16.0
-offset_right = -24.0
-offset_bottom = 170.0
+offset_left = 18.0
+offset_top = 12.0
+offset_right = -18.0
+offset_bottom = 164.0
+grow_horizontal = 2
+theme_override_styles/panel = SubResource("StyleBox_panel")
+mouse_filter = 2
 
-[node name="StateLabel" type="Label" parent="TopBar"]
-layout_mode = 2
-horizontal_alignment = 1
-text = "EM PE - NEUTRO"
+[node name="TopBar" type="HBoxContainer" parent="."]
+anchors_preset = 10
+anchor_right = 1.0
+offset_left = 32.0
+offset_top = 24.0
+offset_right = -32.0
+offset_bottom = 154.0
+grow_horizontal = 2
+theme_override_constants/separation = 16
 
 [node name="PlayerPanel" type="GridContainer" parent="TopBar"]
+custom_minimum_size = Vector2(430, 0)
 layout_mode = 2
-columns = 4
+size_flags_horizontal = 3
+columns = 2
+theme_override_constants/h_separation = 8
+theme_override_constants/v_separation = 3
+
+[node name="PlayerName" type="Label" parent="TopBar/PlayerPanel"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.949, 0.761, 0.188, 1)
+theme_override_font_sizes/font_size = 18
+text = "RUAN “MACACÃO” SILVA"
+
+[node name="PlayerStatus" type="Label" parent="TopBar/PlayerPanel"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.82, 0.82, 0.79, 1)
+theme_override_font_sizes/font_size = 14
+text = "PRESSÃO • SILVERBACK GRIP"
+horizontal_alignment = 2
+
+[node name="HPLabel" type="Label" parent="TopBar/PlayerPanel"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.91, 0.875, 0.816, 1)
+text = "VIDA"
 
 [node name="PlayerHP" type="ProgressBar" parent="TopBar/PlayerPanel"]
-custom_minimum_size = Vector2(220, 22)
+custom_minimum_size = Vector2(330, 18)
 layout_mode = 2
+theme_override_font_sizes/font_size = 12
+theme_override_styles/background = SubResource("StyleBox_bar_bg")
+theme_override_styles/fill = SubResource("StyleBox_hp")
 max_value = 100.0
 value = 100.0
+show_percentage = false
+
+[node name="GasLabel" type="Label" parent="TopBar/PlayerPanel"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.91, 0.875, 0.816, 1)
+text = "GÁS"
 
 [node name="PlayerGas" type="ProgressBar" parent="TopBar/PlayerPanel"]
-custom_minimum_size = Vector2(220, 22)
+custom_minimum_size = Vector2(330, 16)
 layout_mode = 2
+theme_override_styles/background = SubResource("StyleBox_bar_bg")
+theme_override_styles/fill = SubResource("StyleBox_gas")
 max_value = 100.0
 value = 100.0
+show_percentage = false
+
+[node name="GuardLabel" type="Label" parent="TopBar/PlayerPanel"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.91, 0.875, 0.816, 1)
+text = "GUARDA"
 
 [node name="PlayerGuarda" type="ProgressBar" parent="TopBar/PlayerPanel"]
-custom_minimum_size = Vector2(220, 22)
+custom_minimum_size = Vector2(330, 14)
 layout_mode = 2
+theme_override_styles/background = SubResource("StyleBox_bar_bg")
+theme_override_styles/fill = SubResource("StyleBox_guard")
 max_value = 100.0
 value = 100.0
+show_percentage = false
+
+[node name="FocusLabel" type="Label" parent="TopBar/PlayerPanel"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.91, 0.875, 0.816, 1)
+text = "FOCO"
 
 [node name="PlayerFoco" type="ProgressBar" parent="TopBar/PlayerPanel"]
-custom_minimum_size = Vector2(220, 22)
+custom_minimum_size = Vector2(330, 14)
 layout_mode = 2
+theme_override_styles/background = SubResource("StyleBox_bar_bg")
+theme_override_styles/fill = SubResource("StyleBox_focus")
 max_value = 100.0
 value = 100.0
+show_percentage = false
+
+[node name="MoralLabel" type="Label" parent="TopBar/PlayerPanel"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.91, 0.875, 0.816, 1)
+text = "MORAL"
 
 [node name="PlayerMoral" type="ProgressBar" parent="TopBar/PlayerPanel"]
-custom_minimum_size = Vector2(220, 22)
+custom_minimum_size = Vector2(330, 14)
 layout_mode = 2
+theme_override_styles/background = SubResource("StyleBox_bar_bg")
+theme_override_styles/fill = SubResource("StyleBox_moral")
 max_value = 100.0
 value = 100.0
+show_percentage = false
+
+[node name="StateLabel" type="Label" parent="TopBar"]
+custom_minimum_size = Vector2(190, 0)
+layout_mode = 2
+theme_override_colors/font_color = Color(0.949, 0.761, 0.188, 1)
+theme_override_font_sizes/font_size = 19
+text = "EM PÉ • NEUTRO"
+horizontal_alignment = 1
+vertical_alignment = 1
+autowrap_mode = 2
+
+[node name="TimerLabel" type="Label" parent="TopBar"]
+custom_minimum_size = Vector2(120, 0)
+layout_mode = 2
+theme_override_colors/font_color = Color(0.91, 0.875, 0.816, 1)
+theme_override_font_sizes/font_size = 36
+text = "03:45"
+horizontal_alignment = 1
+vertical_alignment = 1
 
 [node name="OpponentPanel" type="GridContainer" parent="TopBar"]
+custom_minimum_size = Vector2(360, 0)
 layout_mode = 2
+size_flags_horizontal = 3
 columns = 2
+theme_override_constants/h_separation = 8
+theme_override_constants/v_separation = 5
+
+[node name="OpponentStatus" type="Label" parent="TopBar/OpponentPanel"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.82, 0.82, 0.79, 1)
+theme_override_font_sizes/font_size = 14
+text = "RIVAL TÉCNICO"
+
+[node name="OpponentName" type="Label" parent="TopBar/OpponentPanel"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.949, 0.761, 0.188, 1)
+theme_override_font_sizes/font_size = 18
+text = "DAVI RELÂMPAGO"
+horizontal_alignment = 2
+
+[node name="OpponentHPLabel" type="Label" parent="TopBar/OpponentPanel"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.91, 0.875, 0.816, 1)
+text = "VIDA"
 
 [node name="OpponentHP" type="ProgressBar" parent="TopBar/OpponentPanel"]
-custom_minimum_size = Vector2(260, 22)
+custom_minimum_size = Vector2(270, 18)
 layout_mode = 2
+theme_override_styles/background = SubResource("StyleBox_bar_bg")
+theme_override_styles/fill = SubResource("StyleBox_hp")
 max_value = 100.0
 value = 100.0
+show_percentage = false
+
+[node name="OpponentGasLabel" type="Label" parent="TopBar/OpponentPanel"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.91, 0.875, 0.816, 1)
+text = "GÁS"
 
 [node name="OpponentGas" type="ProgressBar" parent="TopBar/OpponentPanel"]
-custom_minimum_size = Vector2(260, 22)
+custom_minimum_size = Vector2(270, 16)
 layout_mode = 2
+theme_override_styles/background = SubResource("StyleBox_bar_bg")
+theme_override_styles/fill = SubResource("StyleBox_gas")
 max_value = 100.0
 value = 100.0
+show_percentage = false
+
+[node name="RoundLabel" type="Label" parent="TopBar/OpponentPanel"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.91, 0.875, 0.816, 1)
+text = "ROUND"
+
+[node name="RoundValue" type="Label" parent="TopBar/OpponentPanel"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.949, 0.761, 0.188, 1)
+theme_override_font_sizes/font_size = 18
+text = "1 / 3"
+horizontal_alignment = 2
+
+[node name="ControlPanel" type="PanelContainer" parent="."]
+anchors_preset = 4
+anchor_top = 0.5
+anchor_bottom = 0.5
+offset_left = 24.0
+offset_top = 92.0
+offset_right = 236.0
+offset_bottom = 206.0
+grow_vertical = 2
+theme_override_styles/panel = SubResource("StyleBox_command")
+
+[node name="ControlStack" type="VBoxContainer" parent="ControlPanel"]
+layout_mode = 2
+
+[node name="ControlTitle" type="Label" parent="ControlPanel/ControlStack"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.31, 0.79, 0.9, 1)
+theme_override_font_sizes/font_size = 18
+text = "CONTROLE"
+horizontal_alignment = 1
+
+[node name="ControlValue" type="Label" parent="ControlPanel/ControlStack"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.91, 0.875, 0.816, 1)
+theme_override_font_sizes/font_size = 28
+text = "50%"
+horizontal_alignment = 1
+
+[node name="ControlHint" type="Label" parent="ControlPanel/ControlStack"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.72, 0.75, 0.78, 1)
+text = "POSIÇÃO NEUTRA"
+horizontal_alignment = 1
+
+[node name="GripPanel" type="PanelContainer" parent="."]
+layout_mode = 1
+anchors_preset = 6
+anchor_left = 1.0
+anchor_top = 0.5
+anchor_right = 1.0
+anchor_bottom = 0.5
+offset_left = -236.0
+offset_top = 92.0
+offset_right = -24.0
+offset_bottom = 206.0
+grow_horizontal = 0
+grow_vertical = 2
+theme_override_styles/panel = SubResource("StyleBox_command")
+
+[node name="GripStack" type="VBoxContainer" parent="GripPanel"]
+layout_mode = 2
+
+[node name="GripTitle" type="Label" parent="GripPanel/GripStack"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.949, 0.761, 0.188, 1)
+theme_override_font_sizes/font_size = 18
+text = "PEGADA"
+horizontal_alignment = 1
+
+[node name="GripValue" type="Label" parent="GripPanel/GripStack"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.91, 0.875, 0.816, 1)
+theme_override_font_sizes/font_size = 28
+text = "FORTE"
+horizontal_alignment = 1
+
+[node name="GripHint" type="Label" parent="GripPanel/GripStack"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.72, 0.75, 0.78, 1)
+text = "INTEGRIDADE 72%"
+horizontal_alignment = 1
 
 [node name="MessageLabel" type="Label" parent="."]
 anchors_preset = 12
 anchor_top = 1.0
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_left = 24.0
-offset_top = -96.0
-offset_right = -24.0
-offset_bottom = -24.0
+offset_left = 260.0
+offset_top = -188.0
+offset_right = -260.0
+offset_bottom = -144.0
+grow_horizontal = 2
+grow_vertical = 0
+theme_override_colors/font_color = Color(0.949, 0.761, 0.188, 1)
+theme_override_font_sizes/font_size = 18
 horizontal_alignment = 1
+vertical_alignment = 1
 autowrap_mode = 3
+
+[node name="CommandPlate" type="PanelContainer" parent="."]
+anchors_preset = 12
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 118.0
+offset_top = -136.0
+offset_right = -118.0
+offset_bottom = -18.0
+grow_horizontal = 2
+grow_vertical = 0
+theme_override_styles/panel = SubResource("StyleBox_panel")
+
+[node name="CommandBar" type="HBoxContainer" parent="CommandPlate"]
+layout_mode = 2
+theme_override_constants/separation = 10
+alignment = 1
+
+[node name="Action1" type="Button" parent="CommandPlate/CommandBar"]
+custom_minimum_size = Vector2(180, 80)
+layout_mode = 2
+theme_override_colors/font_color = Color(0.91, 0.875, 0.816, 1)
+theme_override_font_sizes/font_size = 17
+theme_override_styles/normal = SubResource("StyleBox_command")
+text = "PRESSÃO"
+
+[node name="Action2" type="Button" parent="CommandPlate/CommandBar"]
+custom_minimum_size = Vector2(180, 80)
+layout_mode = 2
+theme_override_colors/font_color = Color(0.91, 0.875, 0.816, 1)
+theme_override_font_sizes/font_size = 17
+theme_override_styles/normal = SubResource("StyleBox_command")
+text = "DEFESA"
+
+[node name="Action3" type="Button" parent="CommandPlate/CommandBar"]
+custom_minimum_size = Vector2(180, 80)
+layout_mode = 2
+theme_override_colors/font_color = Color(0.91, 0.875, 0.816, 1)
+theme_override_font_sizes/font_size = 17
+theme_override_styles/normal = SubResource("StyleBox_command")
+text = "PEGADA"
+
+[node name="Action4" type="Button" parent="CommandPlate/CommandBar"]
+custom_minimum_size = Vector2(180, 80)
+layout_mode = 2
+theme_override_colors/font_color = Color(0.91, 0.875, 0.816, 1)
+theme_override_font_sizes/font_size = 17
+theme_override_styles/normal = SubResource("StyleBox_command")
+text = "TRANSIÇÃO"
+
+[node name="Action5" type="Button" parent="CommandPlate/CommandBar"]
+custom_minimum_size = Vector2(180, 80)
+layout_mode = 2
+theme_override_colors/font_color = Color(1, 0.82, 0.72, 1)
+theme_override_font_sizes/font_size = 17
+theme_override_styles/normal = SubResource("StyleBox_danger")
+text = "FINALIZAÇÃO"

--- a/tools/validate_runtime_contracts.py
+++ b/tools/validate_runtime_contracts.py
@@ -71,11 +71,11 @@ VALID_TRANSITIONS = {
 
 SCENE_NODE_CONTRACTS = {
     "scenes/main_menu/MainMenu.tscn": [
-        "Content/MenuButtons/NewGame",
-        "Content/MenuButtons/Continue",
-        "Content/MenuButtons/Options",
-        "Content/OptionsPanel/AudioToggle",
-        "Content/OptionsPanel/Back",
+        "ContentPanel/Content/MenuButtons/NewGame",
+        "ContentPanel/Content/MenuButtons/Continue",
+        "ContentPanel/Content/MenuButtons/Options",
+        "ContentPanel/Content/OptionsPanel/AudioToggle",
+        "ContentPanel/Content/OptionsPanel/Back",
     ],
     "scenes/hubs/TerreiroDaLuta.tscn": [
         "Panel/Status",


### PR DESCRIPTION
## Objetivo

Transformar as referências visuais aprovadas em contratos executáveis e iniciar a aplicação real no runtime Godot.

## Implementado

- Bíblia visual V10 consolidada.
- Design tokens canônicos para desktop/Android.
- Contratos de tela para mapa, hub, combate, Cria Live, skill tree e fichas de arena.
- Backlog de implantação audiovisual por gates.
- `AGENTS.md` atualizado para obrigar o novo padrão.
- Main Menu reconstruído em preto/dourado com canon Ruan “Macacão” Silva.
- Combat HUD reconstruído com layout espelhado, timer, Controle, Pegada e cinco comandos contextuais.
- Script do HUD preparado para nomes, timer, recursos e ações contextuais.

## Arquivos principais

- `docs/art/VISUAL_TARGET_V10.md`
- `data/ui/ui_design_tokens_v01.json`
- `data/visual/screen_contracts_v01.json`
- `docs/production/VISUAL_IMPLEMENTATION_BACKLOG_V10.md`
- `scenes/main_menu/MainMenu.tscn`
- `scenes/ui/CombatHUD.tscn`

## Limites honestos

Este PR não declara o jogo visualmente concluído. Assets finais, World Map, Hub final, Cria Live mobile, skill tree, sprites sincronizados, arenas em layers, áudio e testes Android continuam como gates obrigatórios.

## Validação necessária antes do merge

- `npm run quality`
- parser/import Godot headless
- runtime smoke
- inspeção do Main Menu em 1280×720
- inspeção do HUD na Arena do Dique
- teste de safe area e botões no Android
