### PR TITLE
fix: fechar bloqueadores P0 do vertical slice

### DIFF
--- a/scenes/result/ResultScreen.gd
+++ b/scenes/result/ResultScreen.gd
@@ -4,6 +4,7 @@ const HUB_SCENE := "res://scenes/hubs/TerreiroDaLuta.tscn"
 const CRIA_LIVE_SCENE := "res://scenes/ui/CriaLiveUI.tscn"
 
 var _leaving := false
+var _progression_committed := false
 
 func _ready() -> void:
 	_connect_buttons()
@@ -22,7 +23,7 @@ func _connect_buttons() -> void:
 func _update_result() -> void:
 	var data: Dictionary = WorldState.last_combat_result
 	var winner := str(data.get("winner", ""))
-	var won := winner == "ruan_macacao"
+	var won := winner == WorldState.player_id
 	var title := "VITORIA" if won else "DERROTA"
 	var method := _humanize_method(str(data.get("method", "controle_posicional")))
 	if has_node("Panel/Result"):
@@ -48,15 +49,21 @@ func _humanize_method(method: String) -> String:
 		"cansaco": return "Cansaco"
 	return method.replace("_", " ").capitalize()
 
+func _commit_post_combat_progression() -> void:
+	if _progression_committed:
+		return
+	_progression_committed = true
+	CareerLoop.advance_day()
+	if not SaveManager.save_game(1):
+		push_warning("[ResultScreen] O dia avancou, mas o save pos-combate falhou.")
+
 func _on_cria_live_pressed() -> void:
 	if _leaving:
 		return
 	_leaving = true
-	var won := str(WorldState.last_combat_result.get("winner", "")) == "ruan_macacao"
-	var post_type := "vitoria_luta" if won else "derrota_respeitosa"
-	if has_node("/root/CriaLiveManager") and CriaLiveManager.has_method("publish_post"):
-		CriaLiveManager.publish_post(post_type, "humilde", "resultado_luta")
-	SaveManager.save_game(1)
+	# A postagem da luta e criada pelo CriaLiveManager ao receber combat_finished.
+	# Aqui apenas consolidamos o calendario e abrimos o feed.
+	_commit_post_combat_progression()
 	var error := get_tree().change_scene_to_file(CRIA_LIVE_SCENE)
 	if error != OK:
 		_leaving = false
@@ -66,8 +73,7 @@ func _on_back_pressed() -> void:
 	if _leaving:
 		return
 	_leaving = true
-	CareerLoop.advance_day()
-	SaveManager.save_game(1)
+	_commit_post_combat_progression()
 	var error := get_tree().change_scene_to_file(HUB_SCENE)
 	if error != OK:
 		_leaving = false

--- a/src/autoloads/CombatManager.gd
+++ b/src/autoloads/CombatManager.gd
@@ -148,6 +148,7 @@ func execute_technique(actor_id: String, defender_id: String, technique: Diction
 	if not fighters.has(actor_id) or not fighters.has(defender_id):
 		return {"success": false, "error": "fighter_not_found", "technique_id": technique.get("id", "unknown")}
 	SignalBus.technique_started.emit(technique.get("id", "unknown"), actor_id)
+	var state_before: String = get_current_state_name()
 	var actor: Dictionary = fighters.get(actor_id, {})
 	var defender: Dictionary = fighters.get(defender_id, {})
 	var resolver_result: Dictionary = technique_resolver.call(
@@ -155,26 +156,66 @@ func execute_technique(actor_id: String, defender_id: String, technique: Diction
 		technique,
 		actor,
 		defender,
-		{"state": get_current_state_name()}
+		{"state": state_before}
 	)
 	var applied: Dictionary = technique_resolver.call("aplicar_resultado", actor, defender, resolver_result)
 	fighters[actor_id] = applied.get("actor", actor)
 	fighters[defender_id] = applied.get("defender", defender)
+
+	last_result = resolver_result.duplicate(true)
+	last_result["actor_id"] = actor_id
+	last_result["defender_id"] = defender_id
+	last_result["state_from"] = state_before
+
+	if _resolve_finisher_before_transition(actor_id, defender_id, technique, last_result, state_before):
+		last_result["phase"] = CombatPhase.keys()[phase]
+		last_result["combat_state"] = state_before
+		last_result["fighters"] = fighters
+		SignalBus.technique_resolved.emit(last_result)
+		_emit_resources()
+		var finish_result: Dictionary = {
+			"winner": actor_id,
+			"loser": defender_id,
+			"method": str(technique.get("id", "encerramento_tecnico")),
+			"technical": true,
+			"technique_id": str(technique.get("id", "encerramento_tecnico")),
+			"state_from": state_before
+		}
+		finish_combat(finish_result)
+		return last_result
+
 	if bool(resolver_result.get("success", false)):
 		_apply_state_transition(str(resolver_result.get("state_to", get_current_state_name())))
 		_change_phase(_phase_from_string(str(technique.get("phase_to", "TRANSITION"))))
 	else:
 		_adjust(defender_id, "focus", 2.0)
-	last_result = resolver_result.duplicate(true)
-	last_result["actor_id"] = actor_id
-	last_result["defender_id"] = defender_id
+
 	last_result["phase"] = CombatPhase.keys()[phase]
 	last_result["combat_state"] = get_current_state_name()
 	last_result["fighters"] = fighters
 	SignalBus.technique_resolved.emit(last_result)
 	_emit_resources()
-	_check_end(technique, last_result)
+	_check_end(actor_id, defender_id, technique, last_result)
 	return last_result
+
+func _resolve_finisher_before_transition(
+	actor_id: String,
+	defender_id: String,
+	technique: Dictionary,
+	result: Dictionary,
+	state_before: String
+) -> bool:
+	if not is_running:
+		return false
+	if not bool(result.get("success", false)):
+		return false
+	if not bool(technique.get("requer_finalizacao", false)):
+		return false
+	if state_before != "PLAYER_SUBMISSION_ATTACK":
+		return false
+	var actor: Dictionary = fighters.get(actor_id, {})
+	var defender: Dictionary = fighters.get(defender_id, {})
+	return float(actor.get("control", 0)) >= 55.0 or float(defender.get("health", 100)) <= 70.0
 
 func _apply_state_transition(state_name: String) -> void:
 	var target_state: int = int(state_machine.call("estado_por_nome", state_name))
@@ -186,21 +227,32 @@ func _apply_state_transition(state_name: String) -> void:
 		push_warning("[CombatManager] Transicao nao catalogada: %s -> %s" % [get_current_state_name(), state_name])
 		state_machine.call("forcar_estado", target_state)
 
-func _check_end(technique: Dictionary = {}, result: Dictionary = {}) -> void:
+func _check_end(actor_id: String, defender_id: String, technique: Dictionary = {}, result: Dictionary = {}) -> void:
 	if not is_running:
 		return
-	var player: Dictionary = fighters.get(player_id, {})
-	var opponent: Dictionary = fighters.get(opponent_id, {})
-	if bool(result.get("success", false)) and bool(technique.get("requer_finalizacao", false)) and get_current_state_name() == "PLAYER_SUBMISSION_ATTACK":
-		if float(player.get("control", 0)) >= 55.0 or float(opponent.get("health", 100)) <= 70.0:
-			finish_combat({"winner": player_id, "method": str(technique.get("id", "encerramento_tecnico")), "technical": true})
-			return
-	if float(opponent.get("health", 100)) <= 0.0:
-		finish_combat({"winner": player_id, "method": "encerramento_tecnico", "technical": true})
-	elif float(opponent.get("gas", 100)) <= 0.0 and float(player.get("control", 0)) >= 65.0:
-		finish_combat({"winner": player_id, "method": "controle_posicional", "technical": true})
-	elif float(player.get("gas", 100)) <= 0.0:
-		finish_combat({"winner": opponent_id, "method": "cansaco", "technical": false})
+	var actor: Dictionary = fighters.get(actor_id, {})
+	var defender: Dictionary = fighters.get(defender_id, {})
+	if float(defender.get("health", 100)) <= 0.0:
+		finish_combat({
+			"winner": actor_id,
+			"loser": defender_id,
+			"method": str(technique.get("id", "encerramento_tecnico")),
+			"technical": true
+		})
+	elif float(defender.get("gas", 100)) <= 0.0 and float(actor.get("control", 0)) >= 65.0:
+		finish_combat({
+			"winner": actor_id,
+			"loser": defender_id,
+			"method": "controle_posicional",
+			"technical": true
+		})
+	elif float(actor.get("gas", 100)) <= 0.0:
+		finish_combat({
+			"winner": defender_id,
+			"loser": actor_id,
+			"method": "cansaco",
+			"technical": false
+		})
 
 func _adjust(id: String, key: String, delta: float) -> void:
 	if not fighters.has(id):

--- a/src/autoloads/CriaLiveManager.gd
+++ b/src/autoloads/CriaLiveManager.gd
@@ -2,16 +2,18 @@ extends Node
 
 var posts: Array = []
 var pending_crises: Array = []
+var _last_combat_fingerprint: String = ""
 
 func _ready() -> void:
-	if SignalBus.has_signal("combat_finished"):
+	# O CombatManager preserva dois sinais por compatibilidade, mas o Cria Live
+	# consome apenas o contrato canonico para evitar duas postagens por luta.
+	if SignalBus.has_signal("combat_finished") and not SignalBus.combat_finished.is_connected(_on_combat_finished):
 		SignalBus.combat_finished.connect(_on_combat_finished)
-	if SignalBus.has_signal("combat_ended"):
-		SignalBus.combat_ended.connect(_on_combat_finished)
-	SignalBus.reputation_changed.connect(_on_reputation_changed)
+	if SignalBus.has_signal("reputation_changed") and not SignalBus.reputation_changed.is_connected(_on_reputation_changed):
+		SignalBus.reputation_changed.connect(_on_reputation_changed)
 
-func create_post(text: String, tone: String, author := "cria_live"):
-	var post = {
+func create_post(text: String, tone: String, author := "cria_live") -> Dictionary:
+	var post: Dictionary = {
 		"id": "post_%d" % posts.size(),
 		"author": author,
 		"tone": tone,
@@ -41,15 +43,28 @@ func _text_for_context(context: String, data: Dictionary) -> String:
 		"crise":
 			return "Cria Live esta pegando fogo. Todo mundo quer resposta."
 		"sponsor":
-			return "Novo apoio fechado. Disciplina tambem constrói oportunidade."
+			return "Novo apoio fechado. Disciplina tambem constroi oportunidade."
 		_:
 			return "Movimento registrado no Cria Live."
 
 func _on_combat_finished(result: Dictionary) -> void:
+	var fingerprint := _combat_fingerprint(result)
+	if fingerprint == _last_combat_fingerprint:
+		return
+	_last_combat_fingerprint = fingerprint
 	if result.get("winner", "") == WorldState.player_id or result.get("winner", "") == "ruan_macacao":
 		generate_post("vitoria", result)
 	else:
 		generate_post("derrota", result)
+
+func _combat_fingerprint(result: Dictionary) -> String:
+	return "%s|%s|%d|%d|%d" % [
+		str(result.get("winner", "")),
+		str(result.get("method", "")),
+		WorldState.week,
+		WorldState.day_index,
+		WorldState.fights_won + WorldState.fights_lost
+	]
 
 func _on_reputation_changed(axis, delta, new_value) -> void:
 	if str(axis) == "sombra" and float(new_value) > 60.0:

--- a/src/autoloads/SaveManager.gd
+++ b/src/autoloads/SaveManager.gd
@@ -1,11 +1,13 @@
 extends Node
 
+const SAVE_VERSION := 2
 const SAVE_PREFIX := "user://cria_save_"
 const SAVE_SUFFIX := ".json"
 const SAVE_PATH := "user://savegame.json"
 
-func save_game(slot_id := 1):
-	var data = WorldState.to_dict()
+func save_game(slot_id := 1) -> bool:
+	var data: Dictionary = WorldState.to_dict()
+	data["save_version"] = SAVE_VERSION
 	data["saved_at"] = Time.get_datetime_string_from_system()
 	if has_node("/root/TinkerBondManager"):
 		data["tinker_bond"] = TinkerBondManager.to_dict()
@@ -25,26 +27,65 @@ func save_game(slot_id := 1):
 		data["cria_live_interaction_state"] = CriaLiveInteractionManager.to_dict()
 	if has_node("/root/GameFlowManager"):
 		data["game_flow_state"] = GameFlowManager.to_dict()
-	var path = SAVE_PREFIX + str(slot_id) + SAVE_SUFFIX
-	var file = FileAccess.open(path, FileAccess.WRITE)
-	if file == null:
-		push_error("[SaveManager] Falha ao salvar.")
+	var path := get_slot_path(slot_id)
+	if not _write_atomic_json(path, data):
+		push_error("[SaveManager] Falha ao salvar slot %s de forma atomica." % slot_id)
 		return false
-	file.store_string(JSON.stringify(data, "\t"))
 	SignalBus.save_completed.emit(slot_id)
 	return true
 
-func load_game(slot_id := 1):
-	var path = SAVE_PREFIX + str(slot_id) + SAVE_SUFFIX
-	if not FileAccess.file_exists(path):
-		return false
-	var file = FileAccess.open(path, FileAccess.READ)
+func _write_atomic_json(final_path: String, data: Dictionary) -> bool:
+	var temp_path := final_path + ".tmp"
+	var backup_path := final_path + ".bak"
+	var file := FileAccess.open(temp_path, FileAccess.WRITE)
 	if file == null:
 		return false
-	var parsed = JSON.parse_string(file.get_as_text())
-	if typeof(parsed) != TYPE_DICTIONARY:
-		push_error("[SaveManager] Save invalido.")
+	file.store_string(JSON.stringify(data, "\t"))
+	file.flush()
+	file.close()
+
+	var dir := DirAccess.open("user://")
+	if dir == null:
+		DirAccess.remove_absolute(temp_path)
 		return false
+
+	var final_name := final_path.get_file()
+	var temp_name := temp_path.get_file()
+	var backup_name := backup_path.get_file()
+	if dir.file_exists(backup_name) and dir.remove(backup_name) != OK:
+		dir.remove(temp_name)
+		return false
+
+	var had_final := dir.file_exists(final_name)
+	if had_final:
+		var backup_error := dir.rename(final_name, backup_name)
+		if backup_error != OK:
+			dir.remove(temp_name)
+			return false
+
+	var promote_error := dir.rename(temp_name, final_name)
+	if promote_error != OK:
+		if had_final and dir.file_exists(backup_name):
+			dir.rename(backup_name, final_name)
+		if dir.file_exists(temp_name):
+			dir.remove(temp_name)
+		return false
+
+	if dir.file_exists(backup_name):
+		dir.remove(backup_name)
+	return true
+
+func load_game(slot_id := 1) -> bool:
+	var path := get_slot_path(slot_id)
+	var parsed := _read_json_dictionary(path)
+	if parsed.is_empty():
+		var backup_path := path + ".bak"
+		parsed = _read_json_dictionary(backup_path)
+		if parsed.is_empty():
+			return false
+		# Recupera automaticamente o save principal a partir do backup valido.
+		if not _write_atomic_json(path, parsed):
+			push_warning("[SaveManager] Backup carregado, mas nao foi possivel restaurar o arquivo principal.")
 	WorldState.load_from_dict(parsed)
 	if parsed.has("tinker_bond") and has_node("/root/TinkerBondManager"):
 		TinkerBondManager.load_from_dict(parsed["tinker_bond"])
@@ -67,13 +108,31 @@ func load_game(slot_id := 1):
 	SignalBus.save_loaded.emit(slot_id)
 	return true
 
-func has_save(slot_id := 1):
-	return FileAccess.file_exists(SAVE_PREFIX + str(slot_id) + SAVE_SUFFIX)
+func _read_json_dictionary(path: String) -> Dictionary:
+	if not FileAccess.file_exists(path):
+		return {}
+	var file := FileAccess.open(path, FileAccess.READ)
+	if file == null:
+		return {}
+	var raw := file.get_as_text()
+	file.close()
+	var parsed = JSON.parse_string(raw)
+	if typeof(parsed) != TYPE_DICTIONARY:
+		push_warning("[SaveManager] Save invalido em %s." % path)
+		return {}
+	return parsed
+
+func get_slot_path(slot_id := 1) -> String:
+	return SAVE_PREFIX + str(slot_id) + SAVE_SUFFIX
+
+func has_save(slot_id := 1) -> bool:
+	return FileAccess.file_exists(get_slot_path(slot_id))
 
 func delete_save(slot_id := 1) -> void:
-	var path = SAVE_PREFIX + str(slot_id) + SAVE_SUFFIX
-	if FileAccess.file_exists(path):
-		DirAccess.remove_absolute(path)
+	var path := get_slot_path(slot_id)
+	for candidate in [path, path + ".tmp", path + ".bak"]:
+		if FileAccess.file_exists(candidate):
+			DirAccess.remove_absolute(candidate)
 
 func salvar_jogo() -> bool:
 	return save_game(1)

--- a/tests/runtime_smoke.gd
+++ b/tests/runtime_smoke.gd
@@ -20,6 +20,7 @@ var combat_manager: Node
 var career_loop: Node
 var game_flow_manager: Node
 var audio_manager: Node
+var cria_live_manager: Node
 
 func _initialize() -> void:
 	call_deferred("_run")
@@ -40,6 +41,7 @@ func _run() -> void:
 	await _test_scene_loading()
 	_test_save_roundtrip()
 	_test_combat_domain()
+	_test_cria_live_single_post_contract()
 	_test_campaign_progression()
 	_finish()
 
@@ -52,6 +54,7 @@ func _resolve_autoloads() -> void:
 	career_loop = root.get_node_or_null("CareerLoop")
 	game_flow_manager = root.get_node_or_null("GameFlowManager")
 	audio_manager = root.get_node_or_null("AudioManager")
+	cria_live_manager = root.get_node_or_null("CriaLiveManager")
 
 func _test_autoloads() -> void:
 	var nodes: Dictionary = {
@@ -62,7 +65,8 @@ func _test_autoloads() -> void:
 		"CombatManager": combat_manager,
 		"CareerLoop": career_loop,
 		"GameFlowManager": game_flow_manager,
-		"AudioManager": audio_manager
+		"AudioManager": audio_manager,
+		"CriaLiveManager": cria_live_manager
 	}
 	for singleton_value in nodes.keys():
 		var singleton_name: String = str(singleton_value)
@@ -111,6 +115,9 @@ func _test_save_roundtrip() -> void:
 	world_state.set("energy", 77.0)
 	world_state.call("_sync_aliases")
 	_assert(bool(save_manager.call("save_game", SLOT)), "SaveManager falhou ao salvar slot de teste")
+	var slot_path: String = str(save_manager.call("get_slot_path", SLOT))
+	_assert(not FileAccess.file_exists(slot_path + ".tmp"), "Save atomico deixou arquivo temporario")
+	_assert(not FileAccess.file_exists(slot_path + ".bak"), "Save atomico deixou backup residual")
 	world_state.set("money", 0)
 	world_state.set("energy", 1.0)
 	_assert(bool(save_manager.call("load_game", SLOT)), "SaveManager falhou ao carregar slot de teste")
@@ -158,9 +165,45 @@ func _test_combat_domain() -> void:
 	_assert(is_equal_approx(float(defender.get("grip_integrity", 100)), 92.0), "Reducao de grip foi aplicada com sinal incorreto")
 	engine.queue_free()
 
+	# Regressao P0: uma finalizacao bem-sucedida precisa encerrar antes do RESET.
+	var state_machine: Node = combat_manager.get("state_machine")
+	state_machine.call("forcar_estado", state_machine.call("estado_por_nome", "PLAYER_SUBMISSION_ATTACK"))
+	var fighters: Dictionary = combat_manager.get("fighters")
+	fighters["ruan_macacao"]["control"] = 100.0
+	fighters["davi_relampago"]["health"] = 60.0
+	combat_manager.set("fighters", fighters)
+	var finisher: Dictionary = data_registry.call("get_technique", "encerramento_tecnico").duplicate(true)
+	finisher["base_chance"] = 0.95
+	finisher["chance_sucesso"] = 0.95
+	var runtime_resolver: Node = combat_manager.get("technique_resolver")
+	var rng: RandomNumberGenerator = runtime_resolver.get("rng")
+	var deterministic_seed := 0
+	for seed_value in range(1000):
+		rng.seed = seed_value
+		if rng.randf() <= 0.95:
+			deterministic_seed = seed_value
+			break
+	rng.seed = deterministic_seed
+	combat_manager.call("execute_technique", "ruan_macacao", "davi_relampago", finisher)
+	_assert(not bool(combat_manager.get("is_running")), "Finalizacao tecnica nao encerrou o combate")
+	var final_result: Dictionary = world_state.get("last_combat_result")
+	_assert(str(final_result.get("winner", "")) == "ruan_macacao", "Finalizacao nao registrou Ruan como vencedor")
+	_assert(str(final_result.get("state_from", "")) == "PLAYER_SUBMISSION_ATTACK", "Finalizacao perdeu o estado de origem antes do encerramento")
+
+func _test_cria_live_single_post_contract() -> void:
+	if signal_bus == null or cria_live_manager == null:
+		return
+	var before: int = cria_live_manager.call("get_feed").size()
+	var result := {"winner": "ruan_macacao", "method": "smoke_duplicate_guard", "technical": true}
+	signal_bus.combat_finished.emit(result)
+	signal_bus.combat_ended.emit(result)
+	var after: int = cria_live_manager.call("get_feed").size()
+	_assert(after == before + 1, "Cria Live gerou mais de uma postagem para o mesmo combate")
+
 func _test_campaign_progression() -> void:
 	if combat_manager == null or world_state == null or career_loop == null:
 		return
+	combat_manager.call("start_combat", "terreiro_da_luta", "ruan_macacao", "davi_relampago")
 	var money_before: int = int(world_state.get("money"))
 	var wins_before: int = int(world_state.get("fights_won"))
 	combat_manager.call("finish_combat", {"winner": "ruan_macacao", "method": "controle_posicional", "technical": true})


### PR DESCRIPTION
## Objetivo
Fechar os quatro bloqueadores P0 identificados na auditoria do vertical slice Android.

## Alterações
- finalização técnica é resolvida antes da transição para `RESET`;
- encerramento funciona para jogador ou oponente sem assumir ator fixo;
- Cria Live consome apenas `combat_finished` e possui proteção idempotente;
- resultado consolida avanço do calendário nas duas rotas: Terreiro ou Cria Live;
- save usa arquivo temporário, backup, promoção atômica e recuperação de backup;
- smoke test cobre finalização, postagem única e resíduos do save atômico.

## Critérios de aceite
- Godot 4.2.2 importa o projeto;
- runtime smoke passa;
- validadores de dados, estrutura e contratos passam;
- nenhum `.tmp` ou `.bak` sobra após um save bem-sucedido.

## Escopo seguinte
Após este PR: IA funcional de Davi e loop de combate determinístico. A IA generativa continuará opcional e fora do loop crítico do APK.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safer, versioned save handling with backup recovery and success feedback.
  * Added support for player-specific combat winner detection.
  * Added protection against duplicate Cria Live posts for the same combat.

* **Bug Fixes**
  * Prevented post-combat progression from being applied more than once.
  * Fixed finisher techniques so combat ends at the correct point.
  * Improved recovery from interrupted or invalid saves.

* **Tests**
  * Added coverage for combat finishing, duplicate posts, and atomic save behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->