### PR TITLE
feat: tornar a IA de Davi funcional no combate

### DIFF
--- a/scenes/combat/CombatArenaBase.gd
+++ b/scenes/combat/CombatArenaBase.gd
@@ -10,6 +10,7 @@ var davi_ai: Node
 var ruan_placeholder: Node
 var davi_placeholder: Node
 var action_buttons: Array[Button] = []
+var ai_turn_delay: float = 0.35
 
 var estados_ptbr: Dictionary = {
 	"DISTANCE": "EM PE - NEUTRO",
@@ -40,6 +41,7 @@ func _ready() -> void:
 	add_child(gamefeel)
 	davi_ai = DaviAIControllerScript.new()
 	add_child(davi_ai)
+	davi_ai.call("setup", "davi_relampago", "normal")
 	_build_placeholder_fighters()
 	_connect_buttons()
 	_connect_runtime_signals()
@@ -80,6 +82,10 @@ func _ensure_ai_hint() -> void:
 		label.name = "AIHint"
 		label.text = "Davi esta lendo seu ritmo. Varie as entradas."
 		get_node("Panel").add_child(label)
+
+func _set_ai_hint(text: String) -> void:
+	if has_node("Panel/AIHint"):
+		$Panel/AIHint.text = text
 
 func _connect_buttons() -> void:
 	action_buttons.clear()
@@ -131,10 +137,31 @@ func _on_action_button_pressed(button: Button) -> void:
 	var success: bool = bool(result.get("success", false))
 	AudioManager.play_sfx(action_id)
 	gamefeel.call("apply_for_technique", action_id, success)
-	_update_ai_hint(result)
+	if CombatManager.is_running:
+		await _run_davi_turn()
+	if not is_inside_tree():
+		return
 	if CombatManager.is_running:
 		_refresh_action_buttons()
 		_set_actions_enabled(true)
+
+func _run_davi_turn() -> void:
+	_set_ai_hint("%s Davi esta escolhendo a resposta..." % str(davi_ai.call("pressure_message")))
+	await get_tree().create_timer(ai_turn_delay).timeout
+	if not is_inside_tree() or not CombatManager.is_running:
+		return
+	var technique: Dictionary = davi_ai.call("choose_technique", CombatManager)
+	if technique.is_empty():
+		_set_ai_hint("Davi nao encontrou uma acao segura e preservou a base.")
+		return
+	var technique_id := str(technique.get("id", ""))
+	var technique_name := str(technique.get("nome", technique.get("name", technique_id)))
+	_set_ai_hint("%s Resposta escolhida: %s." % [str(davi_ai.call("pressure_message")), technique_name])
+	if davi_placeholder != null:
+		davi_placeholder.call("play_action", technique_id)
+	AudioManager.play_sfx(technique_id)
+	var result: Dictionary = CombatManager.apply_opponent_action(technique_id)
+	gamefeel.call("apply_for_technique", technique_id, bool(result.get("success", false)))
 
 func _set_actions_enabled(enabled: bool) -> void:
 	for button in action_buttons:
@@ -144,16 +171,6 @@ func _set_actions_enabled(enabled: bool) -> void:
 			button.disabled = action_id == "" or not affordable
 		else:
 			button.disabled = true
-
-func _update_ai_hint(result: Dictionary) -> void:
-	if not has_node("Panel/AIHint"):
-		return
-	var phase_name: String = str(result.get("phase", "DISTANCE"))
-	var player_resources: Dictionary = CombatManager.fighters.get("ruan_macacao", {})
-	var response: String = str(davi_ai.call("choose_response", phase_name, player_resources))
-	$Panel/AIHint.text = "%s Proxima leitura: %s" % [str(davi_ai.call("pressure_message")), response]
-	if davi_placeholder != null:
-		davi_placeholder.call("play_action", response)
 
 func _on_resources_changed(fighter_id, resources) -> void:
 	if str(fighter_id) != CombatManager.player_id or typeof(resources) != TYPE_DICTIONARY:
@@ -179,7 +196,9 @@ func _on_technique_resolved(result) -> void:
 		var technique: Dictionary = DataRegistry.get_technique(technique_id)
 		var name_text: String = str(technique.get("nome", technique.get("name", technique_id)))
 		var message: String = str(result.get("message", "sucesso" if result.get("success", false) else "defendido"))
-		$Panel/Message.text = "%s: %s" % [name_text, _humanize_message(message)]
+		var actor_id := str(result.get("actor_id", "ruan_macacao"))
+		var actor_name := "Ruan" if actor_id == CombatManager.player_id else "Davi"
+		$Panel/Message.text = "%s • %s: %s" % [actor_name, name_text, _humanize_message(message)]
 	if SignalBus.has_signal("technique_executed"):
 		SignalBus.technique_executed.emit(StringName(result.get("actor_id", "ruan_macacao")), StringName(result.get("technique_id", "unknown")))
 	if SignalBus.has_signal("tecnica_executada"):

--- a/src/autoloads/CombatManager.gd
+++ b/src/autoloads/CombatManager.gd
@@ -7,6 +7,23 @@ const DEFAULT_OPPONENT_ID: String = "davi_relampago"
 const CombatStateMachineScript = preload("res://src/combat/CombatStateMachine.gd")
 const TechniqueResolverScript = preload("res://src/combat/TechniqueResolver.gd")
 
+const STATE_MIRROR := {
+	"PLAYER_STANDING_NEUTRAL": "PLAYER_STANDING_NEUTRAL",
+	"PLAYER_TOP_CLINCH": "PLAYER_BOTTOM_CLINCH",
+	"PLAYER_BOTTOM_CLINCH": "PLAYER_TOP_CLINCH",
+	"PLAYER_TOP_GUARD": "PLAYER_BOTTOM_GUARD",
+	"PLAYER_BOTTOM_GUARD": "PLAYER_TOP_GUARD",
+	"PLAYER_TOP_SIDE": "PLAYER_BOTTOM_SIDE",
+	"PLAYER_BOTTOM_SIDE": "PLAYER_TOP_SIDE",
+	"PLAYER_TOP_MOUNT": "PLAYER_BOTTOM_MOUNT",
+	"PLAYER_BOTTOM_MOUNT": "PLAYER_TOP_MOUNT",
+	"PLAYER_BACK_ATTACK": "PLAYER_BACK_DEFENSE",
+	"PLAYER_BACK_DEFENSE": "PLAYER_BACK_ATTACK",
+	"PLAYER_SUBMISSION_ATTACK": "PLAYER_SUBMISSION_DEFENSE",
+	"PLAYER_SUBMISSION_DEFENSE": "PLAYER_SUBMISSION_ATTACK",
+	"RESET": "RESET"
+}
+
 var phase: int = CombatPhase.DISTANCE
 var arena_id: String = ""
 var player_id: String = DEFAULT_PLAYER_ID
@@ -78,17 +95,31 @@ func get_current_state_name() -> String:
 		return "PLAYER_STANDING_NEUTRAL"
 	return str(state_machine.call("get_current_state_name"))
 
+func get_actor_state_name(actor_id: String) -> String:
+	var player_perspective := get_current_state_name()
+	if actor_id == player_id:
+		return player_perspective
+	return _mirror_state(player_perspective)
+
+func _mirror_state(state_name: String) -> String:
+	return str(STATE_MIRROR.get(state_name, state_name))
+
+func _state_to_player_perspective(actor_id: String, actor_state_name: String) -> String:
+	if actor_id == player_id:
+		return actor_state_name
+	return _mirror_state(actor_state_name)
+
 func get_available_techniques(actor_id: String = "") -> Array:
 	var resolved_actor: String = actor_id if actor_id != "" else player_id
 	var actor: Dictionary = fighters.get(resolved_actor, {})
-	var current_state: String = get_current_state_name()
+	var actor_state: String = get_actor_state_name(resolved_actor)
 	var available: Array = []
 	for technique_value in DataRegistry.techniques.values():
 		if typeof(technique_value) != TYPE_DICTIONARY:
 			continue
 		var technique: Dictionary = technique_value
 		var entry_state: String = str(technique.get("entry_state", technique.get("estado_entrada", "")))
-		if entry_state != "" and entry_state != current_state:
+		if entry_state != "" and entry_state != actor_state:
 			continue
 		var owner: String = str(technique.get("dono", technique.get("owner", "qualquer")))
 		if owner != "" and owner != "qualquer" and owner != resolved_actor:
@@ -103,6 +134,7 @@ func get_available_techniques(actor_id: String = "") -> Array:
 			and float(actor.get("focus", 0)) >= focus_cost
 			and float(actor.get("moral", 0)) >= moral_cost
 		)
+		item["actor_state"] = actor_state
 		available.append(item)
 	available.sort_custom(_sort_techniques_by_name)
 	return available
@@ -134,21 +166,33 @@ func apply_player_action(action_id: String) -> Dictionary:
 		SignalBus.technique_resolved.emit(reset_result)
 		_emit_resources()
 		return reset_result
+	return apply_actor_action(player_id, action_id)
+
+func apply_opponent_action(action_id: String) -> Dictionary:
+	return apply_actor_action(opponent_id, action_id)
+
+func apply_actor_action(actor_id: String, action_id: String) -> Dictionary:
+	if not is_running:
+		return {"success": false, "error": "combat_not_running", "action_id": action_id}
+	var defender_id := opponent_id if actor_id == player_id else player_id
 	var technique: Dictionary = DataRegistry.get_technique(action_id)
 	if technique.is_empty():
 		return {
 			"success": false,
 			"error": "technique_not_found",
 			"action_id": action_id,
+			"actor_id": actor_id,
+			"defender_id": defender_id,
 			"message": "Tecnica nao encontrada no catalogo."
 		}
-	return execute_technique(player_id, opponent_id, technique)
+	return execute_technique(actor_id, defender_id, technique)
 
 func execute_technique(actor_id: String, defender_id: String, technique: Dictionary) -> Dictionary:
 	if not fighters.has(actor_id) or not fighters.has(defender_id):
 		return {"success": false, "error": "fighter_not_found", "technique_id": technique.get("id", "unknown")}
 	SignalBus.technique_started.emit(technique.get("id", "unknown"), actor_id)
-	var state_before: String = get_current_state_name()
+	var player_state_before: String = get_current_state_name()
+	var actor_state_before: String = get_actor_state_name(actor_id)
 	var actor: Dictionary = fighters.get(actor_id, {})
 	var defender: Dictionary = fighters.get(defender_id, {})
 	var resolver_result: Dictionary = technique_resolver.call(
@@ -156,7 +200,7 @@ func execute_technique(actor_id: String, defender_id: String, technique: Diction
 		technique,
 		actor,
 		defender,
-		{"state": state_before}
+		{"state": actor_state_before}
 	)
 	var applied: Dictionary = technique_resolver.call("aplicar_resultado", actor, defender, resolver_result)
 	fighters[actor_id] = applied.get("actor", actor)
@@ -165,11 +209,12 @@ func execute_technique(actor_id: String, defender_id: String, technique: Diction
 	last_result = resolver_result.duplicate(true)
 	last_result["actor_id"] = actor_id
 	last_result["defender_id"] = defender_id
-	last_result["state_from"] = state_before
+	last_result["state_from"] = player_state_before
+	last_result["actor_state_from"] = actor_state_before
 
-	if _resolve_finisher_before_transition(actor_id, defender_id, technique, last_result, state_before):
+	if _resolve_finisher_before_transition(actor_id, defender_id, technique, last_result, actor_state_before):
 		last_result["phase"] = CombatPhase.keys()[phase]
-		last_result["combat_state"] = state_before
+		last_result["combat_state"] = player_state_before
 		last_result["fighters"] = fighters
 		SignalBus.technique_resolved.emit(last_result)
 		_emit_resources()
@@ -179,13 +224,18 @@ func execute_technique(actor_id: String, defender_id: String, technique: Diction
 			"method": str(technique.get("id", "encerramento_tecnico")),
 			"technical": true,
 			"technique_id": str(technique.get("id", "encerramento_tecnico")),
-			"state_from": state_before
+			"state_from": player_state_before,
+			"actor_state_from": actor_state_before
 		}
 		finish_combat(finish_result)
 		return last_result
 
 	if bool(resolver_result.get("success", false)):
-		_apply_state_transition(str(resolver_result.get("state_to", get_current_state_name())))
+		var actor_state_to := str(resolver_result.get("state_to", actor_state_before))
+		var player_state_to := _state_to_player_perspective(actor_id, actor_state_to)
+		last_result["actor_state_to"] = actor_state_to
+		last_result["state_to"] = player_state_to
+		_apply_state_transition(player_state_to)
 		_change_phase(_phase_from_string(str(technique.get("phase_to", "TRANSITION"))))
 	else:
 		_adjust(defender_id, "focus", 2.0)
@@ -203,7 +253,7 @@ func _resolve_finisher_before_transition(
 	defender_id: String,
 	technique: Dictionary,
 	result: Dictionary,
-	state_before: String
+	actor_state_before: String
 ) -> bool:
 	if not is_running:
 		return false
@@ -211,7 +261,7 @@ func _resolve_finisher_before_transition(
 		return false
 	if not bool(technique.get("requer_finalizacao", false)):
 		return false
-	if state_before != "PLAYER_SUBMISSION_ATTACK":
+	if actor_state_before != "PLAYER_SUBMISSION_ATTACK":
 		return false
 	var actor: Dictionary = fighters.get(actor_id, {})
 	var defender: Dictionary = fighters.get(defender_id, {})

--- a/src/combat/DaviAIController.gd
+++ b/src/combat/DaviAIController.gd
@@ -1,17 +1,160 @@
 extends Node
 class_name DaviAIController
 
-var seen_player_actions := {}
-var last_action := ""
+var rival_id: String = "davi_relampago"
+var difficulty: String = "normal"
+var seen_player_actions: Dictionary = {}
+var seen_player_families: Dictionary = {}
+var last_action: String = ""
+var last_chosen_technique: String = ""
+var profile: Dictionary = {}
+var rng := RandomNumberGenerator.new()
+
+func _ready() -> void:
+	setup(rival_id, difficulty)
+
+func setup(p_rival_id: String = "davi_relampago", p_difficulty: String = "normal") -> void:
+	rival_id = p_rival_id
+	difficulty = p_difficulty
+	profile = DataRegistry.rival_ai_profiles.get("profiles", {}).get(rival_id, {})
+	rng.seed = hash("%s|%s" % [rival_id, difficulty])
+	reset()
 
 func reset() -> void:
 	seen_player_actions.clear()
+	seen_player_families.clear()
 	last_action = ""
+	last_chosen_technique = ""
 
 func record_player_action(action_id: String) -> void:
 	seen_player_actions[action_id] = int(seen_player_actions.get(action_id, 0)) + 1
 	last_action = action_id
+	var technique: Dictionary = DataRegistry.get_technique(action_id)
+	var family := str(technique.get("family", technique.get("familia", "geral")))
+	seen_player_families[family] = int(seen_player_families.get(family, 0)) + 1
 
+func choose_technique(combat_manager: Node) -> Dictionary:
+	if combat_manager == null or not bool(combat_manager.get("is_running")):
+		return {}
+	var available: Array = combat_manager.call("get_available_techniques", rival_id)
+	var affordable: Array[Dictionary] = []
+	for value in available:
+		if typeof(value) == TYPE_DICTIONARY and bool(value.get("affordable", false)):
+			affordable.append(value)
+	if affordable.is_empty():
+		return {}
+
+	var actor_state := str(combat_manager.call("get_actor_state_name", rival_id))
+	var player_id := str(combat_manager.get("player_id"))
+	var fighters: Dictionary = combat_manager.get("fighters")
+	var player_resources: Dictionary = fighters.get(player_id, {})
+	var rival_resources: Dictionary = fighters.get(rival_id, {})
+	var best: Dictionary = affordable[0]
+	var best_score := -INF
+	for technique in affordable:
+		var score := _score_technique(technique, actor_state, player_resources, rival_resources)
+		if score > best_score:
+			best_score = score
+			best = technique
+	last_chosen_technique = str(best.get("id", ""))
+	return best
+
+func _score_technique(
+	technique: Dictionary,
+	actor_state: String,
+	player_resources: Dictionary,
+	rival_resources: Dictionary
+) -> float:
+	var technique_id := str(technique.get("id", ""))
+	var base_chance := float(technique.get("base_chance", technique.get("chance_sucesso", 0.5)))
+	var score := base_chance * 100.0
+	var cost: Dictionary = technique.get("cost", technique.get("custo", {}))
+	var gas_cost := float(cost.get("gas", technique.get("gas_cost", 0)))
+	var focus_cost := float(cost.get("focus", cost.get("foco", technique.get("focus_cost", 0))))
+	var gas_ratio := float(rival_resources.get("gas", 0)) / 100.0
+	var focus_ratio := float(rival_resources.get("focus", 0)) / 100.0
+	score -= gas_cost * (1.4 if gas_ratio < 0.35 else 0.55)
+	score -= focus_cost * (1.2 if focus_ratio < 0.35 else 0.45)
+
+	var preferred_actions: Array = profile.get("preferred_actions", [])
+	if preferred_actions.has(technique_id):
+		score += 18.0
+	var preferred_states: Array = profile.get("preferred_states", [])
+	if preferred_states.has(actor_state):
+		score += 8.0
+
+	score += _anti_pattern_bonus(technique_id, player_resources)
+	score += _difficulty_bonus(technique)
+	score -= _risk_penalty(technique)
+	if float(player_resources.get("gas", 100)) < 30.0:
+		score += float(technique.get("control_gain", 0)) * 0.6
+	if int(seen_player_actions.get(technique_id, 0)) > 0:
+		score += 2.0
+	# Pequena variacao deterministica evita que a IA repita sempre a mesma tecnica
+	# quando duas opcoes possuem valor praticamente igual.
+	score += rng.randf_range(-1.5, 1.5)
+	return score
+
+func _anti_pattern_bonus(technique_id: String, player_resources: Dictionary) -> float:
+	var bonus := 0.0
+	for rule_value in profile.get("anti_patterns", []):
+		if typeof(rule_value) != TYPE_DICTIONARY:
+			continue
+		var rule: Dictionary = rule_value
+		if str(rule.get("response", "")) != technique_id:
+			continue
+		var weight := float(rule.get("weight", 1.0))
+		if rule.has("if_player_repeats_family"):
+			var family := str(rule.get("if_player_repeats_family", ""))
+			if int(seen_player_families.get(family, 0)) >= 2:
+				bonus += 32.0 * weight
+		if bool(rule.get("if_player_low_gas", false)) and float(player_resources.get("gas", 100)) < 30.0:
+			bonus += 28.0 * weight
+		if bool(rule.get("if_player_low_focus", false)) and float(player_resources.get("focus", 100)) < 30.0:
+			bonus += 24.0 * weight
+	return bonus
+
+func _difficulty_bonus(technique: Dictionary) -> float:
+	match difficulty:
+		"facil":
+			return -float(technique.get("control_gain", 0)) * 0.25
+		"dificil":
+			return float(technique.get("control_gain", 0)) * 0.45
+		"pesadelo":
+			return float(technique.get("control_gain", 0)) * 0.75
+		_:
+			return float(technique.get("control_gain", 0)) * 0.20
+
+func _risk_penalty(technique: Dictionary) -> float:
+	var risk_value = technique.get("risk", technique.get("risco", "medio"))
+	var risk_level := 2.0
+	if typeof(risk_value) == TYPE_STRING:
+		match str(risk_value):
+			"baixo": risk_level = 1.0
+			"medio": risk_level = 2.0
+			"alto": risk_level = 3.0
+			"extremo": risk_level = 4.0
+	else:
+		risk_level = float(risk_value)
+	var configured_risk := float(profile.get("tuning", {}).get("risk", 0.35))
+	return risk_level * (1.0 - configured_risk) * 4.0
+
+func pressure_message() -> String:
+	if last_action != "" and int(seen_player_actions.get(last_action, 0)) >= 3:
+		return "Davi leu a repeticao. Muda o ritmo."
+	for family_value in seen_player_families.keys():
+		var family := str(family_value)
+		if int(seen_player_families.get(family, 0)) >= 3:
+			return "Davi percebeu seu padrao de %s." % family.replace("_", " ")
+	return "Davi Relampago esta estudando seu jogo."
+
+func chosen_action_label() -> String:
+	if last_chosen_technique == "":
+		return "esperando"
+	var technique := DataRegistry.get_technique(last_chosen_technique)
+	return str(technique.get("nome", technique.get("name", last_chosen_technique)))
+
+# Compatibilidade com a interface antiga de dica. A decisao real usa choose_technique().
 func choose_response(combat_phase: String, player_resources: Dictionary) -> String:
 	var gas := float(player_resources.get("gas", 100))
 	if _player_is_repeating("baiana"):
@@ -23,11 +166,6 @@ func choose_response(combat_phase: String, player_resources: Dictionary) -> Stri
 	if gas < 30.0:
 		return "pressao_cabeca"
 	return "grip_de_ferro"
-
-func pressure_message() -> String:
-	if last_action != "" and int(seen_player_actions.get(last_action, 0)) >= 3:
-		return "Davi leu a repeticao. Muda o ritmo."
-	return "Davi Relampago esta estudando seu jogo."
 
 func _player_is_repeating(action_id: String) -> bool:
 	return int(seen_player_actions.get(action_id, 0)) >= 2

--- a/tests/runtime_smoke.gd
+++ b/tests/runtime_smoke.gd
@@ -1,6 +1,7 @@
 extends SceneTree
 
 const CombatSimulationEngineScript = preload("res://src/combat/CombatManager.gd")
+const DaviAIControllerScript = preload("res://src/combat/DaviAIController.gd")
 
 const REQUIRED_SCENES := [
 	"res://scenes/main_menu/MainMenu.tscn",
@@ -41,6 +42,7 @@ func _run() -> void:
 	await _test_scene_loading()
 	_test_save_roundtrip()
 	_test_combat_domain()
+	_test_opponent_ai_turn()
 	_test_cria_live_single_post_contract()
 	_test_campaign_progression()
 	_finish()
@@ -175,20 +177,51 @@ func _test_combat_domain() -> void:
 	var finisher: Dictionary = data_registry.call("get_technique", "encerramento_tecnico").duplicate(true)
 	finisher["base_chance"] = 0.95
 	finisher["chance_sucesso"] = 0.95
-	var runtime_resolver: Node = combat_manager.get("technique_resolver")
-	var rng: RandomNumberGenerator = runtime_resolver.get("rng")
-	var deterministic_seed := 0
-	for seed_value in range(1000):
-		rng.seed = seed_value
-		if rng.randf() <= 0.95:
-			deterministic_seed = seed_value
-			break
-	rng.seed = deterministic_seed
+	_seed_runtime_resolver_for_success(0.95)
 	combat_manager.call("execute_technique", "ruan_macacao", "davi_relampago", finisher)
 	_assert(not bool(combat_manager.get("is_running")), "Finalizacao tecnica nao encerrou o combate")
 	var final_result: Dictionary = world_state.get("last_combat_result")
 	_assert(str(final_result.get("winner", "")) == "ruan_macacao", "Finalizacao nao registrou Ruan como vencedor")
 	_assert(str(final_result.get("state_from", "")) == "PLAYER_SUBMISSION_ATTACK", "Finalizacao perdeu o estado de origem antes do encerramento")
+
+func _test_opponent_ai_turn() -> void:
+	if combat_manager == null or data_registry == null:
+		return
+	combat_manager.call("start_combat", "terreiro_da_luta", "ruan_macacao", "davi_relampago")
+	_assert(str(combat_manager.call("get_actor_state_name", "davi_relampago")) == "PLAYER_STANDING_NEUTRAL", "Estado inicial do rival nao foi espelhado corretamente")
+	var available: Array = combat_manager.call("get_available_techniques", "davi_relampago")
+	_assert(not available.is_empty(), "Davi nao recebeu tecnicas disponiveis")
+
+	var ai: Node = DaviAIControllerScript.new()
+	root.add_child(ai)
+	ai.call("setup", "davi_relampago", "normal")
+	ai.call("record_player_action", "grip_de_ferro")
+	ai.call("record_player_action", "grip_de_ferro")
+	var chosen: Dictionary = ai.call("choose_technique", combat_manager)
+	_assert(not chosen.is_empty(), "IA de Davi nao escolheu tecnica")
+	_assert(bool(chosen.get("affordable", false)), "IA escolheu tecnica sem recursos")
+
+	_seed_runtime_resolver_for_success(0.95)
+	var result: Dictionary = combat_manager.call("apply_opponent_action", "grip_de_ferro")
+	_assert(str(result.get("actor_id", "")) == "davi_relampago", "Acao rival foi atribuida ao ator errado")
+	_assert(str(result.get("actor_state_from", "")) == "PLAYER_STANDING_NEUTRAL", "Resolver rival recebeu perspectiva posicional errada")
+	if bool(result.get("success", false)):
+		_assert(str(combat_manager.call("get_current_state_name")) == "PLAYER_BOTTOM_CLINCH", "Entrada de Davi nao virou clinch por baixo para Ruan")
+		_assert(str(result.get("actor_state_to", "")) == "PLAYER_TOP_CLINCH", "Estado de saida do rival nao foi preservado na perspectiva do ator")
+	ai.queue_free()
+	combat_manager.set("is_running", false)
+	combat_manager.get("state_machine").call("reset")
+
+func _seed_runtime_resolver_for_success(chance: float) -> void:
+	var runtime_resolver: Node = combat_manager.get("technique_resolver")
+	var rng: RandomNumberGenerator = runtime_resolver.get("rng")
+	var deterministic_seed := 0
+	for seed_value in range(1000):
+		rng.seed = seed_value
+		if rng.randf() <= chance:
+			deterministic_seed = seed_value
+			break
+	rng.seed = deterministic_seed
 
 func _test_cria_live_single_post_contract() -> void:
 	if signal_bus == null or cria_live_manager == null:


### PR DESCRIPTION
## Objetivo
Transformar Davi Relâmpago de dica textual em rival que realmente executa técnicas, consome recursos, altera posição e pode vencer.

## Implementado
- estado posicional espelhado para ações do oponente;
- `apply_actor_action` e `apply_opponent_action` no `CombatManager`;
- resolução de técnicas na perspectiva correta do ator;
- IA data-driven de Davi usando `rival_ai_profiles_v01.json`;
- memória de ações e famílias repetidas do jogador;
- pontuação por custo, chance, risco, recursos e anti-padrões;
- turno real da IA após a ação do jogador;
- feedback de ação de Davi no HUD;
- smoke tests para escolha de técnica, custo e transição espelhada.

## Arquitetura
O loop crítico permanece determinístico e offline. LLMs/Ollama não controlam o combate e não são dependência do APK.

## Próximo passo
Janela de defesa, cronômetro/pontuação e telemetria de balanceamento.