### PR TITLE
feat: adicionar IA local opcional com fallback offline

### DIFF
--- a/data/ai/local_ai_config_v01.json
+++ b/data/ai/local_ai_config_v01.json
@@ -1,0 +1,73 @@
+{
+  "version": "0.1.0",
+  "language": "pt-BR",
+  "runtime_policy": {
+    "enabled_by_default": false,
+    "combat_llm_allowed": false,
+    "apk_requires_llm": false,
+    "fallback_required": true,
+    "network_default": false,
+    "max_response_chars": 420,
+    "max_history_messages": 6
+  },
+  "backends": {
+    "disabled": {
+      "type": "disabled",
+      "description": "Modo oficial do APK: respostas canonicas locais sem servidor."
+    },
+    "ollama_desktop": {
+      "type": "ollama_http",
+      "description": "Desenvolvimento no PC ou Android conectado a um servidor na rede local.",
+      "desktop_url": "http://127.0.0.1:11434",
+      "android_emulator_url": "http://10.0.2.2:11434",
+      "model": "qwen3:0.6b",
+      "timeout_seconds": 8.0,
+      "max_tokens": 96,
+      "temperature": 0.55,
+      "top_p": 0.85
+    },
+    "llama_cpp_server": {
+      "type": "openai_compatible",
+      "description": "Servidor local llama.cpp com endpoint de chat compatível.",
+      "base_url": "http://127.0.0.1:8080",
+      "chat_path": "/v1/chat/completions",
+      "model": "qwen3-local",
+      "timeout_seconds": 8.0,
+      "max_tokens": 96,
+      "temperature": 0.55,
+      "top_p": 0.85
+    }
+  },
+  "recommended_models": [
+    {
+      "hub_id": "Qwen/Qwen3-0.6B",
+      "role": "dialogo curto e classificacao de intencao",
+      "license": "Apache-2.0",
+      "tier": "baixo_consumo",
+      "production_note": "Preferir quantizacao GGUF Q4 quando executado fora do APK."
+    },
+    {
+      "hub_id": "Qwen/Qwen3-1.7B-GGUF",
+      "role": "dialogo com melhor coerencia em equipamentos mais fortes",
+      "license": "Apache-2.0",
+      "tier": "qualidade_equilibrada",
+      "production_note": "Uso opcional via servidor local ou plugin nativo futuro."
+    },
+    {
+      "hub_id": "HuggingFaceTB/SmolLM3-3B",
+      "role": "prototipacao multilíngue no desktop",
+      "license": "Apache-2.0",
+      "tier": "desktop_forte",
+      "production_note": "Nao e o modelo padrao do Android por custo de memoria e bateria."
+    }
+  ],
+  "prompt_rules": {
+    "max_sentences": 3,
+    "require_ptbr": true,
+    "require_canon": true,
+    "forbid_combat_instruction": true,
+    "forbid_new_major_lore": true,
+    "fallback_on_timeout": true,
+    "fallback_on_invalid_json": true
+  }
+}

--- a/data/dialogues/ai_fallbacks_v01.json
+++ b/data/dialogues/ai_fallbacks_v01.json
@@ -1,0 +1,59 @@
+{
+  "version": "0.1.0",
+  "language": "pt-BR",
+  "characters": {
+    "mestre_dende": {
+      "default": [
+        "O tatame nao mente. Respira, firma a base e faz o simples direito.",
+        "Forca sem direcao vira peso morto. Controle primeiro, pressao depois.",
+        "Quem aprende a bater o tap tambem aprende a respeitar o limite. Isso e maturidade."
+      ],
+      "treino": [
+        "Hoje nao quero pressa. Quero postura, pegada limpa e repeticao bem feita.",
+        "Se a tecnica falhou, nao brigue com ela. Volte uma etapa e reconstrua a base."
+      ],
+      "disciplina": [
+        "Talento abre a porta. Disciplina e o que impede voce de ser expulso dela.",
+        "Ser forte e ser gentil, mas gentileza sem firmeza tambem nao sustenta ninguem."
+      ],
+      "derrota": [
+        "Perder com os olhos abertos ensina mais que vencer no escuro.",
+        "Nao esconda a falha. Estuda, corrige e volta melhor."
+      ]
+    },
+    "tinker_bell": {
+      "default": [
+        "Eu vi o padrao. Voce repete a entrada quando fica ansioso.",
+        "Nao e falta de forca. E previsibilidade. Muda o tempo e o jogo abre.",
+        "Deixa comigo a leitura. Voce cuida da base e nao entrega o pescoco."
+      ],
+      "analise": [
+        "Davi reage depois da segunda repeticao. Mostra uma coisa e entra por outra.",
+        "Seu gas cai quando voce tenta resolver tudo na explosao. Usa mais controle."
+      ]
+    },
+    "davi_relampago": {
+      "default": [
+        "Velocidade sem tecnica e correria. Tecnica sem coragem e enfeite.",
+        "Eu respeito sua pressao, Macacao. Mas repetir a mesma entrada e pedir contra-ataque.",
+        "No tatame eu nao preciso falar alto. Meu timing fala por mim."
+      ],
+      "pos_luta": [
+        "Foi luta de verdade. Corrige seus erros que eu vou corrigir os meus.",
+        "Hoje um de nos venceu. O estudo continua para os dois."
+      ]
+    },
+    "cassio_molho": {
+      "default": [
+        "Honra e bonita, mas boleto nao aceita faixa preta como pagamento.",
+        "Eu nao estou oferecendo atalho. Estou oferecendo uma porta que pouca gente enxerga.",
+        "Fama nao espera. Ou voce pega a onda ou vira historia que ninguem ouviu."
+      ]
+    }
+  },
+  "global_fallback": [
+    "O momento pede calma. Volte ao objetivo e siga pelo caminho seguro.",
+    "Nao ha resposta nova agora. O mundo continua reagindo pelas escolhas registradas.",
+    "A conversa termina por aqui. O proximo passo esta no treino ou na missao ativa."
+  ]
+}

--- a/docs/LOCAL_AI_ANDROID.md
+++ b/docs/LOCAL_AI_ANDROID.md
@@ -1,0 +1,170 @@
+# Cria do Tatame — IA local, NPCs e Android
+
+## Decisão arquitetural
+
+O jogo possui duas camadas de IA separadas:
+
+1. **IA crítica de gameplay**: luta, defesa, contra-ataque, rotina e navegação. É determinística, data-driven e executada em GDScript/Behavior Tree.
+2. **IA generativa opcional**: somente diálogo experimental e ferramenta externa de produção. Nunca controla o combate, nunca é necessária para abrir o APK e sempre possui fallback canônico.
+
+Esta separação é obrigatória para preservar FPS, bateria, previsibilidade, QA e funcionamento offline.
+
+## Estado implementado
+
+- `CombatManager` e `DaviAIController` executam a IA real de luta sem LLM.
+- `LocalAIManager` oferece um gateway opcional para Ollama ou servidor local compatível.
+- O backend padrão é `disabled`.
+- `ai_fallbacks_v01.json` garante diálogos offline para Mestre Dendê, Tinker Bell, Davi e Cássio.
+- Respostas remotas são limitadas, saneadas e rejeitadas quando violam regras básicas de segurança.
+- Nenhuma API key é exigida.
+
+## Beehave
+
+Beehave pode ser usado para rotinas complexas de NPCs, bosses e hubs. Ele não deve substituir o `CombatManager` nem introduzir dependência obrigatória no primeiro APK.
+
+Repositório oficial:
+
+- `https://github.com/bitbrain/beehave`
+- branch padrão para Godot 4: `godot-4.x`
+
+Integração recomendada:
+
+1. Fixar uma versão compatível com Godot 4.2.2.
+2. Copiar apenas `addons/beehave` e os templates necessários.
+3. Registrar a versão e licença em `THIRD_PARTY_NOTICES.md`.
+4. Usar árvores para comportamento de hub, patrulha, treino e boss.
+5. Manter uma rotina GDScript de fallback para o APK continuar abrindo se o addon for removido.
+
+A instalação automática do addon será feita somente após o combate e o vertical slice Android estarem estáveis. Evita-se vender a colmeia antes de ter abelha. 🐝
+
+## Ollama: uso correto
+
+Ollama é suportado oficialmente em macOS, Windows, Linux e Docker. No projeto, ele é um **servidor de desenvolvimento**, não um runtime Android embutido.
+
+Fluxos válidos:
+
+- Godot no PC → `http://127.0.0.1:11434`.
+- Emulador Android → `http://10.0.2.2:11434`.
+- Celular físico → servidor na mesma LAN, com URL informada manualmente e configuração de rede segura.
+
+Fluxo inválido para release:
+
+- prometer que `ollama serve` roda dentro do APK sem plugin nativo, NDK, empacotamento e benchmark físico.
+
+## Modelos avaliados
+
+### Qwen/Qwen3-0.6B
+
+- 751,6 milhões de parâmetros.
+- Apache-2.0.
+- Melhor candidato para diálogo curto e classificação simples.
+- Usar versão quantizada no runtime externo.
+
+### Qwen/Qwen3-1.7B-GGUF
+
+- Apache-2.0.
+- Melhor coerência, maior uso de memória.
+- Candidato para PC, servidor local ou aparelho Android forte em uma fase posterior.
+
+### HuggingFaceTB/SmolLM3-3B
+
+- 3,075 bilhões de parâmetros.
+- Apache-2.0.
+- Suporte explícito a português entre os idiomas do modelo.
+- Recomendado para prototipação no desktop, não como padrão de aparelho intermediário.
+
+## Backend nativo Android futuro
+
+Uma versão realmente on-device exige uma destas rotas:
+
+- plugin Android/JNI para `llama.cpp`;
+- integração MLC LLM;
+- runtime móvel equivalente, com biblioteca nativa e modelo quantizado.
+
+Critérios antes de integrar:
+
+- APK/AAB abre sem modelo instalado;
+- download do modelo é opcional e verificável por hash;
+- memória de pico medida em aparelho físico;
+- geração não bloqueia a thread principal;
+- cancelamento, timeout e fallback funcionam;
+- consumo de bateria e temperatura são documentados;
+- licença do modelo e da quantização são registradas.
+
+## API do LocalAIManager
+
+### Fallback imediato
+
+```gdscript
+var text := LocalAIManager.get_fallback_dialogue(
+    "mestre_dende",
+    "treino"
+)
+```
+
+### Requisição assíncrona
+
+```gdscript
+func _ready() -> void:
+    LocalAIManager.dialogue_ready.connect(_on_dialogue_ready)
+    LocalAIManager.dialogue_failed.connect(_on_dialogue_failed)
+
+func pedir_conselho() -> void:
+    LocalAIManager.request_dialogue(
+        "mestre_dende",
+        "Mestre, por que minha passagem falhou?",
+        {"category": "treino", "location": "terreiro_da_luta"}
+    )
+
+func _on_dialogue_ready(_id: int, npc_id: String, text: String, source: String) -> void:
+    print(npc_id, ": ", text, " [", source, "]")
+```
+
+### Ativar Ollama manualmente no desenvolvimento
+
+```gdscript
+LocalAIManager.configure_backend("ollama_desktop")
+```
+
+Para celular físico, a URL deve ser informada explicitamente:
+
+```gdscript
+LocalAIManager.configure_backend(
+    "ollama_desktop",
+    "http://192.168.1.50:11434"
+)
+```
+
+## Política de segurança e canon
+
+- máximo de três frases;
+- PT-BR obrigatório;
+- sem novo protagonista, facção, morte ou parentesco canônico;
+- sem instruções reais de lesão;
+- sem LLM no combate;
+- timeout vira fallback;
+- JSON inválido vira fallback;
+- rede desligada por padrão;
+- nenhuma chave OpenAI ou Hugging Face dentro do APK.
+
+## Testes obrigatórios
+
+1. APK sem rede: diálogos de fallback funcionam.
+2. Servidor Ollama desligado: resposta de fallback chega sem travar.
+3. JSON inválido: fallback e sinal de erro.
+4. Resposta vazia: fallback.
+5. Resposta acima do limite: truncamento.
+6. Dois NPCs pedindo fala: fila sequencial sem mistura.
+7. Combate durante falha de IA generativa: zero impacto no loop.
+8. Fechar e reabrir o jogo: nenhuma dependência de servidor.
+
+## Definition of Done da IA generativa
+
+A feature só pode ser chamada de pronta quando:
+
+- o jogo funciona integralmente com backend `disabled`;
+- o diálogo opcional funciona no desktop;
+- o fallback passa no smoke test;
+- o Android físico foi testado;
+- RAM, bateria, temperatura e latência estão documentadas;
+- nenhuma promessa de "IA dentro do APK" depende de um servidor escondido na rede.

--- a/export_presets.cfg
+++ b/export_presets.cfg
@@ -31,6 +31,8 @@ screen/support_xlarge=true
 launcher_icons/main_192x192=""
 launcher_icons/adaptive_foreground_432x432=""
 launcher_icons/adaptive_background_432x432=""
+permissions/internet=true
+permissions/access_network_state=true
 
 [preset.1]
 

--- a/project.godot
+++ b/project.godot
@@ -8,6 +8,7 @@ run/main_scene="res://scenes/main_menu/MainMenu.tscn"
 [autoload]
 SignalBus="*res://src/autoloads/SignalBus.gd"
 DataRegistry="*res://src/autoloads/DataRegistry.gd"
+LocalAIManager="*res://src/autoloads/LocalAIManager.gd"
 WorldState="*res://src/autoloads/WorldState.gd"
 SaveManager="*res://src/autoloads/SaveManager.gd"
 CombatManager="*res://src/autoloads/CombatManager.gd"

--- a/src/ai/NPCDialogueController.gd
+++ b/src/ai/NPCDialogueController.gd
@@ -1,0 +1,41 @@
+extends Node
+class_name NPCDialogueController
+
+signal response_received(text: String, source: String)
+signal response_failed(reason: String)
+
+@export var npc_id: String = "mestre_dende"
+@export var default_category: String = "default"
+
+var _active_request_id: int = -1
+
+func _ready() -> void:
+	if not LocalAIManager.dialogue_ready.is_connected(_on_dialogue_ready):
+		LocalAIManager.dialogue_ready.connect(_on_dialogue_ready)
+	if not LocalAIManager.dialogue_failed.is_connected(_on_dialogue_failed):
+		LocalAIManager.dialogue_failed.connect(_on_dialogue_failed)
+
+func ask(user_message: String, context: Dictionary = {}) -> int:
+	var request_context := context.duplicate(true)
+	if not request_context.has("category"):
+		request_context["category"] = default_category
+	_active_request_id = LocalAIManager.request_dialogue(npc_id, user_message, request_context)
+	return _active_request_id
+
+func clear_history() -> void:
+	LocalAIManager.clear_history(npc_id)
+
+func get_immediate_fallback(category: String = "") -> String:
+	var resolved_category := category if category != "" else default_category
+	return LocalAIManager.get_fallback_dialogue(npc_id, resolved_category)
+
+func _on_dialogue_ready(request_id: int, response_npc_id: String, text: String, source: String) -> void:
+	if request_id != _active_request_id or response_npc_id != npc_id:
+		return
+	_active_request_id = -1
+	response_received.emit(text, source)
+
+func _on_dialogue_failed(request_id: int, response_npc_id: String, reason: String) -> void:
+	if request_id != _active_request_id or response_npc_id != npc_id:
+		return
+	response_failed.emit(reason)

--- a/src/autoloads/DataRegistry.gd
+++ b/src/autoloads/DataRegistry.gd
@@ -31,6 +31,8 @@ var hub_activities := {}
 var complete_game_flow := {}
 var campaign_cinematics := {}
 var rival_ai_profiles := {}
+var local_ai_config := {}
+var ai_dialogue_fallbacks := {}
 var full_completion_backlog := {}
 var character_bible := {}
 var world_bible := {}
@@ -69,6 +71,8 @@ const DATA_FILES := {
 	"complete_game_flow": "res://data/gameplay/complete_game_flow_v01.json",
 	"campaign_cinematics": "res://data/story/campaign_cinematics_v01.json",
 	"rival_ai_profiles": "res://data/ai/rival_ai_profiles_v01.json",
+	"local_ai_config": "res://data/ai/local_ai_config_v01.json",
+	"ai_dialogue_fallbacks": "res://data/dialogues/ai_fallbacks_v01.json",
 	"full_completion_backlog": "res://data/production/full_completion_backlog_v01.json",
 	"character_bible": "res://data/lore/character_bible_v01.json",
 	"world_bible": "res://data/lore/world_bible_v01.json",
@@ -110,6 +114,8 @@ func load_all():
 	complete_game_flow = _load_raw("complete_game_flow")
 	campaign_cinematics = _load_raw("campaign_cinematics")
 	rival_ai_profiles = _load_raw("rival_ai_profiles")
+	local_ai_config = _load_raw("local_ai_config")
+	ai_dialogue_fallbacks = _load_raw("ai_dialogue_fallbacks")
 	full_completion_backlog = _load_raw("full_completion_backlog")
 	character_bible = _load_raw("character_bible")
 	world_bible = _load_raw("world_bible")
@@ -136,6 +142,7 @@ func _load_json(path):
 	if file == null:
 		return {}
 	var result = JSON.parse_string(file.get_as_text())
+	file.close()
 	if typeof(result) != TYPE_DICTIONARY:
 		return {}
 	return result
@@ -168,6 +175,14 @@ func validate_core_data():
 		errors.append("campaign_cinematics_v01.json nao carregado")
 	if rival_ai_profiles.is_empty():
 		errors.append("rival_ai_profiles_v01.json nao carregado")
+	if local_ai_config.is_empty():
+		errors.append("local_ai_config_v01.json nao carregado")
+	if ai_dialogue_fallbacks.is_empty():
+		errors.append("ai_fallbacks_v01.json nao carregado")
+	if bool(local_ai_config.get("runtime_policy", {}).get("combat_llm_allowed", true)):
+		errors.append("politica local permite LLM no combate")
+	if not bool(local_ai_config.get("runtime_policy", {}).get("fallback_required", false)):
+		errors.append("politica local exige fallback offline")
 	if character_bible.is_empty():
 		errors.append("character_bible_v01.json nao carregado")
 	if world_bible.is_empty():

--- a/src/autoloads/LocalAIManager.gd
+++ b/src/autoloads/LocalAIManager.gd
@@ -1,0 +1,254 @@
+extends Node
+
+signal dialogue_ready(request_id: int, npc_id: String, text: String, source: String)
+signal dialogue_failed(request_id: int, npc_id: String, reason: String)
+
+enum BackendType { DISABLED, OLLAMA_HTTP, OPENAI_COMPATIBLE }
+
+var backend_id: String = "disabled"
+var backend_type: int = BackendType.DISABLED
+var base_url: String = ""
+var chat_path: String = ""
+var model_name: String = ""
+var timeout_seconds: float = 8.0
+var max_tokens: int = 96
+var temperature: float = 0.55
+var top_p: float = 0.85
+var max_response_chars: int = 420
+var max_history_messages: int = 6
+
+var _http: HTTPRequest
+var _queue: Array[Dictionary] = []
+var _active: Dictionary = {}
+var _next_request_id: int = 1
+var _history_by_npc: Dictionary = {}
+
+func _ready() -> void:
+	_http = HTTPRequest.new()
+	_http.name = "LocalAIHTTPRequest"
+	add_child(_http)
+	_http.request_completed.connect(_on_request_completed)
+	call_deferred("_initialize_from_registry")
+
+func _initialize_from_registry() -> void:
+	var policy: Dictionary = DataRegistry.local_ai_config.get("runtime_policy", {})
+	max_response_chars = int(policy.get("max_response_chars", 420))
+	max_history_messages = int(policy.get("max_history_messages", 6))
+	# O APK sempre inicia em modo offline seguro. Rede ou servidor local so entram
+	# quando um menu de desenvolvimento chama configure_backend explicitamente.
+	configure_backend("disabled")
+
+func configure_backend(p_backend_id: String, override_url: String = "") -> bool:
+	var backend_config: Dictionary = DataRegistry.local_ai_config.get("backends", {}).get(p_backend_id, {})
+	if backend_config.is_empty():
+		return false
+	backend_id = p_backend_id
+	var type_name := str(backend_config.get("type", "disabled"))
+	match type_name:
+		"ollama_http": backend_type = BackendType.OLLAMA_HTTP
+		"openai_compatible": backend_type = BackendType.OPENAI_COMPATIBLE
+		_: backend_type = BackendType.DISABLED
+	model_name = str(backend_config.get("model", ""))
+	timeout_seconds = float(backend_config.get("timeout_seconds", 8.0))
+	max_tokens = int(backend_config.get("max_tokens", 96))
+	temperature = float(backend_config.get("temperature", 0.55))
+	top_p = float(backend_config.get("top_p", 0.85))
+	chat_path = str(backend_config.get("chat_path", ""))
+	if override_url != "":
+		base_url = override_url.trim_suffix("/")
+	elif backend_type == BackendType.OLLAMA_HTTP:
+		if OS.get_name() == "Android":
+			base_url = str(backend_config.get("android_emulator_url", "")).trim_suffix("/")
+		else:
+			base_url = str(backend_config.get("desktop_url", "")).trim_suffix("/")
+	else:
+		base_url = str(backend_config.get("base_url", "")).trim_suffix("/")
+	_http.timeout = timeout_seconds
+	return true
+
+func disable_backend() -> void:
+	configure_backend("disabled")
+
+func is_network_backend_enabled() -> bool:
+	return backend_type != BackendType.DISABLED and base_url != ""
+
+func request_dialogue(npc_id: String, user_message: String, context: Dictionary = {}) -> int:
+	var request_id := _next_request_id
+	_next_request_id += 1
+	var category := str(context.get("category", "default"))
+	var clean_message := _sanitize_user_message(user_message)
+	var fallback := get_fallback_dialogue(npc_id, category, clean_message)
+	var item: Dictionary = {
+		"request_id": request_id,
+		"npc_id": npc_id,
+		"user_message": clean_message,
+		"context": context.duplicate(true),
+		"fallback": fallback
+	}
+	if not is_network_backend_enabled():
+		call_deferred("_emit_fallback", item, "fallback_offline")
+		return request_id
+	_queue.append(item)
+	_pump_queue()
+	return request_id
+
+func _pump_queue() -> void:
+	if not _active.is_empty() or _queue.is_empty():
+		return
+	_active = _queue.pop_front()
+	var payload := _build_payload(_active)
+	var url := _build_chat_url()
+	if url == "":
+		_finish_with_fallback("backend_url_empty")
+		return
+	var headers := PackedStringArray(["Content-Type: application/json"])
+	var error := _http.request(url, headers, HTTPClient.METHOD_POST, JSON.stringify(payload))
+	if error != OK:
+		_finish_with_fallback("request_start_failed_%s" % error)
+
+func _build_chat_url() -> String:
+	match backend_type:
+		BackendType.OLLAMA_HTTP:
+			return base_url + "/api/chat"
+		BackendType.OPENAI_COMPATIBLE:
+			return base_url + (chat_path if chat_path != "" else "/v1/chat/completions")
+	return ""
+
+func _build_payload(item: Dictionary) -> Dictionary:
+	var npc_id := str(item.get("npc_id", "npc"))
+	var messages: Array = [{"role": "system", "content": _system_prompt_for(npc_id, item.get("context", {}))}]
+	for historic_message in _history_by_npc.get(npc_id, []):
+		messages.append(historic_message)
+	messages.append({"role": "user", "content": str(item.get("user_message", ""))})
+	if backend_type == BackendType.OLLAMA_HTTP:
+		return {
+			"model": model_name,
+			"messages": messages,
+			"stream": false,
+			"options": {
+				"temperature": temperature,
+				"top_p": top_p,
+				"num_predict": max_tokens,
+				"seed": int(item.get("request_id", 0))
+			}
+		}
+	return {
+		"model": model_name,
+		"messages": messages,
+		"stream": false,
+		"temperature": temperature,
+		"top_p": top_p,
+		"max_tokens": max_tokens
+	}
+
+func _system_prompt_for(npc_id: String, context: Dictionary) -> String:
+	var character: Dictionary = DataRegistry.get_character(npc_id)
+	var display_name := str(character.get("name", npc_id.replace("_", " ").capitalize()))
+	var role := str(character.get("role", "personagem"))
+	var origin := str(character.get("origin", "Baixo Sul da Bahia"))
+	var location := str(context.get("location", WorldState.current_hub))
+	return """Voce interpreta %s, personagem do jogo Cria do Tatame.
+Papel: %s. Origem: %s. Local atual: %s.
+Responda em portugues brasileiro, em no maximo tres frases curtas.
+Mantenha o canon de Ruan Macacao, Mestre Dende, Tinker Bell e do Baixo Sul da Bahia.
+Nao invente personagem principal, faccao, morte, parentesco ou evento canonico novo.
+Nao forneca instrucao real para machucar, lesionar ou finalizar uma pessoa.
+Fale como personagem, sem explicar que voce e uma IA.""" % [display_name, role, origin, location]
+
+func _on_request_completed(result: int, response_code: int, _headers: PackedStringArray, body: PackedByteArray) -> void:
+	if _active.is_empty():
+		return
+	if result != HTTPRequest.RESULT_SUCCESS or response_code < 200 or response_code >= 300:
+		_finish_with_fallback("http_%s_result_%s" % [response_code, result])
+		return
+	var parsed = JSON.parse_string(body.get_string_from_utf8())
+	if typeof(parsed) != TYPE_DICTIONARY:
+		_finish_with_fallback("invalid_json")
+		return
+	var text := _extract_response_text(parsed)
+	text = _sanitize_response(text)
+	if text == "" or not _passes_safety_filter(text):
+		_finish_with_fallback("unsafe_or_empty_response")
+		return
+	var npc_id := str(_active.get("npc_id", "npc"))
+	_append_history(npc_id, str(_active.get("user_message", "")), text)
+	var request_id := int(_active.get("request_id", 0))
+	var source := "ollama" if backend_type == BackendType.OLLAMA_HTTP else "openai_compatible_local"
+	_active = {}
+	dialogue_ready.emit(request_id, npc_id, text, source)
+	_pump_queue()
+
+func _extract_response_text(parsed: Dictionary) -> String:
+	if backend_type == BackendType.OLLAMA_HTTP:
+		return str(parsed.get("message", {}).get("content", ""))
+	var choices: Array = parsed.get("choices", [])
+	if choices.is_empty() or typeof(choices[0]) != TYPE_DICTIONARY:
+		return ""
+	return str(choices[0].get("message", {}).get("content", ""))
+
+func _append_history(npc_id: String, user_message: String, assistant_message: String) -> void:
+	var history: Array = _history_by_npc.get(npc_id, [])
+	history.append({"role": "user", "content": user_message})
+	history.append({"role": "assistant", "content": assistant_message})
+	while history.size() > max_history_messages:
+		history.pop_front()
+	_history_by_npc[npc_id] = history
+
+func clear_history(npc_id: String = "") -> void:
+	if npc_id == "":
+		_history_by_npc.clear()
+	else:
+		_history_by_npc.erase(npc_id)
+
+func get_fallback_dialogue(npc_id: String, category: String = "default", entropy: String = "") -> String:
+	var root_data: Dictionary = DataRegistry.ai_dialogue_fallbacks
+	var character_sets: Dictionary = root_data.get("characters", {})
+	var npc_data: Dictionary = character_sets.get(npc_id, {})
+	var options: Array = npc_data.get(category, npc_data.get("default", []))
+	if options.is_empty():
+		options = root_data.get("global_fallback", [])
+	if options.is_empty():
+		return "O tatame ficou em silencio. Volte ao objetivo atual."
+	var index := absi(hash("%s|%s|%s" % [npc_id, category, entropy])) % options.size()
+	return str(options[index])
+
+func _emit_fallback(item: Dictionary, source: String) -> void:
+	dialogue_ready.emit(
+		int(item.get("request_id", 0)),
+		str(item.get("npc_id", "npc")),
+		str(item.get("fallback", "")),
+		source
+	)
+
+func _finish_with_fallback(reason: String) -> void:
+	var item := _active.duplicate(true)
+	_active = {}
+	dialogue_failed.emit(int(item.get("request_id", 0)), str(item.get("npc_id", "npc")), reason)
+	_emit_fallback(item, "fallback_after_error")
+	_pump_queue()
+
+func _sanitize_user_message(text: String) -> String:
+	var clean := text.strip_edges().replace("\r", " ").replace("\n", " ")
+	while clean.find("  ") >= 0:
+		clean = clean.replace("  ", " ")
+	return clean.left(300)
+
+func _sanitize_response(text: String) -> String:
+	var clean := text.strip_edges().replace("\r", " ").replace("\n", " ")
+	while clean.find("  ") >= 0:
+		clean = clean.replace("  ", " ")
+	return clean.left(max_response_chars)
+
+func _passes_safety_filter(text: String) -> bool:
+	var lower := text.to_lower()
+	var blocked_phrases := [
+		"quebre o braco",
+		"torca ate quebrar",
+		"continue mesmo depois do tap",
+		"apague o adversario",
+		"cause lesao"
+	]
+	for phrase in blocked_phrases:
+		if lower.find(phrase) >= 0:
+			return false
+	return true

--- a/tests/runtime_smoke.gd
+++ b/tests/runtime_smoke.gd
@@ -15,6 +15,7 @@ var failures: Array[String] = []
 var checks: int = 0
 var signal_bus: Node
 var data_registry: Node
+var local_ai_manager: Node
 var world_state: Node
 var save_manager: Node
 var combat_manager: Node
@@ -22,6 +23,11 @@ var career_loop: Node
 var game_flow_manager: Node
 var audio_manager: Node
 var cria_live_manager: Node
+
+var _local_ai_expected_request_id: int = -1
+var _local_ai_received: bool = false
+var _local_ai_text: String = ""
+var _local_ai_source: String = ""
 
 func _initialize() -> void:
 	call_deferred("_run")
@@ -39,6 +45,7 @@ func _run() -> void:
 		audio_manager.set("enabled", false)
 	_test_autoloads()
 	_test_data_registry()
+	await _test_local_ai_fallback()
 	await _test_scene_loading()
 	_test_save_roundtrip()
 	_test_combat_domain()
@@ -50,6 +57,7 @@ func _run() -> void:
 func _resolve_autoloads() -> void:
 	signal_bus = root.get_node_or_null("SignalBus")
 	data_registry = root.get_node_or_null("DataRegistry")
+	local_ai_manager = root.get_node_or_null("LocalAIManager")
 	world_state = root.get_node_or_null("WorldState")
 	save_manager = root.get_node_or_null("SaveManager")
 	combat_manager = root.get_node_or_null("CombatManager")
@@ -62,6 +70,7 @@ func _test_autoloads() -> void:
 	var nodes: Dictionary = {
 		"SignalBus": signal_bus,
 		"DataRegistry": data_registry,
+		"LocalAIManager": local_ai_manager,
 		"WorldState": world_state,
 		"SaveManager": save_manager,
 		"CombatManager": combat_manager,
@@ -82,9 +91,46 @@ func _test_data_registry() -> void:
 	var ruan: Dictionary = data_registry.call("get_character", "ruan_macacao")
 	var arena: Dictionary = data_registry.call("get_arena", "terreiro_da_luta")
 	var techniques: Dictionary = data_registry.get("techniques")
+	var local_ai_config: Dictionary = data_registry.get("local_ai_config")
+	var dialogue_fallbacks: Dictionary = data_registry.get("ai_dialogue_fallbacks")
 	_assert(not ruan.is_empty(), "Ruan Macacao nao foi carregado")
 	_assert(not arena.is_empty(), "Terreiro da Luta nao foi carregado")
 	_assert(techniques.size() >= 10, "Catalogo principal possui menos de 10 tecnicas")
+	_assert(not local_ai_config.is_empty(), "Configuracao da IA local nao foi carregada")
+	_assert(not dialogue_fallbacks.is_empty(), "Dialogos offline de fallback nao foram carregados")
+	_assert(not bool(local_ai_config.get("runtime_policy", {}).get("combat_llm_allowed", true)), "LLM foi permitido no combate por engano")
+	_assert(bool(local_ai_config.get("runtime_policy", {}).get("fallback_required", false)), "Fallback offline nao esta marcado como obrigatorio")
+
+func _test_local_ai_fallback() -> void:
+	if local_ai_manager == null:
+		return
+	_assert(not bool(local_ai_manager.call("is_network_backend_enabled")), "IA local iniciou com rede habilitada")
+	var direct_fallback := str(local_ai_manager.call("get_fallback_dialogue", "mestre_dende", "treino", "smoke"))
+	_assert(direct_fallback.length() > 10, "Fallback direto de Mestre Dende esta vazio")
+	_local_ai_received = false
+	_local_ai_text = ""
+	_local_ai_source = ""
+	if not local_ai_manager.dialogue_ready.is_connected(_on_local_ai_test_ready):
+		local_ai_manager.dialogue_ready.connect(_on_local_ai_test_ready)
+	_local_ai_expected_request_id = int(local_ai_manager.call(
+		"request_dialogue",
+		"mestre_dende",
+		"Mestre, por que minha passagem falhou?",
+		{"category": "treino", "location": "terreiro_da_luta"}
+	))
+	await process_frame
+	_assert(_local_ai_received, "IA local desligada nao entregou fallback assíncrono")
+	_assert(_local_ai_text.length() > 10, "Fallback assíncrono retornou texto vazio")
+	_assert(_local_ai_source == "fallback_offline", "IA local desligada retornou fonte inesperada: %s" % _local_ai_source)
+	if local_ai_manager.dialogue_ready.is_connected(_on_local_ai_test_ready):
+		local_ai_manager.dialogue_ready.disconnect(_on_local_ai_test_ready)
+
+func _on_local_ai_test_ready(request_id: int, npc_id: String, text: String, source: String) -> void:
+	if request_id != _local_ai_expected_request_id or npc_id != "mestre_dende":
+		return
+	_local_ai_received = true
+	_local_ai_text = text
+	_local_ai_source = source
 
 func _test_scene_loading() -> void:
 	for scene_path in REQUIRED_SCENES:


### PR DESCRIPTION
## Objetivo
Adicionar uma camada segura de diálogo local sem transformar LLM em dependência do APK ou do combate.

## Implementado
- `LocalAIManager` como gateway assíncrono para Ollama e servidor local compatível;
- backend `disabled` por padrão em todas as plataformas;
- fila de requisições, timeout, histórico limitado e saneamento de resposta;
- fallbacks canônicos PT-BR para Dendê, Tinker Bell, Davi e Cássio;
- política explícita: LLM proibido no combate e fallback obrigatório;
- modelos Hugging Face avaliados e registrados por uso/licença;
- `NPCDialogueController` reutilizável;
- permissão de internet apenas para o backend HTTP opcional no Android debug;
- documentação técnica sobre Ollama, Beehave e futura integração nativa Android;
- smoke test garantindo rede desligada e fallback offline funcional.

## Correção importante de arquitetura
Ollama é tratado como servidor de desenvolvimento em PC/LAN. Este PR não afirma que Ollama roda embutido dentro do APK. Uma inferência realmente on-device exigirá plugin Android/JNI com llama.cpp, MLC LLM ou runtime móvel equivalente, além de benchmark físico.

## Garantias
- nenhuma API key;
- jogo abre e funciona sem servidor;
- nenhuma chamada de LLM no loop crítico;
- dados e diálogos validados pelo `DataRegistry`;
- Android continua ARM64 e offline-first.