### PR TITLE
docs(canon): portar GDD-CDT v4.0 para integração v4

### DIFF
--- a/docs/canon/GDD_CDT_V4_CANON_INTAKE.md
+++ b/docs/canon/GDD_CDT_V4_CANON_INTAKE.md
@@ -1,0 +1,109 @@
+# CRIA DO TATAME – PRESSÃO
+## GDD‑CDT v4.0 — Canon Intake
+
+**Status:** authoritative from 2026-07-24  
+**Target:** Godot 4.3+  
+**Supersedes:** GDD and world-bible versions v1.0 through v3.1
+
+> This repository must resolve future canon conflicts in favor of GDD‑CDT v4.0.
+
+## Non-negotiable canon
+
+### Exactly three factions
+
+Only these IDs may exist as factions in runtime data, UI, dialogue, saves, tests, or the Faction Director:
+
+| Runtime ID | Display name | Color |
+|---|---|---|
+| `lem` | LÁ ELE MIL VEZES | `#D92323` |
+| `ntm` | NÓS TEM UM MOLHO | `#2D5016` |
+| `ale` | OS ALELUIADOS | `#4B0082` |
+
+Operational nuclei are tags owned by one of the three factions and must never be promoted to faction status:
+
+- `bonde_do_dique` → `lem`
+- `patrulha_da_br` → `lem`
+- `travessia` → `ntm`
+- `ponta_de_areia` → `ntm`
+- `lavanderia_do_festival` → `ntm`
+- `obra_nova` → `ale`
+- `congregacao_de_rua` → `ale`
+
+Required runtime contract:
+
+```gdscript
+enum FACCAO { LEM, NTM, ALE }
+```
+
+A data-validation gate must fail when a fourth faction ID is introduced.
+
+### TUPA‑200 artistic intent
+
+TUPA‑200 is fictional social criticism about the commodification of common territory, capture of access by corrupt or criminal power, decontextualized outrage, land grabbing, and environmental degradation.
+
+It is not a report, accusation, or portrayal of any real person, community, ethnic group, police officer, politician, festival owner, DJ, or criminal organization.
+
+Required credits and README disclosure:
+
+> A taxa TUPA‑200 é uma obra de ficção e crítica artística sobre a mercantilização do território e a captura do acesso pelo poder. Personagens, comunidades, facções e operações são fictícios; a geografia, a cultura e os fatos ambientais do Baixo Sul da Bahia são reais e tratados com respeito.
+
+### Safety and platform rules
+
+- Never name, symbolize, or imitate real criminal factions.
+- Never portray identifiable real people as criminals or corrupt actors.
+- No playable gunfights, gore, or operational crime instruction.
+- Playable conflict is jiu-jitsu, restraint, escape, evidence gathering, and consequence.
+- PF and PM are internally plural: lawful and corrupt characters coexist.
+- Target rating remains 14+.
+
+## Core design pillars
+
+The official logo defines the progression model:
+
+- DISCIPLINA — base, defense, routine, fatigue recovery.
+- FOCO — reading, timing, grips, BPM, resistance to noise and manipulation.
+- RESPEITO — clean endings, ritual, community legitimacy, lower corruption.
+- EVOLUÇÃO — transitions, deck growth, adaptation.
+
+The crown represents title and public power. 柔術 represents the soul of the practice. A crown without 柔術 routes toward `campeao_oco`; 柔術 without the crown may still route toward `cria_de_verdade`.
+
+## Economy contract
+
+- `criacoin` (`₵`, `#F2C230`) is clean, traceable community currency.
+- `molho` (`💵`, `#2D5016`) is gray, untraceable influence currency.
+- Parallel Pratigi may convert Molho into CRIAcoin as a money-laundering narrative hook.
+- Carrying or spending Molho increases faction marking and moral corruption.
+
+## Required world systems
+
+- Faction Director with exactly three factions.
+- Operational nuclei represented as owned tags.
+- World-map nodes, road and river travel, blocked areas, and APA rules.
+- Terrain modifiers: `areia_fofa`, `mobilidade_instavel`, `plateia`, `por_do_sol`, `strobo`, `lama`, `entulho`, `estreito_vento`, `batida_bpm`, `silencio_eco`, `manto_olhar`.
+- Parallel Pratigi as a cyclical festival event combining exhibition combat, infiltration, environmental choice, and non-lethal escape.
+- TUPA‑200 as a branching social-criticism arc with community dignity, evidence, law, and consequence.
+
+## Repository audit at intake
+
+The current repository does not yet satisfy this canon:
+
+1. `src/autoloads/FactionManager.gd` currently registers seven faction-like IDs.
+2. `data/factions.json` mixes institutions, community axes, media systems, and retired groups into the faction catalog.
+3. `tests/test_faction_director_data.py` explicitly requires seven active factions.
+4. `project.godot` still identifies the project as a Godot 4.2+ base while v4.0 targets Godot 4.3+.
+
+These conflicts require a save-aware migration, not a blind search-and-replace.
+
+## Migration policy
+
+1. Preserve boot and the canonical main scene.
+2. Introduce a compatibility mapper for old save IDs.
+3. Reclassify `terreiro`, `raiz`, `cria_live`, and `circuito_oficial` as systems or reputation axes.
+4. Retire `dragao_vermelho` and `fantasma` from the faction domain; preserve legacy save migration only where required.
+5. Rebuild faction JSON, territory ownership, director operations, and tests around `lem`, `ntm`, and `ale`.
+6. Add a lint test that fails on any fourth faction ID.
+7. Do not merge implementation changes until boot audit and automated tests pass.
+
+## Intake completeness note
+
+The source message received on 2026-07-24 was truncated during Section 8 and did not include the promised complete Sections 9–17 or appendices. This file records the authoritative rules that were fully received. Missing sections must be added verbatim or reconstructed in a later reviewed change; they must not be silently invented and labeled as user-approved canon.

--- a/docs/canon/GDD_CDT_V4_CANON_INTAKE.md
+++ b/docs/canon/GDD_CDT_V4_CANON_INTAKE.md
@@ -94,6 +94,22 @@ The current repository does not yet satisfy this canon:
 
 These conflicts require a save-aware migration, not a blind search-and-replace.
 
+## Exact legacy-ID disposition
+
+The seven current IDs and their required v4 destinations are now known:
+
+| Legacy ID | v4 disposition | Runtime domain |
+|---|---|---|
+| `la_ele_mil_vezes` | map to `lem` | faction |
+| `nos_tem_um_molho` | map to `ntm` | faction |
+| `os_aleluia` | map to `ale` and normalize display name to Os Aleluiados | faction |
+| `terreiro` | reclassify as Ituberá hub/local | world node |
+| `raiz` | reclassify as narrative axis/flag | NarrativeFlags |
+| `dragao_vermelho` | retire from active runtime; optional lore flag during migration | retired lore |
+| `fantasma` | retire from active runtime; optional lore flag during migration | retired lore |
+
+`cria_live` and `circuito_oficial`, although present in the broader legacy data catalog, are systems/institutions and must never become v4 faction IDs.
+
 ## Migration policy
 
 1. Preserve boot and the canonical main scene.
@@ -103,7 +119,22 @@ These conflicts require a save-aware migration, not a blind search-and-replace.
 5. Rebuild faction JSON, territory ownership, director operations, and tests around `lem`, `ntm`, and `ale`.
 6. Add a lint test that fails on any fourth faction ID.
 7. Do not merge implementation changes until boot audit and automated tests pass.
+8. Upgrade Godot 4.2 → 4.3 in a separate pull request.
 
-## Intake completeness note
+## Canon continuation
 
-The source message received on 2026-07-24 was truncated during Section 8 and did not include the promised complete Sections 9–17 or appendices. This file records the authoritative rules that were fully received. Missing sections must be added verbatim or reconstructed in a later reviewed change; they must not be silently invented and labeled as user-approved canon.
+The approved material for Sections 9–17 is stored in:
+
+- `docs/canon/GDD_CDT_V4_SECTIONS_09_17.md`
+
+It defines the beat sheet, systems, five endings, target autoload contracts, art/audio direction, QA, accessibility, milestones and the approved seven-phase implementation approach.
+
+## Completeness note
+
+This intake is no longer missing the material content of Sections 9–15 and 17. Three documentary gaps remain explicit:
+
+1. The original full Section 16 text containing the exact branch/commit/PR-template sequence was referenced but not reproduced verbatim; Issue #28 remains the executable source until that text arrives.
+2. Appendix B was truncated again after the opening source list and must be resent and audited before being treated as factual canon.
+3. Appendix C, the master list of flags, was not included in the received message.
+
+No missing text may be silently invented and labeled as user-approved canon.

--- a/docs/canon/GDD_CDT_V4_SECTIONS_09_17.md
+++ b/docs/canon/GDD_CDT_V4_SECTIONS_09_17.md
@@ -1,0 +1,277 @@
+# CRIA DO TATAME – PRESSÃO
+## GDD‑CDT v4.0 — Seções 9–17
+
+**Fonte:** conteúdo aprovado pelo Mestre em 24/07/2026.  
+**Autoridade:** complementa `GDD_CDT_V4_CANON_INTAKE.md` e substitui versões anteriores quando houver conflito.
+
+> Nota de integridade: as Seções 9–15 e 17 foram recebidas com conteúdo material. A Seção 16 veio como referência ao plano de migração em sete fases, não como o texto integral original de branches/commits/template. O Apêndice B voltou a ser truncado e o Apêndice C não chegou nesta mensagem; portanto, esses itens permanecem pendentes e não serão inventados.
+
+# 9. Estrutura narrativa e beat sheet
+
+```text
+PRÓLOGO  "O Peso do Macacão"        Terreiro                         Escolha 1
+ATO I    "Raiz"                     Terreiro→Pancada→Manguezal       Escolhas 2,3
+ATO II-A "O Circuito"               Dique→Budokan                    Escolha 4; Kenzo
+ATO II-B "O Submundo + TUPA-200"    Ferro Velho→Ponte→Trilha         Escolha 5; T1,T2; Oni
+ATO II-C "O Fio" — reviravolta      Verena/Reis/Montenegro/CriaLive  Escolha 6
+ATO III  "A Maré"                   Zambiapunga→Mirante→Itacaré      Escolha 7; Belt Ceremony
+CLÍMAX   "Sede Circuito Final"      final + escolha "O Código"
+EPÍLOGO  ramificado                  cinco finais
+```
+
+Diálogos literais do Prólogo e Ato I pertencem a `docs/narrative/dialogos_ato1.md`. Diálogos TUPA‑200 pertencem a `docs/narrative/dialogos_tupa200.md`. Os demais atos obedecem ao beat sheet e às flags canônicas.
+
+# 10. Sistemas
+
+| Sistema | Contrato |
+|---|---|
+| World Director | Clima, NPCs, arenas, mangue e trilha reagem às flags. |
+| Faction Director v3 | Exatamente `LEM`, `NTM`, `ALE`; leis não são facções. |
+| Cria Live Feed | Coro grego, reputação pública e arco de Joaquim; posts podem mentir ou acertar. |
+| InformantSystem | Missões PF/PMBA e escolhas de infiltração. |
+| Economia | CRIAcoin limpa × Molho cinza; lavagem no festival. |
+| Terrain/CombatBus | Modificadores por arena e corrupção por movimento sujo. |
+| Clima | Dia/noite/chuva e evento sazonal de alagamento. |
+| Eventos cíclicos | Zambiapunga, Paralelo Pratigi, São João e chuvas. |
+| Belt Ceremony | Quem entrega a faixa expressa o estado moral da jornada. |
+| Deck / Skill Tree | Quatro ramos correspondem aos quatro pilares do logo. |
+| Weekly Career | Ato II estruturado em semanas de pressão crescente. |
+
+# 11. Cinco finais
+
+| Final | Condições canônicas | Resultado |
+|---|---|---|
+| Cria de Verdade | `honra>=8`, `raiz>=8`, mangue vivo, TUPA formalizada/comunitária, informante não queimado | Dendê entrega a chave do Terreiro; Ruan vira mestre. |
+| Campeão Oco | circuito/ego altos, honra negativa, uso de Molho/festival | Ruan vira garoto-propaganda; Terreiro fecha; Joaquim é apagado. |
+| Mártir do Tatame | honra alta, informante ativo, `provas>=3`, ajuda à comunidade | Ruan perde a final de propósito; dossiê vaza; Montenegro cai; Ruan é banido. |
+| Sombra | roxo alto, underground cedo, informante queimado | Ruan vira o novo executor/aliciador; tela roxa. |
+| Ponte | honra e raiz altas, vínculo forte com Leoa, TUPA comunitária | Ruan e Leoa fundam Terreiro na trilha reconhecida; Joaquim assina o próprio nome. |
+
+Boss moral adicional: Irmão Calebe. A vitória ocorre recusando o discurso, não apenas reduzindo vida.
+
+# 12. Spec técnica Godot
+
+## Autoloads-alvo
+
+- `WorldDirectorManager`
+- `FactionDirectorV3`
+- `CriaLiveFeed`
+- `SaveManager`
+- `CombatBus`
+- `DeckManager`
+- `NarrativeFlags`
+- `InformantSystem`
+- `Economy`
+- `Weather`
+
+## NarrativeFlags — contrato mínimo
+
+```gdscript
+extends Node
+signal flag_changed(key: String, value)
+
+var honra: int = 0
+var roxo: int = 0
+var raiz: int = 0
+var circuito: int = 0
+var ego: int = 0
+var foco: int = 0
+var dende_confianca: int = 0
+var leoa_vinculo: int = 0
+var joaquim_confianca: int = 0
+var cassio_relacao: int = 0
+var verena_confianca: int = 0
+var reis_confianca: int = 0
+var underground_acesso: String = "nenhum"
+var bencao_mare: bool = false
+var informant_status: String = "nenhum"
+var mangue_estado: String = "vivo"
+var tupa200_resolucao: String = "pendente"
+var provas_joaquim: int = 0
+var beats: Array[String] = []
+
+func set_flag(key: String, value: Variant) -> void:
+    set(key, value)
+    flag_changed.emit(key, value)
+    SaveManager.mark_dirty()
+```
+
+## Faction Director v3 — invariante
+
+```gdscript
+extends Node
+
+enum FACCAO { LEM, NTM, ALE }
+
+const NUCLEOS := {
+    "bonde_dique": FACCAO.LEM,
+    "patrulha_br": FACCAO.LEM,
+    "travessia": FACCAO.NTM,
+    "ponta_de_areia": FACCAO.NTM,
+    "lavanderia_festival": FACCAO.NTM,
+    "obra_nova": FACCAO.ALE,
+    "congregacao_rua": FACCAO.ALE,
+}
+
+var rep: Dictionary = {
+    FACCAO.LEM: 0,
+    FACCAO.NTM: 0,
+    FACCAO.ALE: 0,
+}
+```
+
+A seleção de boss deve considerar informante, reputação ALE/LEM, circuito, honra, roxo, foco e raiz, sem criar quarta facção.
+
+## Dados obrigatórios
+
+- `res://data/factions/factions_v3.json`
+- `res://data/economy/economy.json`
+- `res://data/world/world_map_nodes.json`
+- `res://data/world/seasonal_events.json`
+- `res://scripts/combat/terrain_modifiers.gd`
+
+`factions_v3.json` deve conter somente `LEM`, `NTM`, `ALE`; núcleos devem ter `faccao_pai` implícita ou explícita. PF limpa, PM honesta e PM suja são lei/instituição, não facções.
+
+A economia contém `CRIACOIN` limpa e rastreável, `MOLHO` cinza e não rastreável, e a lavagem narrativa no Paralelo Pratigi.
+
+Sinais obrigatórios do `CombatBus`:
+
+```gdscript
+signal moral_tension_changed(value: float)
+signal dirty_move_attempted(id: String)
+signal code_break_in_final(broken: bool)
+```
+
+# 13. Direção de arte e áudio
+
+## Paleta oficial fechada
+
+`#0A0A0A #1A1A1A #B8860B #F2C230 #F2F2F2 #D92323 #1E3A5F #2D5016 #4B0082`
+
+## Regras visuais
+
+- HD Pixel Art 2.5D regional premium.
+- Contorno preto grosso.
+- Cel shading de 3–4 tons.
+- Rim light dourado.
+- Nenhum texto incorporado em sprite.
+- Silhueta legível a 64 px.
+- Pivot nos pés.
+- Ícone CRIAcoin: coroa + 柔術, sem efígie real.
+- Ícone Molho: nota verde + gota, sem efígie real.
+
+## Trilha por ato
+
+- Prólogo: berimbau + maré.
+- Ato I: atabaque + viola.
+- Ato II-A: cordas tensas.
+- Ato II-B: grave + percussão de ferro.
+- Ato II-C: silêncio + drones roxos.
+- Ato III: coral regional.
+- Clímax: orquestra + atabaque.
+- Epílogo: reprise do berimbau.
+- Festival: eletrônica com amostra original de atabaque.
+
+# 14. QA, acessibilidade e classificação
+
+## Gate canônico
+
+O CI falha quando:
+
+1. `FACCAO` não possui exatamente três valores.
+2. Um JSON declara facção fora de `LEM`, `NTM`, `ALE`.
+3. Terreiro, Raiz, Cria Live, Dragão Vermelho ou Fantasma aparecem como facção.
+4. Asset aprovado contém texto rasterizado indevido.
+5. Áreas-chave usam cor fora da paleta oficial.
+
+## QA de asset
+
+- Paleta validada.
+- Sem texto em sprite.
+- Personagem com fundo off-white e contorno preto na folha de produção.
+- Arena em pixel art.
+- Card com moldura dourada e faixa textual vazia.
+- Silhueta legível a 64 px.
+- Pivot nos pés.
+- Nome conforme convenção.
+
+## Acessibilidade
+
+- UI escalável.
+- Modo daltônico com ícones além de cor.
+- Vibração opcional.
+- Legendas.
+- Remapeamento de toque.
+- Redução de flashes para strobo e `manto_olhar`.
+- O sistema BPM não pode depender apenas de áudio.
+
+Classificação-alvo: 14+. Aumento para 18+ altera apenas a intensidade do Ato II-C.
+
+# 15. Plano de produção
+
+| Milestone | Semanas | Entrega |
+|---|---:|---|
+| M1 Fundação jogável | 1–2 | Input, CombatArena, HUD, touch, Ruan base, core anims, Terreiro em cinco camadas. |
+| M2 Mundo aberto v1 | 3–4 | Mapa, viagens, clima, três arenas, Cria Live. |
+| M3 Elenco + facções | 5–6 | Personagens base, Faction Director v3, núcleos, economia. |
+| M4 II-A/II-B + TUPA | 7–8 | Kenzo, Oni, T1/T2, Paralelo Pratigi, recrutamento como informante. |
+| M5 Reviravolta + finais | 9–10 | Ato II-C, cinco finais, Belt Ceremony. |
+| M6 Polimento + APK | 11–12 | QA, acessibilidade, áudio, Android ARM64 e Windows. |
+
+# 16. Instruções de implementação
+
+A execução do runtime segue a Issue #28 e o plano em sete fases aprovado:
+
+1. Schema novo em paralelo ao legado.
+2. Reclassificação dos IDs antigos.
+3. Dados v3 mantendo legado por uma release.
+4. Migração de saves para `save_version = 3`.
+5. Reescrita dos testes.
+6. Gate/lint canônico.
+7. Upgrade Godot 4.2 → 4.3 em PR separado.
+
+A sequência detalhada original de branches, arquivos, commits, template de PR, changelog e validação não foi recebida integralmente nesta mensagem. A Issue #28 é o plano executável vigente até o texto integral ser incorporado.
+
+# 17. Honestidade final e perguntas abertas
+
+## Fixado como cânone
+
+- Três facções e seus núcleos.
+- CRIAcoin × Molho.
+- TUPA‑200 como crítica artística.
+- Montenegro ligado aos Aleluiados.
+- Dendê como ex-informante.
+- Joaquim/Tinker como testemunha e prova.
+- Ruan como informante possível.
+- Geografia real tratada com respeito.
+- Cinco finais.
+- Quatro pilares na Skill Tree.
+- Invariante de lint.
+
+## Perguntas abertas
+
+1. Existe câmbio livre CRIAcoin↔Molho com corrupção variável, ou moedas separadas até o festival?
+2. A isenção tributária municipal inspiradora vira missão ou apenas lore?
+3. O nome TUPA‑200 permanece ou recebe nome totalmente inventado?
+4. Aleluiados usam somente coerção/discurso ou violência sempre off-screen?
+5. Dendê conta seu passado antes ou depois da abordagem da PF?
+6. Reis sobrevive ao clímax?
+7. NG+ mostra o histórico do Cria Live da primeira jornada?
+
+# Apêndice A — Glossário
+
+- **Cria:** filho do lugar e do Terreiro.
+- **Macacão:** apelido de Ruan, associado à força bruta.
+- **Molho:** moeda viva e nome-símbolo da facção da água.
+- **CRIAcoin:** moeda limpa do comum.
+- **TUPA‑200:** arco de crítica artística sobre mercantilização do acesso.
+- **Pressão:** antagonista invisível; cinco mãos puxando a faixa.
+- **Rito:** luta feita para pedir licença, não simplesmente vencer.
+- **Fio:** informante.
+- **Manto/Olhar:** modificador dos Aleluiados; ser julgado pela fé alheia.
+
+# Pendências documentais
+
+- **Apêndice B:** a lista de fontes foi interrompida após o início dos portais; precisa ser reenviada integralmente e auditada antes de entrar no cânone factual.
+- **Apêndice C:** master list de flags não foi recebida nesta mensagem.
+- **Seção 16 original completa:** não foi recebida; o plano aprovado da Issue #28 permanece como substituto operacional provisório.

--- a/docs/canon/GDD_SYSTEMS_V4_1_PARTIAL.md
+++ b/docs/canon/GDD_SYSTEMS_V4_1_PARTIAL.md
@@ -1,0 +1,259 @@
+# CRIA DO TATAME – PRESSÃO
+## GDD‑SYSTEMS v4.1 — Camada Técnica de Gameplay
+
+**Status:** authoritative partial intake from 2026-07-24  
+**Target:** Godot 4.3+ / GDScript  
+**Platforms:** Android ARM64 + Windows  
+**Relation:** complements `GDD‑CDT v4.0`; narrative/canon rules remain superior in conflicts.
+
+> This file records only the systems content actually received. The source message was truncated during Section 4.4 and must not be treated as a complete v4.1 specification.
+
+---
+
+## 0. Encaixe e convenções
+
+- This document governs gameplay/runtime behavior.
+- `GDD‑CDT v4.0` governs narrative, canon and production.
+- Canon invariants remain mandatory, especially exactly three factions and the TUPA‑200 artistic-intent rules.
+- Existing assumed autoloads: `WorldDirectorManager`, `FactionDirectorV3`, `CriaLiveFeed`, `SaveManager`, `CombatBus`, `DeckManager`, `NarrativeFlags`, `InformantSystem`, `Economy`, `Weather`.
+- New systems introduced here: `PositionFSM`, `CombatResources`, `OverworldController`, `SkillTree`.
+- No gacha or loot boxes. Cards and skill nodes unlock through training, mentors, progression and CRIAcoin.
+- Molho currency may buy world shortcuts, never randomized combat power.
+
+## 1. Three nested loops
+
+### Macro — Weekly Career
+
+Seven-day pressure cycle. Each day the player chooses one or two actions: train, fight, complete a mission, rest, investigate or publish. The World Director advances weather, factions and feed state. Belt Ceremony closes acts and progression routes toward five endings.
+
+### Meso — Open world day
+
+Top-down overworld inside municipalities plus a world map between municipalities. The player walks, talks to NPCs, accepts missions, enters arenas, dojos and stores, travels by land or river, encounters events, manages CRIAcoin/Molho, edits the deck and unlocks skill nodes.
+
+### Micro — Positional combat
+
+Shared positional state machine, combat resources, contextual hand and five principal action buttons. Victory by submission, positional control or surrender. Combat choices alter honor, corruption and root flags, feeding back into the meso and macro loops.
+
+## 2. Positional combat system
+
+### 2.1 Combat resources
+
+| Resource | Meaning | Zero-state consequence |
+|---|---|---|
+| Integrity | Ability to endure before tapping | defeat/tap |
+| Gas | Physical stamina | slower and weaker actions |
+| Focus | Reading and concentration | hidden/shuffled cards and lost timing clarity |
+| Grip | Gi control level, 0–3 | control/submission cards lock |
+| Pressure | Offensive threat accumulation | finishing options do not open |
+| Guard | Defensive positional integrity | vulnerable to passes and submissions |
+| Moral tension | Dirty-fighting pressure and corruption | no direct defeat, but raises `roxo` and may fail ritual fights |
+
+HUD contract:
+
+- Opponent Integrity: large red bar.
+- Player Integrity: large blue bar.
+- Player Gas: thin energy bar beneath portrait.
+- Four shield indicators: Guard, Focus, Pressure and Grip.
+- Moral tension: purple aura/overlay.
+
+### 2.2 Shared PositionFSM
+
+Canonical position flow:
+
+```text
+STANDING
+  -> CLINCH_NEUTRO
+  -> CLINCH_DOMINANTE
+  -> GUARD_TOP / GUARD_BOTTOM
+  -> HALF_TOP / HALF_BOTTOM
+  -> SIDE_CONTROL
+  -> MOUNT / BACK_CONTROL
+  -> SUBMISSION
+```
+
+Core rules:
+
+- Position is shared, not duplicated per fighter.
+- State stores relative ownership (`top_id`, `bottom_id`, or attacker/defender).
+- Standing/clinch is grip and takedown play.
+- Guard/half guard is pass versus sweep/recovery.
+- Side/mount/back is submission versus escape.
+- Every transition has resource prerequisites and may be driven by a card or generic move.
+- Every position defines initiative and threat.
+
+Proposed enum:
+
+```gdscript
+enum POS {
+  STANDING,
+  CLINCH_NEUTRO,
+  CLINCH_DOMINANTE,
+  GUARD_TOP,
+  GUARD_BOTTOM,
+  HALF_TOP,
+  HALF_BOTTOM,
+  SIDE_CONTROL,
+  MOUNT,
+  BACK_CONTROL,
+  SUBMISSION
+}
+```
+
+### 2.3 Victory paths
+
+| Path | Rule |
+|---|---|
+| Submission | Reach `SUBMISSION` and win the submission mini-game |
+| Positional control | Official points until round timer ends |
+| Surrender | Opponent Integrity reaches zero through positional damage, fatigue and pressure |
+
+Official points specified in this intake:
+
+- takedown: 2
+- guard pass: 3
+- mount: 4
+- back control: 4
+- sweep: 2
+
+Arena rulesets decide which paths are legal. Underground fights may disable points; ritual fights require symbolic yielding rather than destructive depletion.
+
+### 2.4 Real-time decision windows
+
+Combat is neither hard turn-based nor pure button-mashing. It uses real-time resolution with short decision windows and subtle slow-motion/hitstop when meaningful responses open.
+
+Priority order:
+
+```text
+DEFESA / ENCERRAR
+TRANSIÇÃO / CARD
+PRESSÃO
+GRIP
+MOVEMENT
+```
+
+Resolution loop:
+
+1. Read input.
+2. Tick resources.
+3. Opponent AI selects intention.
+4. Resolve simultaneous actions by priority.
+5. Successful transition updates PositionFSM, points and positional damage.
+6. Enter Submission HUD when reaching submission state.
+7. Check victory, moral tags and combat feel.
+8. Emit CombatBus signals to HUD, Cria Live and World Director.
+
+### 2.5 Damage model
+
+- Positional damage: low Integrity damage plus Gas/Guard loss and official points.
+- Submission damage: massive Integrity loss or direct tap.
+- Extended zero Gas: passive Integrity loss.
+- Damage presentation must communicate domination, leverage and exhaustion rather than striking.
+
+### 2.6 Opponent AI profiles
+
+| Profile | Behavior |
+|---|---|
+| Bruto / Oni | high pressure, low defense, dirty behavior, ignores points |
+| Técnico / Davi | correct positional progression, strong windows, wins by points |
+| Frio / Kenzo | mirrors style, punishes timing mistakes |
+| Moral / Calebe | drains Focus through `manto_olhar`, wins through doubt |
+| Espiritual / Jacaré | ritual test; evaluates clean behavior rather than ordinary victory |
+
+Difficulty scales primarily through positional reading and timing accuracy, not raw damage inflation.
+
+## 3. Combat controls
+
+### 3.1 Input map
+
+| Action | Keyboard | Gamepad | Touch |
+|---|---|---|---|
+| move | WASD/arrows | left stick | virtual d-pad |
+| grip | Q | L1 | GRIP |
+| pressao | E | R1 | PRESSÃO |
+| transicao | Space | A | TRANSIÇÃO |
+| defesa | Shift | B | DEFESA |
+| encerrar | F | Y | ENCERRAR |
+| carta_1/2/3 | 1/2/3 | d-pad/right bumper mapping | tap card |
+| pausa | Esc | Start | menu |
+
+### 3.2 Contextual action contract
+
+- `GRIP`: establishes or improves grips appropriate to current position.
+- `PRESSÃO`: closes distance, applies body pressure or advances passing control.
+- `TRANSIÇÃO`: executes selected card; without a selected card, performs a weaker generic transition.
+- `DEFESA`: contextual sprawl, frame, guard recovery, bridge or submission defense.
+- `ENCERRAR`: disengages, yields position, releases a submission or ends a ritual exchange.
+
+The transition button must relabel itself by context, such as PASSAR, RASPAR or FINALIZAR.
+
+### 3.3 Movement
+
+- Standing/clinch: angle and distance.
+- Ground: hip micro-adjustment and positional leverage.
+- Dash consumes Gas and creates a punishable window when mistimed.
+
+## 4. Deck and cards
+
+### 4.1 Card schema
+
+Required fields:
+
+```text
+id
+nome
+tecnica
+origem
+destino
+lado
+custo { grip, gas, foco }
+janela
+vs_defesa
+pontos
+dano_pos
+moral
+requisito_flag
+raridade
+frames_anim
+```
+
+Rarity is progression classification (`base`, `avancada`, `mestre`) and never a gacha rarity.
+
+### 4.2 Deck construction
+
+- Deck size: 12 cards.
+- Draw hand: 3 cards; maximum hand size 5.
+- Deck capacity grows with level and Evolution skill nodes.
+- Unlock sources: training, mentors, skill nodes and narrative flags.
+- Supported archetypes include pressure, guard, back-control and hybrid/root.
+
+### 4.3 Contextual hand
+
+- On every position change, DeckManager filters cards by origin and compatible side.
+- Low Focus may temporarily hide cards as `?`.
+- Playing a card requires selecting it and pressing TRANSIÇÃO.
+- Without a selected card, TRANSIÇÃO uses a weaker generic positional move.
+
+### 4.4 Canonical cards received before truncation
+
+| Card | Origin -> Destination | Side | Cost grip/gas/focus | Window | Defense | Points | Moral | Progression |
+|---|---|---:|---:|---:|---|---:|---|---|
+| Grip de Ferro | STANDING -> CLINCH_DOMINANTE | any | 0/10/5 | 0.3 | — | 0 | clean | base |
+| Baiana | STANDING/CLINCH -> GUARD_TOP | top | 1/25/10 | 0.6 | sprawl | 2 | clean | base |
+| Guarda Fechada | GUARD_BOTTOM -> fortified GUARD_BOTTOM | bottom | 0/5/15 | — | — | 0 | clean | base |
+| Raspagem Tesoura | GUARD_BOTTOM -> GUARD_TOP | bottom | 1/20/15 | 0.6 | base/frame | 2 | clean | advanced |
+| Knee Cut Pass | GUARD_TOP -> SIDE_CONTROL | top | 2/20/15 | 0.6 | frame/hip | 3 | clean | advanced |
+| Cem Quilos | SIDE_CONTROL -> stronger SIDE_CONTROL | top | 1/10/10 | 0.4 | bridge | control | clean | base |
+| Montada | SIDE_CONTROL -> MOUNT | top | 2/25/15 | 0.7 | elbow escape | 4 | clean | master |
+| Kimura | GUARD_TOP/SIDE -> SUBMISSION | top | 3/15/20 | 0.8 | submission defense | — | clean | master |
+| Triângulo | GUARD_BOTTOM -> SUBMISSION | bottom | 2/20/25 | 0.8 | submission defense | — | clean | master |
+| Mata-Leão | BACK_CONTROL -> SUBMISSION | top | 3/10/20 | 0.9 | submission defense | — | clean | master |
+
+## Intake truncation boundary
+
+The received source stopped immediately after beginning the optional dirty-card subsection:
+
+```text
+Cartas "sujas" (opcionais, do underground): ex.: Cabeçada no Clinch ...
+```
+
+Sections 5–15, the remainder of Section 4.4, all consolidated tables and the final implementation instructions were not received in this message. They must be appended from an explicit reviewed source and must not be reconstructed silently.


### PR DESCRIPTION
## O que este PR faz

- Registra o `GDD‑CDT v4.0` como cânone autoritativo a partir de 24/07/2026.
- Congela a regra de **exatamente três facções**: `lem`, `ntm`, `ale`.
- Fecha o mapeamento dos sete IDs legados atualmente registrados no runtime.
- Reclassifica Terreiro, Raiz, Cria Live e Circuito Oficial como local/eixo/sistema/instituição.
- Aposenta Dragão Vermelho e Fantasma do domínio ativo de facções.
- Registra a intenção artística e as salvaguardas legais do arco TUPA‑200.
- Define economia, pilares, beat sheet, cinco finais, sistemas, contratos técnicos, arte, áudio, QA, acessibilidade e milestones.
- Adiciona o intake parcial do `GDD‑SYSTEMS v4.1`, cobrindo os três loops, combate posicional, recursos, PositionFSM, comandos contextuais, deck e dez cartas canônicas.
- Vincula a migração executável de runtime à Issue #28.

## O que este PR não faz

Não altera o runtime. O código e os testes atuais ainda exigem sete facções; uma troca parcial quebraria o Faction Director e poderia corromper saves. A implementação ficará em PR separado e só será mesclada após migração de saves, lint canônico, testes e auditoria de boot.

O GDD-SYSTEMS v4.1 também não será implementado parcialmente sem auditoria dos gestores existentes. Novos nomes como `PositionFSM`, `CombatResources`, `OverworldController` e `SkillTree` devem ser integrados por fachada/adapter quando já houver responsabilidade equivalente no repo.

## Pendências documentais ainda explícitas

- O texto original integral da Seção 16 do GDD-CDT v4.0 não foi reproduzido.
- O Apêndice B do GDD-CDT v4.0 chegou truncado.
- O Apêndice C, master list de flags, ainda não chegou.
- O GDD-SYSTEMS v4.1 foi truncado durante a Seção 4.4; suas Seções 5–15 ainda não foram recebidas.

Nenhuma lacuna foi preenchida por invenção.

Relaciona-se a #28.