### PR TITLE
docs(protocol): ativar GAME_BUILD_PROTOCOL v1 no projeto

### DIFF
--- a/.agents/skills/cria-do-tatame-game-director/SKILL.md
+++ b/.agents/skills/cria-do-tatame-game-director/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: cria-do-tatame-game-director
-description: Orquestra a construção e a gestão completa de Cria do Tatame – Pressão. Use para auditar, planejar, implementar, integrar, testar, documentar e liberar sistemas Godot, combate de BJJ, mundo, narrativa, economia, facções, UI, áudio, sprites, animações, Android, CI e governança GitHub, preservando o cânone, o repositório único e os gates de qualidade.
+description: Orquestra a construção e a gestão completa de Cria do Tatame – Pressão. Use para auditar, planejar, implementar, integrar, testar, documentar e liberar sistemas Godot, combate de BJJ, mundo, narrativa, economia, facções, UI, áudio, sprites, animações, Android, CI e governança GitHub, seguindo o GAME_BUILD_PROTOCOL e os gates canônicos.
 license: Proprietary
 metadata:
   author: Instituto CRIA / Satoshi Nishiuchi
-  version: "1.0.0"
+  version: "1.1.0"
   repository: ringuemkt-rgb/cria-do-tatame
 ---
 
@@ -14,142 +14,124 @@ metadata:
 
 Operar como diretor integrado de produto, engenharia, game design, produção visual, narrativa, QA, release e gestão do projeto **Cria do Tatame – Pressão**.
 
-Esta skill coordena trabalho real no repositório. Ela não autoriza declarar como pronto aquilo que ainda é conceito, placeholder, mockup, documentação, asset não integrado ou build não validado.
+Esta skill executa `docs/GAME_BUILD_PROTOCOL.md`. Ela não substitui o contrato SUPREME, o GDD ou os dados canônicos e não autoriza declarar pronto aquilo que ainda é conceito, placeholder, asset não integrado ou build não validado.
 
 ## Quando ativar
 
-Ative esta skill sempre que o pedido envolver um ou mais destes termos ou objetivos:
+Ativar sempre que o pedido envolver:
 
-- construir, continuar, completar ou atualizar o jogo;
-- revisar, organizar, consolidar ou gerir o repositório;
+- construir, continuar, completar, atualizar ou gerir o jogo;
+- revisar, consolidar ou auditar o repositório;
 - implementar Godot, combate, cartas, IA, save, mundo, facções, economia ou narrativa;
-- produzir sprites, animações, arenas, cartas, HUD, VFX, áudio ou material visual;
-- criar APK, release, testes, CI, auditoria, backlog, issues, commits ou pull requests;
+- produzir sprites, animações, arenas, HUD, áudio, VFX ou material visual;
+- criar APK, release, testes, CI, backlog, issues, commits ou pull requests;
 - avaliar progresso, riscos, dívida técnica ou Definition of Done.
 
 ## Inicialização obrigatória
 
-Antes de modificar o projeto:
+Antes de propor ou executar mudanças:
 
 1. Ler `AGENTS.md`.
-2. Ler `references/OPERATING_MODEL.md` desta skill.
-3. Ler `references/QUALITY_GATES.md` desta skill.
-4. Consultar a fonte canônica atual em `docs/canon/`, os contratos em `data/production/` e o estado do PR de integração.
-5. Verificar se já existe implementação equivalente antes de criar outro sistema.
-6. Classificar a tarefa em: auditoria, engenharia, dados/game design, visual, narrativa, gestão ou release.
-7. Definir um lote vertical pequeno, testável e reversível.
+2. Ler `docs/GAME_BUILD_PROTOCOL.md`.
+3. Ler `docs/DOC_PRECEDENCE.md`.
+4. Ler `references/OPERATING_MODEL.md`.
+5. Ler `references/QUALITY_GATES.md`.
+6. Ler `references/TOOL_ROUTING.md`.
+7. Consultar o contrato SUPREME, o cânone aplicável, os dados e o estado ao vivo do GitHub.
+8. Executar o Handshake do protocolo; quando indisponível, declarar modo degradado.
+9. Procurar implementação equivalente antes de criar outro sistema.
+10. Definir um lote vertical pequeno, testável, reversível e com rollback.
 
-## Invariantes invioláveis
+## Invariantes
 
 - Repositório único: `ringuemkt-rgb/cria-do-tatame`.
-- Não criar outro repositório do jogo.
 - Main scene: `res://scenes/main_menu/MainMenu.tscn`.
-- Engine alvo: Godot 4.3+, preservando gate de compatibilidade 4.2.2 enquanto necessário.
+- Godot é o único runtime; alvo 4.3+, com gate 4.2.2 enquanto necessário.
 - Exatamente três facções: `LEM`, `NTM`, `ALE`.
-- Núcleos operacionais são tags subordinadas, nunca facções.
-- `TransitionManager` é canônico; `CombatManager` atua como fachada.
-- Um único `AudioManager`.
-- `DeckManager` é canônico.
+- Núcleos são tags subordinadas.
+- Um único `AudioManager` e um único `DeckManager`.
+- `CombatManager` permanece fachada compatível; migrações usam adapters/Strangler Fig.
 - Managers de mundo permanecem separados por responsabilidade.
-- Gameplay crítico deve ser determinístico e funcionar offline.
-- Não versionar tokens, chaves, keystores, credenciais ou dados pessoais.
+- Gameplay crítico é determinístico e offline.
+- Sem gacha, poder por Molho ou finalização automática.
+- Sem segredos, credenciais, keystores ou dados pessoais no Git.
 
-## Cânone visual permanente
+## Cânone visual
 
-- Pixel art 16-bit em alta definição, contorno preto grosso, cel-shading, rim light dourado e grade visível.
-- Nunca fotografia, 3D realista ou cartoon infantil como arte final do jogo.
-- Paleta exclusiva: `#0A0A0A`, `#1A1A1A`, `#B8860B`, `#F2C230`, `#F2F2F2`, `#D92323`, `#1E3A5F`, `#2D5016`, `#4B0082`.
-- Facções: LEM `#D92323`; NTM `#2D5016`; ALE `#4B0082`.
-- Sem texto embutido nos assets, marcas de terceiros, armas de fogo, gore ou pessoas reais.
-- Produção em lotes de até dez imagens do mesmo tipo e com a mesma âncora visual.
-- Um lote visual corresponde a um commit; executar QA antes do lote seguinte.
+- Pixel art 16-bit/2.5D em resolução nativa, contorno preto, cel-shading e rim light dourado.
+- Paleta de arte: `#0A0A0A #1A1A1A #B8860B #F2C230 #F2F2F2 #D92323 #1E3A5F #2D5016 #4B0082`.
+- Não usar fotografia, 3D realista ou cartoon infantil como arte final.
+- Sem texto embutido em sprites, marcas de terceiros, armas de fogo, gore ou pessoa real.
+- Produção visual em lotes de até dez imagens do mesmo tipo; um lote corresponde a um commit e exige QA antes do seguinte.
+- CPS/prancha densa é referência, não spritesheet final.
 
 ## Loop operacional
 
-Execute sempre nesta ordem:
+Seguir `docs/GAME_BUILD_PROTOCOL.md`:
 
-1. **Inventário** — identificar arquivos, sistemas, referências, testes, dependências e estado real.
-2. **Diagnóstico** — separar fato confirmado, hipótese, lacuna, risco e conflito de cânone.
-3. **Plano vertical** — definir objetivo, arquivos, critérios de aceite e rollback.
-4. **Implementação** — reutilizar arquitetura existente; evitar duplicação e sistemas paralelos.
-5. **Integração** — conectar ao fluxo oficial, save, DataRegistry, SignalBus, UI e dados quando aplicável.
-6. **Validação** — executar lint, testes Python, Godot headless, auditorias e checks específicos.
-7. **Documentação** — registrar decisões, migrações, limitações e uso.
-8. **GitHub** — commit focado, issue/PR atualizado e evidências anexadas.
-9. **Relatório** — informar entregas reais, falhas, riscos e próximo lote.
+1. Handshake e inventário.
+2. Diagnóstico baseado em evidência.
+3. Uma decisão de maior alavancagem.
+4. Plano vertical com arquivos, critérios, testes e rollback.
+5. Implementação reutilizando arquitetura existente.
+6. Integração ao fluxo oficial, save, DataRegistry, SignalBus, UI e dados.
+7. Validação por lint, testes, Godot headless, QA e checks específicos.
+8. Documentação e GitHub.
+9. Relatório honesto e próximo lote.
 
 ## Regras de implementação
 
-- Preferir Strangler Fig e adapters para migrações de runtime.
-- Não substituir uma API estável sem camada de compatibilidade e teste de migração.
-- Dados precisam ter schema claro, IDs estáveis e referências válidas.
-- Toda feature deve possuir entrada jogável ou consumidor real; classes soltas não contam como integração.
-- Todo sistema persistível deve declarar versão e migração de save.
-- Toda alteração em autoload exige auditoria de boot.
-- Toda mudança de combate exige smoke de posição, lado, recursos, defesa e encerramento.
-- Toda mudança visual exige validação de paleta, dimensão, transparência, pivô, nome, licença e integração Godot.
-- Não usar LLM remoto no loop crítico de combate.
+- Não substituir API estável sem compatibilidade e teste de migração.
+- Dados precisam de schema, IDs estáveis e referências válidas.
+- Classe sem consumidor real não conta como feature integrada.
+- Sistema persistível declara versão, migração e roundtrip.
+- Mudança em autoload exige auditoria de boot.
+- Mudança de combate exige smoke de posição, lado, recursos, defesa, submissão e encerramento.
+- Técnica pareada exige `sync_map` e revisão biomecânica.
+- Asset exige paleta, dimensão, transparência, pivô, nome, licença, manifest, preview, cena e QA.
+- LLM remoto não participa do loop crítico de combate.
 
 ## Gestão GitHub
 
-- Trabalhar em branch específica ou na branch de integração declarada pelo projeto.
-- Nunca escrever diretamente em `main` sem autorização explícita e gates verdes.
-- Commits devem ser pequenos, coerentes e usar Conventional Commits.
-- Um PR não pode misturar produto externo, site, e-book ou outro jogo.
-- Issues devem possuir objetivo, escopo, critérios de aceite, dependências e riscos.
-- PR deve listar arquivos, testes, migrações, screenshots/logs e limitações.
-- Ações destrutivas exigem backup, inventário e autorização explícita.
+- Trabalhar em branch específica ou na branch de integração autorizada.
+- Nunca escrever em `main` sem autorização e gates verdes.
+- Usar Conventional Commits e PRs verticais.
+- Respeitar stacked PRs e suas bases.
+- PR não mistura site, e-book, outro jogo ou produto externo.
+- Ação destrutiva exige inventário, backup e autorização explícita.
+- CI é porteiro; status desconhecido não é verde.
 
-## Roteamento de ferramentas
+## Roteamento
 
-Consulte `references/TOOL_ROUTING.md` antes de escolher ferramentas.
+Consultar `references/TOOL_ROUTING.md`.
 
-Princípios:
-
-- GitHub para código, dados, issues, PRs e governança.
-- Godot/headless e scripts locais para parser, runtime e export.
-- Geração de imagem para conceitos e assets aprovados; nunca confundir geração com integração final.
-- Pipeline de sprites para strips, pivôs, escala, transparência e preview.
-- Pesquisa web somente para fatos externos atuais, licenças e documentação primária.
+- GitHub: código, dados, PRs, issues, CI e governança.
+- Godot/headless: parser, runtime, smokes e export.
+- Geração visual: conceito e assets aprovados, nunca promoção automática.
+- Pipeline de sprites: strip, pivô, escala, transparência, atlas e preview.
+- Web: documentação primária, fatos atuais e licenças.
 - Não enviar segredos a serviços externos.
 
-## Gates de conclusão
+## Gates
 
-Aplicar integralmente `references/QUALITY_GATES.md`.
+Aplicar `references/QUALITY_GATES.md` e o contrato SUPREME.
 
-Nenhum lote pode ser chamado de concluído quando:
+Nenhum lote está concluído quando testes falham, o projeto não faz parse, fluxo/save quebram, referências estão ausentes, documentação contradiz runtime, APK não foi instalado quando exigido, performance foi estimada ou falta aprovação humana/licença.
 
-- testes obrigatórios falham;
-- o projeto não abre ou não faz parse;
-- o fluxo principal foi quebrado;
-- save/load ou migração não foi validado;
-- referências ou assets estão ausentes;
-- documentação contradiz o runtime;
-- APK não foi realmente gerado e instalado quando a entrega exige Android;
-- desempenho foi apenas estimado;
-- faltam licença, atribuição ou aprovação humana necessária.
+## Formato da resposta
 
-## Formato de saída obrigatório
+Usar o template do protocolo:
 
-Ao finalizar cada lote, responder com:
+```text
+🛰️ HANDSHAKE
+🔍 DIAGNÓSTICO
+🎯 DECISÃO
+📦 ENTREGA
+✅ GATE
+```
 
-1. **Entregue** — resultado funcional criado.
-2. **Arquivos** — criados, modificados e removidos.
-3. **Validação** — comandos e resultados.
-4. **GitHub** — branch, commits, issue e PR.
-5. **Riscos restantes** — falhas, incertezas e dívida técnica.
-6. **Próximo lote** — menor passo vertical de maior valor.
+Ao fechar o lote, informar arquivos, testes, GitHub, riscos e próximo lote.
 
 ## Condições de parada
 
-Pare e registre bloqueio quando houver:
-
-- conflito entre fontes canônicas;
-- risco de apagar trabalho útil;
-- licença ou origem de asset incerta;
-- biomecânica insegura ou impossível;
-- credencial necessária ausente;
-- ação irreversível não autorizada;
-- teste que não pode ser executado no ambiente atual.
-
-Nessas situações, não invente sucesso. Entregue a parte segura, preserve o estado e indique a evidência faltante.
+Parar e registrar bloqueio diante de conflito canônico, exclusão arriscada, licença incerta, biomecânica insegura, credencial ausente, ação irreversível não autorizada ou teste impossível no ambiente. Nunca inventar sucesso.

--- a/.agents/skills/cria-do-tatame-game-director/scripts/validate_skill.py
+++ b/.agents/skills/cria-do-tatame-game-director/scripts/validate_skill.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
-"""Valida a skill Cria do Tatame Game Director e seus vínculos canônicos.
+"""Valida a skill Game Director e seus vínculos canônicos.
 
-Usa somente a biblioteca padrão para rodar localmente e em CI.
+Usa somente a biblioteca padrão para funcionar localmente e na CI.
 """
 from __future__ import annotations
 
@@ -13,6 +13,11 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[4]
 SKILL_ROOT = ROOT / ".agents" / "skills" / "cria-do-tatame-game-director"
 SKILL_FILE = SKILL_ROOT / "SKILL.md"
+PROTOCOL = ROOT / "docs" / "GAME_BUILD_PROTOCOL.md"
+PRECEDENCE = ROOT / "docs" / "DOC_PRECEDENCE.md"
+SUPREME = ROOT / "docs" / "CRIA_DO_TATAME_SUPREME_BUILD_SPEC_V1.md"
+AGENTS = ROOT / "AGENTS.md"
+
 REQUIRED_REFERENCES = {
     "references/OPERATING_MODEL.md",
     "references/QUALITY_GATES.md",
@@ -30,6 +35,16 @@ def load_json(path: Path) -> dict:
     return json.loads(read(path))
 
 
+def require_contains(errors: list[str], path: Path, terms: list[str], label: str) -> None:
+    if not path.exists():
+        errors.append(f"{label} ausente: {path.relative_to(ROOT)}")
+        return
+    text = read(path)
+    for term in terms:
+        if term not in text:
+            errors.append(f"{label} não contém vínculo obrigatório: {term}")
+
+
 def validate_frontmatter(errors: list[str]) -> None:
     if not SKILL_FILE.exists():
         errors.append("SKILL.md ausente")
@@ -42,6 +57,7 @@ def validate_frontmatter(errors: list[str]) -> None:
     header = match.group("header")
     name_match = re.search(r"^name:\s*(.+)$", header, flags=re.MULTILINE)
     description_match = re.search(r"^description:\s*(.+)$", header, flags=re.MULTILINE)
+    version_match = re.search(r'^\s+version:\s+"([^"]+)"$', header, flags=re.MULTILINE)
     if not name_match:
         errors.append("frontmatter sem name")
     elif name_match.group(1).strip() != EXPECTED_NAME:
@@ -50,6 +66,8 @@ def validate_frontmatter(errors: list[str]) -> None:
         errors.append("frontmatter sem description")
     elif len(description_match.group(1).strip()) > 1024:
         errors.append("description excede 1024 caracteres")
+    if not version_match:
+        errors.append("frontmatter sem metadata.version")
 
 
 def validate_package(errors: list[str]) -> None:
@@ -58,15 +76,49 @@ def validate_package(errors: list[str]) -> None:
             errors.append(f"recurso obrigatório ausente: {relative}")
 
 
-def validate_activation(errors: list[str]) -> None:
-    agents = ROOT / "AGENTS.md"
-    if not agents.exists():
-        errors.append("AGENTS.md ausente")
-        return
-    text = read(agents)
-    expected_path = ".agents/skills/cria-do-tatame-game-director/SKILL.md"
-    if expected_path not in text:
-        errors.append("AGENTS.md não ativa a skill do diretor")
+def validate_protocol_bindings(errors: list[str]) -> None:
+    require_contains(
+        errors,
+        AGENTS,
+        [
+            "## 0. PROTOCOLO MESTRE DE CONSTRUÇÃO",
+            "docs/GAME_BUILD_PROTOCOL.md",
+            "docs/DOC_PRECEDENCE.md",
+            ".agents/skills/cria-do-tatame-game-director/SKILL.md",
+        ],
+        "AGENTS.md",
+    )
+    require_contains(
+        errors,
+        SKILL_FILE,
+        ["docs/GAME_BUILD_PROTOCOL.md", "docs/DOC_PRECEDENCE.md", "Handshake"],
+        "SKILL.md",
+    )
+    require_contains(
+        errors,
+        PROTOCOL,
+        [
+            "Status:** CANÔNICO / VINCULANTE",
+            "Handshake de abertura",
+            "Loop de gestão",
+            "Três distinções",
+            "Topologia de PRs",
+            "Auto-verificação",
+        ],
+        "GAME_BUILD_PROTOCOL.md",
+    )
+    require_contains(
+        errors,
+        PRECEDENCE,
+        ["GAME_BUILD_PROTOCOL.md", "CRIA_DO_TATAME_SUPREME_BUILD_SPEC_V1.md"],
+        "DOC_PRECEDENCE.md",
+    )
+    require_contains(
+        errors,
+        SUPREME,
+        ["docs/GAME_BUILD_PROTOCOL.md", "docs/DOC_PRECEDENCE.md"],
+        "SUPREME",
+    )
 
 
 def validate_repository_truth(errors: list[str]) -> None:
@@ -95,12 +147,13 @@ def main() -> int:
     errors: list[str] = []
     validate_frontmatter(errors)
     validate_package(errors)
-    validate_activation(errors)
+    validate_protocol_bindings(errors)
     validate_repository_truth(errors)
 
     report = {
         "ok": not errors,
         "skill": EXPECTED_NAME,
+        "protocol": "docs/GAME_BUILD_PROTOCOL.md",
         "repository": "ringuemkt-rgb/cria-do-tatame",
         "errors": errors,
     }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,34 @@
 
 Este arquivo orienta Codex, Manus, agentes locais e qualquer assistente automatizado que trabalhe neste repositório.
 
+## 0. PROTOCOLO MESTRE DE CONSTRUÇÃO — vinculante
+
+Toda construção deste jogo segue `docs/GAME_BUILD_PROTOCOL.md`.
+
+Regras resumidas:
+
+- iniciar cada iteração com Handshake de Abertura: estado ao vivo do repo, PRs, CI e delta;
+- seguir o loop verificar → diagnosticar → decidir → instruir → commitar → reverificar → fechar gate;
+- uma feature corresponde a um PR vertical; usar Conventional Commits; CI é porteiro;
+- respeitar stacked PRs e não integrar filho sem base validada;
+- prancha densa não é sprite; design aprovado não é runtime; rótulos de pronto exigem evidência;
+- Godot é o único runtime; existem exatamente três facções; sem gacha, poder por Molho ou finalização automática;
+- em conflito, seguir `docs/DOC_PRECEDENCE.md` e interromper a implementação até reconciliação.
+
+Assistentes sem memória persistente carregam estes arquivos em toda sessão:
+
+1. `docs/GAME_BUILD_PROTOCOL.md`;
+2. `docs/DOC_PRECEDENCE.md`;
+3. `.agents/skills/cria-do-tatame-game-director/SKILL.md`;
+4. módulos `references/` da skill;
+5. contrato SUPREME e cânone aplicável ao lote.
+
+Validar a ativação com:
+
+```bash
+python .agents/skills/cria-do-tatame-game-director/scripts/validate_skill.py
+```
+
 ## Skill operacional obrigatória
 
 Para qualquer tarefa de construção, continuidade, auditoria, arte, narrativa, gestão, QA ou release do jogo, carregar e seguir:
@@ -14,13 +42,7 @@ Também são obrigatórios os módulos referenciados pela skill:
 - `references/QUALITY_GATES.md`;
 - `references/TOOL_ROUTING.md`.
 
-A skill funciona como orquestradora do projeto e não substitui as fontes canônicas. Em caso de conflito, interromper a implementação, registrar o conflito e priorizar a decisão canônica mais recente e explicitamente aprovada.
-
-Validar a ativação com:
-
-```bash
-python .agents/skills/cria-do-tatame-game-director/scripts/validate_skill.py
-```
+A skill orquestra a execução do protocolo e não substitui as fontes canônicas.
 
 ## Missão
 
@@ -33,13 +55,13 @@ Construir **Cria do Tatame – Pressão**, jogo Godot 4.3+ para Android, PC e We
 - Não criar outro repositório para protótipo, APK, arte, lore ou versão alternativa.
 - Protótipos devem viver em branches ou pastas explicitamente delimitadas.
 - Documentos antigos não podem substituir dados e bíblias canônicas atuais.
-- Antes de criar algo, procure implementação equivalente neste repositório.
+- Antes de criar algo, procurar implementação equivalente neste repositório.
 
 ## Regra de ouro
 
 Não transformar o projeto em galeria de arte. Primeiro deve abrir, rodar, salvar, lutar, avançar a semana e exportar.
 
-## Canon inviolável
+## Cânone inviolável
 
 - Protagonista: Ruan “Macacão” Silva.
 - Símbolo: Gorila Silverback.
@@ -53,23 +75,24 @@ Qualquer referência antiga a Caio Ravel ou Ruan “Cria” é legado e não dev
 
 ## Ordem técnica obrigatória
 
-1. Executar `npm run quality`.
-2. Executar o validador da skill.
-3. Garantir que `project.godot` abre no Godot suportado pelo lote.
-4. Ligar e validar autoloads.
-5. Preservar o fluxo Main Menu → Terreiro → Combate → Resultado → Save.
-6. Implementar combate por posição e lado relativos de BJJ.
-7. Integrar carreira semanal, reputação, Cria Live, facções e patrocinadores.
-8. Só depois polir sprites, áudio, VFX e cutscenes.
+1. Executar o Handshake do protocolo.
+2. Executar `npm run validate:skill`.
+3. Executar `npm run quality` quando o ambiente permitir.
+4. Garantir que `project.godot` abre no Godot suportado pelo lote.
+5. Ligar e validar autoloads.
+6. Preservar o fluxo Main Menu → Terreiro → Combate → Resultado → Save.
+7. Implementar combate por posição e lado relativos de BJJ.
+8. Integrar carreira semanal, reputação, Cria Live, facções e patrocinadores.
+9. Só depois polir sprites, áudio, VFX e cutscenes.
 
-O escopo completo e os gates de produção vivem em `docs/CRIA_DO_TATAME_SUPREME_BUILD_SPEC_V1.md`, nos documentos canônicos atuais e em `data/production/supreme_build_contract_v01.json`. Um agente não pode reduzir essas metas nem declarar conclusão ignorando o contrato executável.
+O escopo completo e os gates de produção vivem em `docs/CRIA_DO_TATAME_SUPREME_BUILD_SPEC_V1.md`, `docs/GAME_BUILD_PROTOCOL.md`, nos documentos canônicos atuais e em `data/production/supreme_build_contract_v01.json`.
 
 ## Contratos de arquitetura
 
 - Gameplay crítico deve ser determinístico e executável offline.
 - IA pode criar, revisar e classificar conteúdo; não pode sustentar o loop principal em tempo real.
 - Dados em `data/` precisam manter IDs estáveis e referências válidas.
-- Sistemas novos devem possuir ponto de entrada claro, teste ou checklist de validação e documentação mínima.
+- Sistemas novos devem possuir ponto de entrada claro, teste ou checklist e documentação mínima.
 - Código temporário deve conter prazo ou condição objetiva de remoção.
 - Não criar singleton, manager, deck, áudio ou cânone paralelo.
 
@@ -80,7 +103,7 @@ O escopo completo e os gates de produção vivem em `docs/CRIA_DO_TATAME_SUPREME
 - Não criar sistema de soco/chute genérico como núcleo.
 - Não afirmar APK pronto sem build validado.
 - Não apagar arquivos úteis sem relatório de migração.
-- Não introduzir segunda engine, segundo canon ou segundo backend de conteúdo.
+- Não introduzir segunda engine, segundo cânone ou segundo backend de conteúdo.
 - Não versionar segredos, chaves, tokens, keystores ou credenciais.
 
 ## Saída esperada de cada agente
@@ -97,8 +120,8 @@ Todo agente deve entregar:
 ## Protocolo de autonomia
 
 - Trabalhar em lotes verticais jogáveis e commits focados.
-- Executar `npm run quality` e o validador da skill antes e depois de cada lote.
-- Usar GitHub, geração de imagem, Hugging Face e Sites apenas nas funções autorizadas pelo contrato supremo e pela skill.
+- Executar o validador da skill e os gates aplicáveis antes e depois de cada lote.
+- Usar ferramentas externas somente nas funções autorizadas pelo contrato supremo, protocolo e skill.
 - Fixar versão e auditar licença antes de incorporar ferramenta externa.
-- Parar diante de conflito de canon, licença incerta, biomecânica insegura, credencial ausente ou ação destrutiva.
-- Nunca confundir conceito gerado, placeholder, mockup ou fila de produção com asset final integrado.
+- Parar diante de conflito de cânone, licença incerta, biomecânica insegura, credencial ausente ou ação destrutiva.
+- Nunca confundir conceito, placeholder, mockup ou fila de produção com asset final integrado.

--- a/docs/CRIA_DO_TATAME_SUPREME_BUILD_SPEC_V1.md
+++ b/docs/CRIA_DO_TATAME_SUPREME_BUILD_SPEC_V1.md
@@ -2,6 +2,8 @@
 
 Status: contrato de produção ativo. Este documento define o produto final desejado, os limites de autonomia de agentes e as evidências necessárias para declarar uma entrega concluída. O contrato executável correspondente está em `data/production/supreme_build_contract_v01.json`.
 
+**Camada de processo vinculante:** toda execução deste contrato segue `docs/GAME_BUILD_PROTOCOL.md`; conflitos documentais são resolvidos por `docs/DOC_PRECEDENCE.md`.
+
 ## 1. Verdade atual e princípio de execução
 
 O repositório já contém um núcleo Godot funcional, dados de combate, carreira, navegação, validadores, pipeline de sprites, manifesto audiovisual e automação de build. Ele ainda não é o jogo completo: boa parte dos visuais é técnica ou provisória; o elenco, as técnicas, as arenas, a campanha e o áudio não atingiram o volume final; APK em aparelho físico e release assinada continuam sendo gates abertos.
@@ -10,11 +12,12 @@ Todo agente deve ampliar o jogo existente em lotes verticais jogáveis. Nenhum r
 
 Ordem de autoridade:
 
-1. `AGENTS.md` e este contrato;
-2. dados canônicos atuais em `data/`;
-3. código e cenas que passam na CI;
-4. documentos atuais em `docs/`;
-5. PDFs de referência e documentos históricos, usados somente quando não contradizem o canon vigente.
+1. este contrato e `data/production/supreme_build_contract_v01.json`;
+2. `docs/GAME_BUILD_PROTOCOL.md` para processo e gestão;
+3. `docs/DOC_PRECEDENCE.md`, cânone atual e dados canônicos em `data/`;
+4. código e cenas que passam na CI;
+5. documentos atuais em `docs/`;
+6. PDFs e documentos históricos, somente quando não contradizem o cânone vigente.
 
 ## 2. Identidade inviolável
 
@@ -157,7 +160,7 @@ Regras de mix:
 
 ## 10. Pipeline gráfico e audiovisual
 
-1. Ler canon, manifesto e ficha do asset.
+1. Ler cânone, manifesto e ficha do asset.
 2. Reunir referências permitidas e registrar origem.
 3. Gerar thumbnails/conceitos; não integrar conceito cru.
 4. Selecionar uma direção e consolidar model sheet/paleta.
@@ -166,7 +169,7 @@ Regras de mix:
 7. Exportar fonte, atlas, preview e metadados.
 8. Importar no Godot com preset determinístico.
 9. Testar em arena real, escala real e câmera real.
-10. Executar QA visual, técnico, licença, performance e canon.
+10. Executar QA visual, técnico, licença, performance e cânone.
 
 Arquivos finais devem ser reprodutíveis. Prompts, seeds, ferramentas, versões, licenças, edição humana e hashes ficam nos metadados quando IA for usada.
 
@@ -210,7 +213,7 @@ Gates por plataforma:
 
 ### P0 — verdade e contratos
 
-Manter dados válidos, backlog honesto, canon auditado e CI verde.
+Manter dados válidos, backlog honesto, cânone auditado e CI verde.
 
 ### P1 — vertical slice de ouro
 
@@ -236,20 +239,22 @@ Cada lote deve conter gameplay, visual, áudio, dados, testes e documentação n
 
 ## 14. Protocolo autônomo GPT-SOL/Codex
 
+O ciclo detalhado e o Handshake obrigatório vivem em `docs/GAME_BUILD_PROTOCOL.md`.
+
 Para cada ciclo:
 
 1. sincronizar e inspecionar o repositório oficial;
-2. executar `npm run quality` antes de modificar;
-3. selecionar o menor lote vertical prioritário desbloqueado;
-4. procurar implementação equivalente e preservar IDs;
-5. implementar dados, runtime e assets sem introduzir outra engine;
-6. executar fila e validações específicas;
-7. testar o fluxo afetado no Godot;
+2. executar o Handshake e registrar o delta;
+3. executar `npm run quality` antes de modificar, quando o ambiente permitir;
+4. selecionar o menor lote vertical prioritário desbloqueado;
+5. procurar implementação equivalente e preservar IDs;
+6. implementar dados, runtime e assets sem introduzir outra engine;
+7. executar validações específicas e testar o fluxo afetado no Godot;
 8. registrar evidência, limitações e licenças;
-9. executar `npm run quality` novamente;
+9. executar os gates novamente;
 10. criar commit focado e atualizar o GitHub quando autorizado.
 
-O agente deve parar e pedir decisão quando houver conflito de canon, licença incerta, ação destrutiva, biomecânica insegura, mudança de público/classificação, gasto externo ou credencial ausente. Autonomia não autoriza inventar evidência nem publicar fora do escopo.
+O agente deve parar e pedir decisão quando houver conflito de cânone, licença incerta, ação destrutiva, biomecânica insegura, mudança de público/classificação, gasto externo ou credencial ausente. Autonomia não autoriza inventar evidência nem publicar fora do escopo.
 
 ## 15. Quality gates e Definition of Done
 
@@ -258,7 +263,7 @@ O comando central é `npm run quality`. Além dele, release exige:
 - import e parser Godot headless;
 - smoke Main Menu → Terreiro → Combate → Resultado → Save;
 - roundtrip de save e avanço de semana;
-- revisão de canon e conteúdo regional;
+- revisão de cânone e conteúdo regional;
 - auditoria de licenças de todo asset;
 - auditoria de loudness e loops;
 - ausência de placeholder no caminho de shipping;

--- a/docs/DOC_PRECEDENCE.md
+++ b/docs/DOC_PRECEDENCE.md
@@ -1,0 +1,60 @@
+# DOC_PRECEDENCE — Ordem de autoridade documental
+
+**Status:** canônico  
+**Atualizado em:** 2026-07-24
+
+Este arquivo resolve conflitos entre documentos, dados, código e memória de agentes.
+
+## Ordem de autoridade
+
+1. **Contrato supremo do produto e gates de release**
+   - `docs/CRIA_DO_TATAME_SUPREME_BUILD_SPEC_V1.md`
+   - `data/production/supreme_build_contract_v01.json`
+2. **Processo e gestão**
+   - `docs/GAME_BUILD_PROTOCOL.md`
+3. **Cânone narrativo e gameplay atual**
+   - GDD-CDT v4.x
+   - GDD-SYSTEMS v4.x
+   - decisões canônicas explicitamente aprovadas em `docs/canon/`
+4. **Contratos técnicos e visuais vigentes**
+   - ADRs atuais
+   - schemas em `data/`
+   - CPS/Reconciliation/brand book vigentes
+5. **Runtime e dados que passam nos gates**
+   - código Godot, cenas e dados integrados
+   - testes, migrações e manifests correspondentes
+6. **Documentos de entrada**
+   - `AGENTS.md`
+   - README
+   - guias resumidos de contribuição
+7. **Histórico**
+   - versões antigas, mocks, prompts, PDFs e branches aposentadas
+
+## Regra de conflito
+
+Quando duas fontes da mesma camada divergem:
+
+1. preferir a versão explicitamente marcada como mais recente e canônica;
+2. verificar o runtime e os contratos consumidores;
+3. registrar o conflito em issue ou PR;
+4. não implementar até existir decisão ou adapter/migração documentada.
+
+Memória de modelo, conversa anterior ou interpretação pessoal nunca supera arquivo canônico versionado.
+
+## Separação de responsabilidades
+
+- O SUPREME define **o produto final e as evidências de conclusão**.
+- O GAME_BUILD_PROTOCOL define **como planejar, implementar, integrar, verificar e gerir**.
+- Os GDDs definem **narrativa, regras, conteúdo e experiência**.
+- Dados e schemas definem **contratos executáveis**.
+- Código e cenas implementam esses contratos, mas não podem silenciosamente reescrever o cânone.
+
+## Alterações nesta precedência
+
+Qualquer mudança exige:
+
+- commit `docs(protocol):` ou `docs(canon):`;
+- justificativa no PR;
+- atualização das referências cruzadas;
+- validação da skill do diretor;
+- aprovação do dono do projeto.

--- a/docs/GAME_BUILD_PROTOCOL.md
+++ b/docs/GAME_BUILD_PROTOCOL.md
@@ -1,0 +1,301 @@
+# GAME_BUILD_PROTOCOL — Protocolo Mestre de Construção do *Cria do Tatame*
+
+**Versão:** 1.0  
+**Data:** 2026-07-24  
+**Status:** CANÔNICO / VINCULANTE  
+**Escopo:** governa **como** o jogo é construído: processo, engenharia, repositório, criatividade, QA, release e gestão.
+
+> Modelos e agentes não possuem memória confiável entre sessões. Este protocolo vive no Git como `protocol-as-code`. Todo assistente que trabalhar neste repositório deve carregá-lo antes de propor ou executar mudanças.
+
+---
+
+## 0. Precedência e governança
+
+A ordem completa está em `docs/DOC_PRECEDENCE.md`. Resumo:
+
+1. `docs/CRIA_DO_TATAME_SUPREME_BUILD_SPEC_V1.md` e seu contrato executável;
+2. este `GAME_BUILD_PROTOCOL.md` para processo e gestão;
+3. GDD-CDT v4.x, GDD-SYSTEMS v4.x e decisões canônicas atuais;
+4. contratos de produção visual e reconciliação técnica vigentes;
+5. bíblias numeradas, dados canônicos e ADRs atuais;
+6. `AGENTS.md`, README e resumos de entrada;
+7. documentos históricos, somente como referência.
+
+Em conflito, o trabalho para, o conflito é registrado e a decisão canônica mais recente e explicitamente aprovada prevalece.
+
+---
+
+## 1. Papéis
+
+| Papel | Responsabilidade |
+|---|---|
+| **Produtor / Dono** | Decide cânone, aprova gates e autoriza ações irreversíveis. |
+| **Diretor-Gestor** | Verifica o repositório, diagnostica o gargalo, decide a próxima jogada, instrui o executor e fecha gates com evidência. |
+| **Executor-Committer** | Implementa código, dados, cenas, assets, testes e documentação; commita conforme este protocolo. |
+
+Um mesmo agente pode ocupar mais de um papel, mas não pode relaxar as regras correspondentes.
+
+---
+
+## 2. Handshake de abertura
+
+Toda iteração de trabalho começa com um handshake curto contendo:
+
+- estado da `main`: SHA curto e mensagem do último commit;
+- PRs abertos e topologia de empilhamento;
+- status de CI do commit relevante: verde, vermelho, em fila ou desconhecido;
+- delta desde o handshake anterior;
+- fonte e horário da verificação.
+
+### Modo degradado
+
+Quando a verificação ao vivo falhar, truncar ou não puder ser feita, declarar explicitamente:
+
+> Verificação parcial; usando snapshot de `<ISO-8601>`; sem nova chamada porque `<motivo>`.
+
+Nunca afirmar que algo está verde, mergeado, pronto ou publicado sem evidência. Para fechar a leitura localmente:
+
+```bash
+git fetch --all --prune
+git log --oneline -5 origin/main
+gh pr list --state open --json number,title,isDraft,headRefName,baseRefName,statusCheckRollup
+```
+
+Antes de instruir alteração em arquivo ou sistema específico, abrir esse arquivo, a árvore relevante e os contratos consumidores.
+
+---
+
+## 3. Domínios ativos simultaneamente
+
+### 3.1 Engenharia de jogos
+
+- Godot 4.3+ como alvo; manter compatibilidade 4.2.2 enquanto o gate legado existir.
+- Combate de BJJ por oito posições simétricas + lado relativo, vinte cartas, seis rulesets e cinco comandos contextuais.
+- Posição, recursos, timing, defesa, tap e escape são soberanos; cartas especializam ações, não substituem o grappling.
+- World Director e Faction Director v3 separados por responsabilidade.
+- Save atômico, versionado, com migração e roundtrip.
+- Gameplay crítico determinístico e offline.
+- Android: 60 FPS alvo, 30 FPS mínimo funcional, gate de produção ≥45 FPS sustentados em aparelho físico; orçamento de 16,67 ms por frame; memória de combate ≤512 MB; atlas ≤4096 px; até 24 vozes simultâneas.
+- Safe area, alvos touch ≥48 dp, contraste, remapeamento e opção de reduzir flash.
+
+### 3.2 Engenharia de repositório
+
+- Repositório único: `ringuemkt-rgb/cria-do-tatame`.
+- Stacked PRs, Conventional Commits e CI como porteiro.
+- Git LFS para binários grandes quando aplicável.
+- Dependências pinadas; APK fora da raiz, distribuído como artifact/release com SHA-256.
+- Nenhum asset sem licença ou origem registrada.
+- Branches mortas ou noop devem ser removidas após verificação e merge.
+- Node e Python servem somente para validação, automação e pipeline; Godot é o único runtime do jogo.
+
+### 3.3 Criativo
+
+- Pixel art 16-bit/2.5D, adulta e regional, sem fotografia ou 3D realista como arte final.
+- Três facções: LEM, NTM e ALE; núcleos são tags subordinadas.
+- Ruan por eras, sem duplicar faixa ou estado de carreira em movesheets.
+- Cinco atos, cinco finais e TUPA-200 como crítica artística fictícia.
+- HUD funcional preserva leitura de posição, recursos, moral e comandos.
+- Som organizado por ato, arena, posição e intensidade.
+
+### 3.4 Regra anti-alucinação
+
+Quando API, schema, arquivo, licença, biomecânica ou estado do repositório forem incertos, verificar fonte primária ou abrir o arquivo antes de instruir commit. Se a verificação não for possível, declarar a lacuna e não inventar sucesso.
+
+---
+
+## 4. Loop de gestão
+
+```text
+1. VERIFICAR    Handshake ao vivo e delta.
+2. DIAGNOSTICAR Identificar um gargalo com evidência.
+3. DECIDIR      Escolher uma jogada de maior alavancagem.
+4. INSTRUIR     Definir arquivos, patch, testes, commit e rollback.
+5. COMMITAR     Executor aplica e registra um lote focado.
+6. REVERIFICAR  Confirmar que entrou e não causou regressão.
+7. FECHAR GATE  Atualizar manifestos e status somente com evidência.
+```
+
+A regra do funil é uma próxima jogada principal por iteração, não uma lista difusa de tarefas.
+
+---
+
+## 5. Regras de engenharia de repositório
+
+1. Uma feature corresponde a um PR vertical com código, dados, cena, teste e documentação do mesmo tema.
+2. Um personagem completo corresponde a um PR vertical próprio; prancha, frames, atlas, integração e QA ficam no mesmo fluxo.
+3. Evitar commit-bomba e mistura de produtos externos.
+4. Usar commits como `feat(combat):`, `fix(save):`, `art(ruan):`, `test(gut):`, `docs(protocol):` e `chore(struct):`.
+5. Nada mergeia com CI vermelha, lint canônico vermelho ou conflito documental aberto.
+6. Respeitar a topologia dos PRs; filho não mergeia sem a base validada.
+7. Não sobrescrever contratos verdes sem reconciliação explícita e teste de migração.
+8. Assets grandes usam LFS quando apropriado; APK, ZIP e builds não são versionados na raiz.
+9. Toda exclusão exige inventário, backup e relatório de migração.
+10. Depois do merge e verificação, remover branches mortas e atualizar a topologia.
+
+---
+
+## 6. Regras de engenharia do jogo
+
+- Fluxo mínimo preservado: `MainMenu → Terreiro → Combate → Resultado → Save → avanço de semana → Terreiro`.
+- Sem gacha, loot box ou poder comprado com Molho.
+- Sem finalização automática: submissão exige preparação, encaixe, resposta, tap ou escape.
+- CPS/prancha densa não é sprite final.
+- Sprite final é produzido em resolução nativa, limpo manualmente, normalizado, com pivô, atlas, manifest, preview, cena de teste e QA.
+- Animação pareada exige `sync_map` e revisão biomecânica.
+- Todo sistema persistível declara versão e migração.
+- Toda mudança de autoload exige auditoria de boot.
+- Toda mudança de combate exige smoke de posição, lado, recursos, janela defensiva, submissão e encerramento.
+
+---
+
+## 7. Distinções e cânone inviolável
+
+### 7.1 Três distinções
+
+1. **Prancha densa ≠ sprite de jogo.**
+2. **Design aprovado ≠ runtime executável.**
+3. **Um personagem completo = um PR vertical**, não um commit-bomba.
+
+### 7.2 Cânone
+
+- Facções: LEM, NTM e ALE; o lint bloqueia uma quarta facção.
+- Ruan: `campaign_start` aos 19 e `promo_mature` aos 28; faixa vem do equipment/career stage.
+- Tinker Bell permanece `design_aprovado` como lutador e `story_npc` na campanha até migração completa.
+- Mestre Pedrinho permanece `planned` até possuir ID, passport, perfil e agenda.
+- Oni: lore “Oni da Lapa”; display “ONI DO SUL”.
+- Moral é estado bipolar, não recurso consumível.
+- Slots por arquétipo: PRESSÃO=6; TÁTICO=5; terceiro arquétipo permanece em aberto até decisão canônica.
+- Tom 14+ sem gore; oponente em técnica sempre adulto; nenhuma difamação de pessoa ou povo real.
+- Identidade: “Ser forte é ser gentil”, “De cria pra cria” e “Jiu-jitsu é tudo”.
+- IDs legados proibidos não entram em UI, campanha, save novo ou marketing final.
+
+### 7.3 Três camadas de cor
+
+- **Marca:** `#F2C230 #F2F2F2 #0A0A0A #D92323 #1E5BFF`.
+- **Arte pixel:** `#0A0A0A #1A1A1A #B8860B #F2C230 #F2F2F2 #D92323 #1E3A5F #2D5016 #4B0082`.
+- **HUD funcional:** VIDA verde; GÁS azul; FOCO dourado; GRIP magenta; CONTROLE ciano; buff verde; debuff vermelho; moral baixa `#4B0082`.
+
+O lint aplica a allow-list correspondente ao tipo de superfície; não deve reprovar HUD com regra de sprite nem marca com regra de HUD.
+
+### 7.4 Texto e tipografia
+
+- Sprites e frames: sem texto embutido.
+- Logo: lettering permitido e travado por brand book.
+- UI: texto sempre em `Label`, nunca rasterizado em imagem.
+- Títulos: Bebas Neue Bold; textos: Barlow Condensed, respeitando licenças e fallback documentado.
+
+---
+
+## 8. Gates e definição de pronto
+
+| Camada | Evidência mínima |
+|---|---|
+| **Runtime** | fluxo principal, combate v4.1, IA Davi, save roundtrip e smokes/GUT verdes |
+| **Conteúdo** | atlas, manifest, preview, cena, licença, `sync_map` quando necessário e QA humano |
+| **Release** | APK ARM64 instalado e jogado em aparelho físico, ≥45 FPS sustentados, SHA-256, acessibilidade, áudio e licenças aprovados |
+
+Rótulos proibidos sem evidência: “jogo completo”, “arte final”, “áudio final”, “APK pronto” e “release ready”. Até o gate correspondente, usar “núcleo”, “vertical slice”, “alpha”, “beta”, “RC”, `design_aprovado` ou `planned`.
+
+---
+
+## 9. Template de resposta
+
+```text
+🛰️ HANDSHAKE  estado verificado ou modo degradado + delta
+🔍 DIAGNÓSTICO gargalo atual e evidência
+🎯 DECISÃO     próxima jogada de maior alavancagem
+📦 ENTREGA     artefato, patch, código, dados ou instrução executável
+✅ GATE        critério fechado, evidência e verificação seguinte
+```
+
+---
+
+## 10. Invioláveis
+
+Três facções; três distinções; três camadas de cor; Godot como único runtime; sem gacha; sem poder por Molho; sem finalização automática; 14+ sem gore; oponente adulto; CI como porteiro; rótulos de pronto somente com evidência.
+
+---
+
+## 11. Topologia de PRs
+
+A topologia é estado operacional, não cânone permanente. Deve ser confirmada em cada handshake.
+
+Snapshot verificado em 2026-07-24:
+
+```text
+main (f098ab5 — Deck de Combate e disputas de nível)
+ └─ #32 release/v4-integration → main
+      ├─ #25 release/unify-and-feel → #32
+      │    └─ #26 feat/open-pixel-forge-v1 → #25
+      └─ #24 agent/visual-audio-world-v10 → #32
+```
+
+No snapshot, #32 e #26 estavam mergeáveis; #25 e #24 estavam não mergeáveis. A ordem de integração deve respeitar bases e gates; o snapshot não autoriza merge automático.
+
+---
+
+## 12. Auto-verificação
+
+O protocolo só é considerado ativado quando:
+
+- `docs/GAME_BUILD_PROTOCOL.md` existe;
+- `AGENTS.md` o referencia na seção 0;
+- `docs/DOC_PRECEDENCE.md` declara a precedência;
+- o SUPREME referencia este protocolo como camada de processo;
+- a skill `cria-do-tatame-game-director` o carrega;
+- o validador da skill verifica esses vínculos;
+- um handshake posterior confirma o estado ao vivo.
+
+Comandos:
+
+```bash
+python .agents/skills/cria-do-tatame-game-director/scripts/validate_skill.py
+npm run validate:skill
+npm run quality
+```
+
+---
+
+## Apêndice A — Glossário
+
+- **Handshake:** leitura do estado vivo do projeto no início da iteração.
+- **Delta:** diferença entre dois handshakes.
+- **Gargalo:** fator único que mais bloqueia o avanço.
+- **Jogada:** ação de maior alavancagem escolhida para a iteração.
+- **Gate:** condição binária sustentada por evidência.
+- **Stacked PR:** PR cuja base é outra branch de feature.
+- **Commit-bomba:** commit que mistura grande volume e temas desconexos.
+- **PR vertical:** entrega completa de um tema, do contrato ao QA.
+- **Design aprovado:** conteúdo aceito, ainda não executável.
+- **Runtime executável:** conteúdo integrado, testado e consumido pelo jogo.
+- **Modo degradado:** operação transparente sem leitura ao vivo completa.
+
+## Apêndice B — Comandos de verificação
+
+```bash
+# Handshake leve
+git fetch --all --prune
+git log --oneline -5 origin/main
+gh pr list --state open --json number,title,isDraft,headRefName,baseRefName,statusCheckRollup
+
+# Inspeção profunda da integração
+gh pr view 32 --json title,body,headRefName,baseRefName,mergeable,statusCheckRollup,files
+
+# Diff e topologia
+git log --graph --oneline --decorate --all -30
+git diff --stat origin/main...HEAD
+
+# Gates do repositório
+python .agents/skills/cria-do-tatame-game-director/scripts/validate_skill.py
+npm run quality
+
+# Godot headless, quando instalado
+godot --headless --path . --editor --quit
+godot --headless --path . --script tests/runtime_smoke.gd
+
+# Integridade de binários e release
+git lfs ls-files
+sha256sum builds/android/*.apk
+```
+
+Comandos podem variar por sistema operacional; qualquer alteração deve ser documentada no PR correspondente.

--- a/tests/test_game_director_skill.py
+++ b/tests/test_game_director_skill.py
@@ -9,6 +9,9 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 SKILL = ROOT / ".agents/skills/cria-do-tatame-game-director/SKILL.md"
 VALIDATOR = ROOT / ".agents/skills/cria-do-tatame-game-director/scripts/validate_skill.py"
+PROTOCOL = ROOT / "docs/GAME_BUILD_PROTOCOL.md"
+PRECEDENCE = ROOT / "docs/DOC_PRECEDENCE.md"
+SUPREME = ROOT / "docs/CRIA_DO_TATAME_SUPREME_BUILD_SPEC_V1.md"
 
 
 def test_skill_uses_agent_skills_frontmatter() -> None:
@@ -17,12 +20,32 @@ def test_skill_uses_agent_skills_frontmatter() -> None:
     assert header, "SKILL.md deve possuir frontmatter YAML"
     assert "name: cria-do-tatame-game-director" in header.group(1)
     assert re.search(r"^description:\s*\S", header.group(1), flags=re.MULTILINE)
+    assert 'version: "1.1.0"' in header.group(1)
 
 
-def test_agents_file_activates_the_skill() -> None:
+def test_agents_file_activates_skill_and_protocol() -> None:
     agents = (ROOT / "AGENTS.md").read_text(encoding="utf-8")
+    assert "## 0. PROTOCOLO MESTRE DE CONSTRUÇÃO" in agents
+    assert "docs/GAME_BUILD_PROTOCOL.md" in agents
+    assert "docs/DOC_PRECEDENCE.md" in agents
     assert ".agents/skills/cria-do-tatame-game-director/SKILL.md" in agents
     assert "validate_skill.py" in agents
+
+
+def test_protocol_cross_references_are_bidirectional() -> None:
+    protocol = PROTOCOL.read_text(encoding="utf-8")
+    precedence = PRECEDENCE.read_text(encoding="utf-8")
+    supreme = SUPREME.read_text(encoding="utf-8")
+    skill = SKILL.read_text(encoding="utf-8")
+
+    assert "CANÔNICO / VINCULANTE" in protocol
+    assert "Handshake de abertura" in protocol
+    assert "Loop de gestão" in protocol
+    assert "GAME_BUILD_PROTOCOL.md" in precedence
+    assert "CRIA_DO_TATAME_SUPREME_BUILD_SPEC_V1.md" in precedence
+    assert "docs/GAME_BUILD_PROTOCOL.md" in supreme
+    assert "docs/DOC_PRECEDENCE.md" in supreme
+    assert "docs/GAME_BUILD_PROTOCOL.md" in skill
 
 
 def test_skill_validator_passes() -> None:
@@ -37,3 +60,4 @@ def test_skill_validator_passes() -> None:
     assert result.returncode == 0, report
     assert report["ok"] is True
     assert report["skill"] == "cria-do-tatame-game-director"
+    assert report["protocol"] == "docs/GAME_BUILD_PROTOCOL.md"


### PR DESCRIPTION
## Objetivo

Transformar o protocolo de construção do **Cria do Tatame – Pressão** em `protocol-as-code`, carregado por agentes e protegido pela CI.

## Base e topologia

- base: `release/v4-integration` / PR #32;
- head: `docs/game-build-protocol-v1`;
- este PR é documental e deve entrar no #32 antes do merge da integração em `main`.

## Entregas

- `docs/GAME_BUILD_PROTOCOL.md` — processo canônico, Handshake, loop de gestão, regras de repo/jogo, gates e topologia;
- `docs/DOC_PRECEDENCE.md` — ordem de autoridade documental;
- `AGENTS.md` — seção 0 vinculante;
- `docs/CRIA_DO_TATAME_SUPREME_BUILD_SPEC_V1.md` — referência reversa ao protocolo e precedência;
- skill `cria-do-tatame-game-director` v1.1 vinculada ao protocolo;
- `validate_skill.py` ampliado para falhar quando qualquer vínculo for removido;
- testes de ativação e referências cruzadas.

## Estado verificado ao abrir o PR

- `main`: `f098ab5` — Deck de Combate e disputas de nível;
- PR #32: aberto, draft e mergeável;
- PR #25: aberto, draft e não mergeável;
- PR #26: aberto, draft e mergeável, base #25;
- PR #24: aberto, draft e não mergeável;
- CI do novo PR ainda deve executar.

## Limite documental

A mensagem-fonte recebida foi truncada no final do Apêndice B. O arquivo canônico preserva todas as regras recebidas e fecha o apêndice apenas com comandos já declarados no próprio protocolo, sem inventar estado de repo ou gate concluído.

## Gates

```bash
python .agents/skills/cria-do-tatame-game-director/scripts/validate_skill.py
pytest -q tests/test_game_director_skill.py
npm run validate:skill
npm run quality
```

Não marcar como pronto até os checks aplicáveis ficarem verdes.