### PR TITLE
feat(v4): integrar árvore, deck, rulesets e bindings de animação

### DIFF
--- a/data/characters/ruan/animation_manifest.json
+++ b/data/characters/ruan/animation_manifest.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": "1.0.0",
+  "character_id": "ruan",
+  "bindings": {
+    "kimura": {
+      "card_id": "kimura",
+      "move_id": "submission_kimura",
+      "move_number": 23,
+      "technique_id": "kimura_lock",
+      "animation_state": "ruan_kimura_right",
+      "frame_range": "23_01-23_04"
+    }
+  }
+}

--- a/data/combat/animation_manifest.schema.json
+++ b/data/combat/animation_manifest.schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://criadotatame.local/schemas/animation_manifest.schema.json",
+  "title": "Cria do Tatame Character Animation Manifest",
+  "type": "object",
+  "required": ["schema_version", "character_id", "bindings"],
+  "properties": {
+    "schema_version": {"type": "string", "const": "1.0.0"},
+    "character_id": {"type": "string", "minLength": 1},
+    "bindings": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["card_id", "move_id", "move_number", "technique_id", "animation_state"],
+        "properties": {
+          "card_id": {"type": "string", "minLength": 1},
+          "move_id": {"type": "string", "minLength": 1},
+          "move_number": {"type": "integer", "minimum": 1, "maximum": 33},
+          "technique_id": {"type": "string", "minLength": 1},
+          "animation_state": {"type": "string", "minLength": 1},
+          "frame_range": {"type": "string"},
+          "attacker_frames": {"type": "string"},
+          "defender_frames": {"type": "string"},
+          "sync_map": {"type": "string"},
+          "hitbox": {"type": "string"}
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/data/combat/playability_reason_codes.json
+++ b/data/combat/playability_reason_codes.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": "1.0.0",
+  "reason_codes": {
+    "OK": "combat.playability.ok",
+    "DECISION_LOCKED": "combat.playability.decision_locked",
+    "FIGHTER_MISSING": "combat.playability.fighter_missing",
+    "CARD_MISSING": "combat.playability.card_missing",
+    "CARD_NOT_IN_LOADOUT": "combat.playability.card_not_in_loadout",
+    "CARD_FORBIDDEN_BY_PROFILE": "combat.playability.card_forbidden_by_profile",
+    "CARD_NOT_IN_HAND": "combat.playability.card_not_in_hand",
+    "POSITION_INVALID": "combat.playability.position_invalid",
+    "STORY_REQUIREMENT": "combat.playability.story_requirement",
+    "RULESET_FORBIDS_CARD": "combat.playability.ruleset_forbids_card",
+    "RESOURCE_INSUFFICIENT": "combat.playability.resource_insufficient"
+  }
+}

--- a/docs/COMBAT_INTEGRATION_CONTRACT.md
+++ b/docs/COMBAT_INTEGRATION_CONTRACT.md
@@ -1,0 +1,247 @@
+# CRIA DO TATAME – PRESSÃO — CONTRATO DE INTEGRAÇÃO DO COMBATE
+
+**Status:** contrato técnico canônico para a integração v4.3.  
+**Escopo:** árvore de habilidades, catálogo de cartas, loadout por personagem, combate posicional, rulesets de arena, finais e bindings de animação.  
+**Base:** `release/v4-integration`. Este documento não declara sistemas inexistentes como concluídos; ele define as interfaces obrigatórias e os testes que provam as pontes.
+
+---
+
+## 1. Regra de precedência das camadas
+
+| Camada | Autoridade | Não pode fazer |
+|---|---|---|
+| **Moveset / CPS-A** | Vocabulário físico e audiovisual do personagem: estados, movimentos e frame-ranges. | Decidir sozinho se uma ação é jogável ou se vence a luta. |
+| **Cartas** | Ações jogáveis do catálogo global: origem, destino, lado, custo, janela, moral e resposta defensiva. | Ignorar posição, lado, recursos, ruleset, tap ou escape. |
+| **Técnicas centrais / CPS-B** | Domínio, prioridade, eficiência e identidade do personagem sobre cartas específicas. | Criar uma segunda lista incompatível com o catálogo global. |
+| **Árvore de habilidades** | Desbloqueia acesso, amplia consistência, concede pontos de deck e publica consequências persistentes. | Comprar poder com Molho ou aplicar regras diretamente pela UI. |
+| **Arena / ruleset** | Autoriza, restringe ou ressignifica ações e caminhos de vitória. | Ser tratada como skin sem impacto mecânico. |
+| **Animation manifest** | Traduz IDs semânticos em estados, atlas, frames pareados e `sync_map`. | Conter regra de gameplay. |
+
+A cadeia autoritativa é:
+
+```text
+progressão → acesso → loadout → posição/lado → recursos/janela → ruleset
+           → transição do FSM → binding de animação → consequência narrativa
+```
+
+---
+
+## 2. Regra canônica de carta jogável
+
+Existe uma única autoridade pública para a decisão: `pode_jogar(...)`. HUD, IA, tutorial, acessibilidade e comandos devem consumir o mesmo resultado; nenhum deles reimplementa a regra.
+
+Uma carta só pode ser executada quando todas as condições forem verdadeiras:
+
+```text
+CATÁLOGO
+∧ ACESSO DO PERSONAGEM
+∧ POLÍTICA MORAL DO SAVE
+∧ LOADOUT/MÃO
+∧ POSIÇÃO E LADO
+∧ FLAGS NARRATIVAS
+∧ RULESET
+∧ RECURSOS
+∧ JANELA/FASE
+```
+
+A avaliação ocorre nesta ordem:
+
+1. a carta existe no catálogo mestre;
+2. o lutador existe no combate;
+3. a carta está no loadout do lutador;
+4. a política persistente daquele lutador permite a classe moral da carta;
+5. a carta está na mão contextual;
+6. posição de origem e lado relativo são compatíveis;
+7. flags narrativas exigidas estão satisfeitas;
+8. o ruleset permite a categoria moral;
+9. recursos são suficientes;
+10. a fase permite decisão e não há transição, defesa, submissão ou encerramento bloqueando a ação.
+
+O retorno nunca é apenas booleano:
+
+```text
+PlayabilityResult
+├── allowed / ok
+├── reason_code / reason
+├── localized_reason_key
+├── specialized_slot
+├── resource_preview
+└── predicted_transition
+```
+
+Os códigos oficiais estão em `data/combat/playability_reason_codes.json`.
+
+---
+
+## 3. Catálogo mestre, acesso e Código do Cria
+
+O catálogo mestre preserva todas as cartas para NPCs, debugging, replay, migração e conteúdo narrativo. O nó **Código do Cria** não apaga o registro global: ele publica uma política persistente no save do jogador.
+
+```text
+perfil do jogador:
+  forbidden_morals = ["suja"]
+
+SkillHubLoadoutV41:
+  bloqueia desbloqueio por dono;
+  bloqueia inclusão no loadout;
+  sanitiza save legado;
+  sanitiza recompensas futuras;
+  preserva o catálogo global para outros personagens.
+```
+
+Os guards obrigatórios são:
+
+- `unlock_for_owner()`;
+- `can_include()`;
+- `_sanitize_deck()`;
+- `import_state()`.
+
+---
+
+## 4. Passivos da árvore no combate
+
+A árvore não é consultada a cada frame. Antes da luta, progressão, equipamentos e flags mundiais produzem um **snapshot imutável de passivos** por lutador.
+
+```text
+Skill Tree + equipment + WorldState
+                 ↓
+CombatPassiveSnapshot normalizado
+                 ↓
+PositionalCardCombatV41 / Submission HUD / terreno / IA
+```
+
+Multiplicadores começam em `1.0`; bônus aditivos começam em `0.0`. Campos mínimos suportados:
+
+- `sweet_spot_mult`;
+- `dreno_foco_arena_mult`;
+- `fadiga_dano_mult`;
+- `gas_cost_mult`;
+- `focus_cost_mult`;
+- `submission_attack_mult`;
+- `submission_defense_mult`;
+- `grip_inicial`;
+- `grip_por_pegada`;
+- `vida_max_bonus`;
+- `gas_max_bonus`;
+- `foco_max_bonus`.
+
+Um passivo só é considerado implementado quando existe teste numérico que falha sem a ponte.
+
+---
+
+## 5. Autoridade dos rulesets sobre vitória
+
+Nenhum sistema emite `combat_finished` ou chama o encerramento sem consultar o ruleset ativo. O fluxo obrigatório é:
+
+```text
+evento técnico → VictoryCandidate → try_resolve_victory()
+              → ruleset.caminhos_vitoria → aceita ou rejeita
+```
+
+| Ruleset | Caminhos aceitos |
+|---|---|
+| `OFICIAL` | finalização, pontos, desistência |
+| `CLANDESTINA` | finalização, desistência |
+| `RITO` | ceder |
+| `FESTIVAL` | finalização, pontos |
+| `DOJO` | nenhum |
+| `MORAL` | resistir_discurso |
+
+Consequências obrigatórias:
+
+- finalizar tecnicamente no `MORAL` não encerra a luta;
+- finalizar tecnicamente no `RITO` não encerra a luta;
+- `DOJO` nunca produz vencedor convencional;
+- pontos só encerram rulesets que aceitam `pontos`;
+- objetivos especiais são resolvidos por `resolve_ruleset_objective()`.
+
+---
+
+## 6. Efeitos persistentes e finais
+
+A árvore publica consequências no `WorldState`; o resolvedor de finais não consulta a tela ou o nó da árvore diretamente.
+
+```text
+respeito_nao_humilhar desbloqueado
+        ↓
+WorldState.story_flags["moral_nao_humilhar"] = true
+        ↓
+EndingResolverV4 avalia o final Cria de Verdade
+```
+
+A mesma regra vale para qualquer `path_gate_final`: a progressão publica uma flag serializável e o final lê essa flag.
+
+---
+
+## 7. Fachada entre deck legado e v4.1
+
+Durante a migração coexistem o `DeckManager` legado e o `SkillHubLoadoutV41`. A regra é:
+
+1. o catálogo e a progressão v4.1 são a fonte de verdade nova;
+2. o legado é fachada de compatibilidade;
+3. proibições morais e desbloqueios passam pela política v4.1 antes de chegar ao legado;
+4. migração não pode ressuscitar carta removida;
+5. a UI não decide elegibilidade.
+
+A remoção definitiva do legado depende de smoke tests equivalentes e decisão explícita de migração.
+
+---
+
+## 8. Binding de animação
+
+`cards.json`, `moveset.json` e `techniques_<id>.json` representam conceitos diferentes e não precisam compartilhar nomes físicos. Um `animation_manifest.json` por personagem faz a tradução.
+
+```text
+card_id → move_id/move_number → technique_id → animation_state
+        → attacker_frames / defender_frames / sync_map / hitbox
+```
+
+O combate solicita um ID semântico. `AnimationBindingResolver` devolve o binding concreto. Alterar atlas ou regenerar frames não pode exigir alteração da lógica da carta.
+
+---
+
+## 9. Mapa produtor → consumidor
+
+| Dado | Produtor | Consumidor obrigatório |
+|---|---|---|
+| `desbloqueia_carta` | progressão | `SkillHubLoadoutV41.unlock_for_owner` |
+| `deck_points` | progressão | capacidade do loadout |
+| `passivo_stat` | progressão/equipamento | `CombatPassiveSnapshot` e runtime |
+| `remove_cartas_sujas` | progressão | política persistente por dono |
+| `path_gate_final` | progressão | `WorldState` → `EndingResolverV4` |
+| `origem/lado/custo` | carta | `pode_jogar` e Position FSM |
+| `caminhos_vitoria` | ruleset | `try_resolve_victory` |
+| `frames_anim` | carta | `AnimationBindingResolver` |
+| `move_number/frame_range` | CPS-A | animation manifest |
+| `technique_id` | CPS-B | animation manifest e IA de arquétipo |
+
+---
+
+## 10. Testes de ponte obrigatórios
+
+- `Olho de Peixe` ou snapshot equivalente altera `sweet_spot_mult` em exatamente 15%;
+- `Código do Cria` impede carta suja em loadout novo;
+- importação de save legado remove carta suja do dono protegido;
+- recompensa futura não desbloqueia carta suja para o dono protegido;
+- Kimura no `OFICIAL` pode finalizar;
+- Kimura no `MORAL` não emite vitória;
+- finalização no `RITO` não emite vitória convencional;
+- `Cria de Verdade` é bloqueado sem `moral_nao_humilhar`;
+- uma carta de teste resolve binding completo no manifest;
+- carta com posição inválida retorna `POSITION_INVALID`;
+- recursos insuficientes retornam `RESOURCE_INSUFFICIENT`.
+
+---
+
+## 11. Definition of Done
+
+A integração só está pronta quando:
+
+- há uma única autoridade para `pode_jogar`;
+- loadout e migração respeitam políticas por dono;
+- passivos produzem mudanças mensuráveis;
+- MORAL, RITO e DOJO bloqueiam vitórias convencionais no runtime;
+- finais leem consequências persistentes;
+- bindings de animação são validados;
+- testes falham se qualquer ponte for removida;
+- nenhuma tela de UI contém regra de gameplay própria.

--- a/src/autoloads/CombatManagerV41.gd
+++ b/src/autoloads/CombatManagerV41.gd
@@ -60,6 +60,7 @@ func start_positional_combat_v41(new_arena_id: String, new_player_id: String = D
 	positional_mode_active = true
 	state_machine.call("reiniciar_em_pe")
 
+	_sync_owner_policy_v41(player_id)
 	var resolved_player_deck := _resolve_v41_deck(player_id, player_deck)
 	var resolved_opponent_deck := _resolve_v41_deck(opponent_id, opponent_deck)
 	var configure_report: Dictionary = positional_runtime.call(
@@ -68,7 +69,8 @@ func start_positional_combat_v41(new_arena_id: String, new_player_id: String = D
 		DataRegistry.combat_positions_v41,
 		DataRegistry.combat_rulesets_v41,
 		{player_id: resolved_player_deck, opponent_id: resolved_opponent_deck},
-		_build_v41_flags()
+		_build_v41_flags(),
+		_build_v41_passives()
 	)
 	if not bool(configure_report.get("ok", false)):
 		positional_mode_active = false
@@ -152,6 +154,11 @@ func resolve_submission_v41(attacker_progress: float, defender_progress: float, 
 		return {"ok": false, "error": "positional_mode_inactive"}
 	return positional_runtime.call("resolve_submission", attacker_progress, defender_progress, attacker_releases)
 
+func resolve_ruleset_objective_v41(method: String, winner_id: String, loser_id: String = "") -> Dictionary:
+	if not positional_mode_active or positional_runtime == null:
+		return {"ok": false, "error": "positional_mode_inactive"}
+	return positional_runtime.call("resolve_ruleset_objective", method, winner_id, loser_id)
+
 func get_skill_hub_v41() -> Node:
 	_ensure_v41_components()
 	return skill_hub_v41
@@ -175,7 +182,7 @@ func import_v41_state(data: Dictionary) -> void:
 func _resolve_v41_deck(owner_id: String, requested: Array) -> Array:
 	_ensure_v41_components()
 	if not requested.is_empty():
-		_unlock_requested_cards(requested)
+		_unlock_requested_cards(owner_id, requested)
 		skill_hub_v41.call("set_deck_points", owner_id, 100)
 		var set_result: Dictionary = skill_hub_v41.call("set_loadout", owner_id, requested)
 		if bool(set_result.get("ok", false)):
@@ -184,19 +191,19 @@ func _resolve_v41_deck(owner_id: String, requested: Array) -> Array:
 	if stored.size() == 12:
 		return stored
 	var starter := _default_v41_deck()
-	_unlock_requested_cards(starter)
+	_unlock_requested_cards(owner_id, starter)
 	skill_hub_v41.call("set_deck_points", owner_id, 100)
 	skill_hub_v41.call("set_loadout", owner_id, starter)
 	return skill_hub_v41.call("get_loadout", owner_id)
 
-func _unlock_requested_cards(cards: Array) -> void:
+func _unlock_requested_cards(owner_id: String, cards: Array) -> void:
 	for card_id_value in cards:
 		var card_id := str(card_id_value)
 		var card: Dictionary = DataRegistry.get_combat_card_v41(card_id)
 		if card.is_empty():
 			continue
 		if str(card.get("raridade", "base")) != "base":
-			skill_hub_v41.call("unlock", card_id, "training")
+			skill_hub_v41.call("unlock_for_owner", owner_id, card_id, "training")
 
 func _default_v41_deck() -> Array:
 	return [
@@ -204,6 +211,12 @@ func _default_v41_deck() -> Array:
 		"knee_cut_pass", "cem_quilos", "montada", "kimura",
 		"triangulo", "mata_leao", "grip_de_ferro", "baiana",
 	]
+
+func _sync_owner_policy_v41(owner_id: String) -> void:
+	var forbidden: Array[String] = []
+	if bool(WorldState.flags.get("dirty_cards_forbidden", false)):
+		forbidden.append("suja")
+	skill_hub_v41.call("set_owner_policy", owner_id, {"forbidden_morals": forbidden})
 
 func _build_v41_flags() -> Dictionary:
 	return {
@@ -213,6 +226,17 @@ func _build_v41_flags() -> Dictionary:
 		"bencao_mare": bool(WorldState.flags.get("bencao_mare", false)),
 		"leoa_vinculo": int(WorldState.flags.get("leoa_vinculo", 0)),
 		"dende_confianca": int(WorldState.flags.get("dende_confianca", 0)),
+		"owner_policies": {
+			player_id: skill_hub_v41.call("get_owner_policy", player_id),
+			opponent_id: skill_hub_v41.call("get_owner_policy", opponent_id),
+		},
+	}
+
+func _build_v41_passives() -> Dictionary:
+	var stored: Dictionary = WorldState.flags.get("combat_passives", {})
+	return {
+		player_id: stored.get(player_id, {}).duplicate(true),
+		opponent_id: stored.get(opponent_id, {}).duplicate(true),
 	}
 
 func _on_v41_snapshot(snapshot: Dictionary) -> void:

--- a/src/autoloads/EndingResolverV4.gd
+++ b/src/autoloads/EndingResolverV4.gd
@@ -20,6 +20,7 @@ func evaluate() -> Dictionary:
 	var evidence := maxi(int(flags.get("provas_joaquim", 0)), int(InformantSystem.evidence_count))
 	var leoa := int(flags.get("leoa_vinculo", 0))
 	var underground := str(flags.get("underground_acesso", "nenhum"))
+	var moral_nao_humilhar := bool(flags.get("moral_nao_humilhar", false))
 	var molho := Economy.get_balance(Economy.MOLHO)
 	var candidates: Array[String] = []
 
@@ -27,7 +28,7 @@ func evaluate() -> Dictionary:
 		candidates.append("martir_do_tatame")
 	if honra >= 8.0 and raiz >= 8.0 and leoa >= 3 and tupa_comunitaria and mangue_vivo:
 		candidates.append("ponte")
-	if honra >= 8.0 and raiz >= 8.0 and mangue_vivo and tupa_comunitaria and informant_status != "queimado":
+	if honra >= 8.0 and raiz >= 8.0 and mangue_vivo and tupa_comunitaria and informant_status != "queimado" and moral_nao_humilhar:
 		candidates.append("cria_de_verdade")
 	if sombra >= 40.0 and underground == "cedo" and informant_status == "queimado":
 		candidates.append("sombra")
@@ -36,7 +37,7 @@ func evaluate() -> Dictionary:
 
 	var ending_id := _highest_priority(candidates)
 	if ending_id == "":
-		ending_id = _fallback_ending(honra, raiz, sombra, molho)
+		ending_id = _fallback_ending(honra, raiz, sombra, molho, moral_nao_humilhar)
 	var ending: Dictionary = definitions.get("endings", {}).get(ending_id, {}).duplicate(true)
 	last_resolution = {
 		"id": ending_id,
@@ -53,6 +54,7 @@ func evaluate() -> Dictionary:
 			"informant_status": informant_status,
 			"evidence": evidence,
 			"leoa_vinculo": leoa,
+			"moral_nao_humilhar": moral_nao_humilhar,
 			"molho": molho,
 		},
 	}
@@ -89,16 +91,23 @@ func _highest_priority(candidates: Array[String]) -> String:
 			return ending_id
 	return ""
 
-func _fallback_ending(honra: float, raiz: float, sombra: float, molho: int) -> String:
-	if sombra > maxf(honra, raiz): return "sombra"
-	if molho > 0 and honra < 0.0: return "campeao_oco"
-	if raiz >= honra: return "ponte"
+func _fallback_ending(honra: float, raiz: float, sombra: float, molho: int, moral_nao_humilhar: bool) -> String:
+	if sombra > maxf(honra, raiz):
+		return "sombra"
+	if molho > 0 and honra < 0.0:
+		return "campeao_oco"
+	if not moral_nao_humilhar:
+		return "ponte"
+	if raiz >= honra:
+		return "ponte"
 	return "cria_de_verdade"
 
 func _load_json(path: String) -> Dictionary:
-	if not FileAccess.file_exists(path): return {}
+	if not FileAccess.file_exists(path):
+		return {}
 	var file := FileAccess.open(path, FileAccess.READ)
-	if file == null: return {}
+	if file == null:
+		return {}
 	var parsed = JSON.parse_string(file.get_as_text())
 	file.close()
 	return parsed if typeof(parsed) == TYPE_DICTIONARY else {}

--- a/src/autoloads/WorldStateV4.gd
+++ b/src/autoloads/WorldStateV4.gd
@@ -19,6 +19,9 @@ const NARRATIVE_DEFAULTS := {
 	"mangue_estado": "vivo",
 	"tupa200_resolucao": "pendente",
 	"provas_joaquim": 0,
+	"moral_nao_humilhar": false,
+	"dirty_cards_forbidden": false,
+	"combat_passives": {},
 	"beats": [],
 }
 

--- a/src/combat/AnimationBindingResolver.gd
+++ b/src/combat/AnimationBindingResolver.gd
@@ -1,0 +1,49 @@
+class_name AnimationBindingResolver
+extends RefCounted
+
+var character_id := ""
+var bindings: Dictionary = {}
+
+func configure(manifest: Dictionary) -> Dictionary:
+	character_id = str(manifest.get("character_id", ""))
+	bindings = manifest.get("bindings", {}).duplicate(true)
+	return {
+		"ok": character_id != "" and not bindings.is_empty(),
+		"character_id": character_id,
+		"bindings": bindings.size(),
+	}
+
+func resolve(card_id: String) -> Dictionary:
+	if not bindings.has(card_id):
+		return {"ok": false, "error": "binding_missing", "card_id": card_id}
+	var binding: Dictionary = bindings[card_id].duplicate(true)
+	binding["ok"] = true
+	binding["character_id"] = character_id
+	return binding
+
+func has_binding(card_id: String) -> bool:
+	return bindings.has(card_id)
+
+func validate_against_cards(cards_payload: Dictionary) -> Dictionary:
+	var cards_by_id: Dictionary = {}
+	for raw in cards_payload.get("cartas", []):
+		if typeof(raw) != TYPE_DICTIONARY:
+			continue
+		var card_id := str(raw.get("id", ""))
+		if card_id != "":
+			cards_by_id[card_id] = raw
+	var errors: Array[String] = []
+	for card_id_value in bindings.keys():
+		var card_id := str(card_id_value)
+		var binding: Dictionary = bindings[card_id]
+		if not cards_by_id.has(card_id):
+			errors.append("card_missing:%s" % card_id)
+			continue
+		if str(binding.get("card_id", "")) != card_id:
+			errors.append("card_id_mismatch:%s" % card_id)
+		if str(binding.get("animation_state", "")) == "":
+			errors.append("animation_state_missing:%s" % card_id)
+		var card_animation := str(cards_by_id[card_id].get("frames_anim", ""))
+		if card_animation != "" and card_animation != str(binding.get("animation_state", "")):
+			errors.append("animation_state_mismatch:%s" % card_id)
+	return {"ok": errors.is_empty(), "errors": errors}

--- a/src/combat/CombatCommandRouterV41.gd
+++ b/src/combat/CombatCommandRouterV41.gd
@@ -17,7 +17,7 @@ func execute(actor_id: String, command: String, selected_card_id: String = "", q
 		"transicao":
 			if selected_card_id != "":
 				return combat.play_card(actor_id, selected_card_id, quality)
-			return combat.generic_transition(actor_id)
+			return _generic_transition_preserving_loadout(actor_id)
 		"defesa":
 			if combat.phase == "defense_window":
 				return combat.defend(actor_id, "generic", quality)
@@ -33,9 +33,9 @@ func _grip(actor_id: String) -> Dictionary:
 	var resources: Dictionary = combat.fighters[actor_id]
 	if float(resources.get("gas", 0.0)) < 6.0:
 		return {"ok": false, "error": "insufficient_gas"}
-	resources["gas"] = maxf(0.0, float(resources.get("gas", 0.0)) - 6.0)
-	resources["grip"] = minf(3.0, float(resources.get("grip", 0.0)) + 1.0)
-	resources["foco"] = minf(100.0, float(resources.get("foco", 0.0)) + 3.0)
+	combat.call("_adjust", actor_id, "gas", -6.0)
+	combat.call("_adjust", actor_id, "grip", 1.0)
+	combat.call("_adjust", actor_id, "foco", 3.0)
 	combat.call("_emit_snapshot")
 	return {"ok": true, "command": "grip", "snapshot": combat.snapshot()}
 
@@ -45,10 +45,10 @@ func _pressure(actor_id: String) -> Dictionary:
 	var resources: Dictionary = combat.fighters[actor_id]
 	if float(resources.get("gas", 0.0)) < 10.0:
 		return {"ok": false, "error": "insufficient_gas"}
-	resources["gas"] = maxf(0.0, float(resources.get("gas", 0.0)) - 10.0)
-	resources["pressao"] = minf(100.0, float(resources.get("pressao", 0.0)) + 14.0)
+	combat.call("_adjust", actor_id, "gas", -10.0)
+	combat.call("_adjust", actor_id, "pressao", 14.0)
 	var defender := combat.opponent_id if actor_id == combat.player_id else combat.player_id
-	combat.fighters[defender]["guarda"] = maxf(0.0, float(combat.fighters[defender].get("guarda", 0.0)) - 8.0)
+	combat.call("_adjust", defender, "guarda", -8.0)
 	combat.call("_emit_snapshot")
 	return {"ok": true, "command": "pressao", "snapshot": combat.snapshot()}
 
@@ -58,9 +58,9 @@ func _recover_guard(actor_id: String) -> Dictionary:
 	var resources: Dictionary = combat.fighters[actor_id]
 	if float(resources.get("gas", 0.0)) < 5.0:
 		return {"ok": false, "error": "insufficient_gas"}
-	resources["gas"] = maxf(0.0, float(resources.get("gas", 0.0)) - 5.0)
-	resources["guarda"] = minf(100.0, float(resources.get("guarda", 0.0)) + 10.0)
-	resources["foco"] = minf(100.0, float(resources.get("foco", 0.0)) + 5.0)
+	combat.call("_adjust", actor_id, "gas", -5.0)
+	combat.call("_adjust", actor_id, "guarda", 10.0)
+	combat.call("_adjust", actor_id, "foco", 5.0)
 	combat.call("_emit_snapshot")
 	return {"ok": true, "command": "defesa", "snapshot": combat.snapshot()}
 
@@ -73,9 +73,17 @@ func _end_exchange(actor_id: String) -> Dictionary:
 	combat.player_side = "any"
 	combat.phase = "decision"
 	combat.pending_action.clear()
-	var resources: Dictionary = combat.fighters[actor_id]
-	resources["gas"] = minf(100.0, float(resources.get("gas", 0.0)) + 12.0)
-	resources["pressao"] = maxf(0.0, float(resources.get("pressao", 0.0)) - 10.0)
+	combat.call("_adjust", actor_id, "gas", 12.0)
+	combat.call("_adjust", actor_id, "pressao", -10.0)
 	combat.call("_draw_all_hands")
 	combat.call("_emit_snapshot")
 	return {"ok": true, "command": "encerrar", "snapshot": combat.snapshot()}
+
+func _generic_transition_preserving_loadout(actor_id: String) -> Dictionary:
+	var original_deck: Array = combat.decks.get(actor_id, []).duplicate()
+	var result := combat.generic_transition(actor_id)
+	combat.decks[actor_id] = original_deck
+	if combat.phase == "decision":
+		combat.call("_draw_all_hands")
+		combat.call("_emit_snapshot")
+	return result

--- a/src/combat/CombatPassiveSnapshot.gd
+++ b/src/combat/CombatPassiveSnapshot.gd
@@ -1,0 +1,42 @@
+class_name CombatPassiveSnapshot
+extends RefCounted
+
+## Normaliza os modificadores consumidos pelo combate v4.1.
+## Multiplicadores usam 1.0 como identidade; bônus aditivos usam 0.0.
+
+const MULTIPLIER_KEYS: Array[String] = [
+	"sweet_spot_mult",
+	"dreno_foco_arena_mult",
+	"fadiga_dano_mult",
+	"gas_cost_mult",
+	"focus_cost_mult",
+	"submission_attack_mult",
+	"submission_defense_mult",
+]
+
+const ADDITIVE_KEYS: Array[String] = [
+	"grip_inicial",
+	"grip_por_pegada",
+	"vida_max_bonus",
+	"gas_max_bonus",
+	"foco_max_bonus",
+]
+
+static func normalize(payload: Dictionary) -> Dictionary:
+	var output: Dictionary = {}
+	for key in MULTIPLIER_KEYS:
+		output[key] = maxf(0.0, float(payload.get(key, 1.0)))
+	for key in ADDITIVE_KEYS:
+		output[key] = float(payload.get(key, 0.0))
+	return output
+
+static func empty() -> Dictionary:
+	return normalize({})
+
+static func merge(base: Dictionary, extra: Dictionary) -> Dictionary:
+	var output := normalize(base)
+	for key in MULTIPLIER_KEYS:
+		output[key] = float(output[key]) * maxf(0.0, float(extra.get(key, 1.0)))
+	for key in ADDITIVE_KEYS:
+		output[key] = float(output[key]) + float(extra.get(key, 0.0))
+	return output

--- a/src/combat/PositionalCardCombatV41.gd
+++ b/src/combat/PositionalCardCombatV41.gd
@@ -10,7 +10,9 @@ signal action_window_opened(window: Dictionary)
 signal card_resolved(result: Dictionary)
 signal combat_finished(result: Dictionary)
 signal dirty_move_attempted(card_id: String)
+signal victory_rejected(candidate: Dictionary, ruleset_id: String)
 
+const PassiveSnapshotScript = preload("res://src/combat/CombatPassiveSnapshot.gd")
 const POSITIONS := ["STANDING", "CLINCH", "GUARD", "HALF", "SIDE_CONTROL", "MOUNT", "BACK_CONTROL", "SUBMISSION"]
 const SIDES := ["any", "top", "bottom"]
 const DEFAULT_RESOURCES := {
@@ -32,6 +34,7 @@ var hands: Dictionary = {}
 var draw_cursor: Dictionary = {}
 var fighters: Dictionary = {}
 var scores: Dictionary = {}
+var passive_snapshots: Dictionary = {}
 var position: String = "STANDING"
 var player_side: String = "any"
 var player_id: String = ""
@@ -41,7 +44,14 @@ var phase: String = "ready"
 var pending_action: Dictionary = {}
 var time_left: float = 0.0
 
-func configure(cards_payload: Dictionary, positions_payload: Dictionary, rulesets_payload: Dictionary, fighter_decks: Dictionary, narrative_flags: Dictionary = {}) -> Dictionary:
+func configure(
+	cards_payload: Dictionary,
+	positions_payload: Dictionary,
+	rulesets_payload: Dictionary,
+	fighter_decks: Dictionary,
+	narrative_flags: Dictionary = {},
+	fighter_passives: Dictionary = {}
+) -> Dictionary:
 	cards.clear()
 	for raw in cards_payload.get("cartas", []):
 		if typeof(raw) != TYPE_DICTIONARY:
@@ -54,11 +64,16 @@ func configure(cards_payload: Dictionary, positions_payload: Dictionary, ruleset
 	rulesets = rulesets_payload.get("rulesets", {}).duplicate(true)
 	decks = fighter_decks.duplicate(true)
 	flags = narrative_flags.duplicate(true)
+	passive_snapshots.clear()
+	for fighter_id_value in fighter_decks.keys():
+		var fighter_id := str(fighter_id_value)
+		passive_snapshots[fighter_id] = PassiveSnapshotScript.normalize(fighter_passives.get(fighter_id, {}))
 	return {
 		"ok": cards.size() == 20 and position_data.size() == 8 and rulesets.size() == 6,
 		"cards": cards.size(),
 		"positions": position_data.size(),
 		"rulesets": rulesets.size(),
+		"passive_snapshots": passive_snapshots.size(),
 	}
 
 func start_combat(new_player_id: String, new_opponent_id: String, new_ruleset_id: String = "OFICIAL") -> Dictionary:
@@ -70,8 +85,8 @@ func start_combat(new_player_id: String, new_opponent_id: String, new_ruleset_id
 	opponent_id = new_opponent_id
 	ruleset_id = new_ruleset_id
 	fighters = {
-		player_id: DEFAULT_RESOURCES.duplicate(true),
-		opponent_id: DEFAULT_RESOURCES.duplicate(true),
+		player_id: _initial_resources(player_id),
+		opponent_id: _initial_resources(opponent_id),
 	}
 	scores = {player_id: 0, opponent_id: 0}
 	position = "STANDING"
@@ -101,31 +116,41 @@ func tick(delta: float) -> void:
 			_finish_by_points()
 	_emit_snapshot()
 
-func can_play_card(fighter_id: String, card_id: String) -> Dictionary:
-	if phase != "decision":
-		return {"ok": false, "reason": "decision_locked"}
+## Única fonte de verdade para HUD, IA e comandos.
+func pode_jogar(fighter_id: String, card_id: String) -> Dictionary:
+	if not cards.has(card_id):
+		return _blocked("CARD_MISSING", "card_missing")
 	if not fighters.has(fighter_id):
-		return {"ok": false, "reason": "fighter_missing"}
-	if not cards.has(card_id) or not hands.get(fighter_id, []).has(card_id):
-		return {"ok": false, "reason": "card_not_in_hand"}
+		return _blocked("FIGHTER_MISSING", "fighter_missing", cards[card_id])
+	if not decks.get(fighter_id, []).has(card_id):
+		return _blocked("CARD_NOT_IN_LOADOUT", "card_not_in_loadout", cards[card_id])
 	var card: Dictionary = cards[card_id]
+	if not _profile_allows(fighter_id, card):
+		return _blocked("CARD_FORBIDDEN_BY_PROFILE", "card_forbidden_by_profile", card)
+	if not hands.get(fighter_id, []).has(card_id):
+		return _blocked("CARD_NOT_IN_HAND", "card_not_in_hand", card)
 	if not _matches_position(fighter_id, card):
-		return {"ok": false, "reason": "wrong_position_or_side"}
+		return _blocked("POSITION_INVALID", "wrong_position_or_side", card)
 	if not _flag_requirement_met(str(card.get("requisito_flag", ""))):
-		return {"ok": false, "reason": "story_requirement"}
-	if not _has_cost(fighter_id, card.get("custo", {})):
-		return {"ok": false, "reason": "insufficient_resources"}
+		return _blocked("STORY_REQUIREMENT", "story_requirement", card)
 	var dirty_rule := str(rulesets[ruleset_id].get("cartas_sujas", "banida_desclassifica"))
 	if str(card.get("moral", "limpa")) == "suja" and dirty_rule in ["banida_desclassifica", "falha_rito"]:
-		return {"ok": false, "reason": dirty_rule}
-	return {"ok": true}
+		return _blocked("RULESET_FORBIDS_CARD", dirty_rule, card)
+	if not _has_cost(fighter_id, card.get("custo", {})):
+		return _blocked("RESOURCE_INSUFFICIENT", "insufficient_resources", card)
+	if phase != "decision":
+		return _blocked("DECISION_LOCKED", "decision_locked", card)
+	return _playability_result(true, "OK", "ok", card)
+
+func can_play_card(fighter_id: String, card_id: String) -> Dictionary:
+	return pode_jogar(fighter_id, card_id)
 
 func play_card(fighter_id: String, card_id: String, input_quality: float = 0.5) -> Dictionary:
-	var validation := can_play_card(fighter_id, card_id)
+	var validation := pode_jogar(fighter_id, card_id)
 	if not bool(validation.get("ok", false)):
 		if str(validation.get("reason", "")) in ["banida_desclassifica", "falha_rito"]:
 			dirty_move_attempted.emit(card_id)
-		return {"ok": false, "error": validation.get("reason", "blocked")}
+		return {"ok": false, "error": validation.get("reason", "blocked"), "playability": validation}
 	var card: Dictionary = cards[card_id]
 	_consume_cost(fighter_id, card.get("custo", {}))
 	if str(card.get("moral", "limpa")) == "suja":
@@ -180,6 +205,7 @@ func generic_transition(fighter_id: String, transition_index: int = 0) -> Dictio
 	generic["custo"] = generic.get("custo", {})
 	generic["deck_cost"] = 0
 	cards[generic["id"]] = generic
+	decks[fighter_id] = [generic["id"]]
 	hands[fighter_id] = [generic["id"]]
 	return play_card(fighter_id, generic["id"], 0.5)
 
@@ -189,24 +215,69 @@ func resolve_submission(attacker_progress: float, defender_progress: float, atta
 	var attacker := str(pending_action.get("attacker_id", player_id if player_side == "top" else opponent_id))
 	var defender := _other(attacker)
 	if attacker_releases:
+		var release_resolution := try_resolve_victory({"method": "ceder", "winner_id": attacker, "loser_id": defender})
+		if bool(release_resolution.get("accepted", false)):
+			return {"ok": true, "released": true, "winner": attacker, "method": "ceder"}
 		position = "STANDING"
 		player_side = "any"
 		phase = "decision"
+		pending_action.clear()
 		_adjust(attacker, "tensao_moral", -10.0)
-		return {"ok": true, "released": true}
-	var attack_power := clampf(attacker_progress, 0.0, 1.0) + float(fighters[attacker].get("grip", 0.0)) * 0.06
-	var defense_power := clampf(defender_progress, 0.0, 1.0) + float(fighters[defender].get("foco", 0.0)) / 220.0
+		_draw_all_hands()
+		return {"ok": true, "released": true, "victory": release_resolution}
+	var attacker_passives := get_passive_snapshot(attacker)
+	var defender_passives := get_passive_snapshot(defender)
+	var attack_power := clampf(attacker_progress, 0.0, 1.0)
+	attack_power *= float(attacker_passives.get("sweet_spot_mult", 1.0))
+	attack_power *= float(attacker_passives.get("submission_attack_mult", 1.0))
+	attack_power += float(fighters[attacker].get("grip", 0.0)) * 0.06
+	var defense_power := clampf(defender_progress, 0.0, 1.0)
+	defense_power *= float(defender_passives.get("submission_defense_mult", 1.0))
+	defense_power += float(fighters[defender].get("foco", 0.0)) / 220.0
 	if attack_power >= defense_power + 0.12:
-		_adjust(defender, "integridade", -100.0)
-		_finish(attacker, defender, "finalizacao")
-		return {"ok": true, "winner": attacker, "method": "finalizacao"}
+		var resolution := try_resolve_victory({"method": "finalizacao", "winner_id": attacker, "loser_id": defender})
+		if bool(resolution.get("accepted", false)):
+			_adjust(defender, "integridade", -100.0)
+			return {"ok": true, "winner": attacker, "method": "finalizacao", "victory": resolution}
+		_reset_after_blocked_submission(attacker, defender)
+		return {"ok": true, "victory_blocked": true, "method": "finalizacao", "victory": resolution}
 	position = "GUARD"
 	player_side = "bottom" if attacker == player_id else "top"
 	phase = "decision"
+	pending_action.clear()
 	_adjust(attacker, "gas", -15.0)
 	_adjust(defender, "gas", -10.0)
 	_draw_all_hands()
 	return {"ok": true, "escaped": true}
+
+func resolve_ruleset_objective(method: String, winner_id: String, loser_id: String = "") -> Dictionary:
+	return try_resolve_victory({"method": method, "winner_id": winner_id, "loser_id": loser_id})
+
+func try_resolve_victory(candidate: Dictionary) -> Dictionary:
+	var method := str(candidate.get("method", ""))
+	var allowed: Array = rulesets.get(ruleset_id, {}).get("caminhos_vitoria", [])
+	if method == "" or not allowed.has(method):
+		var rejected := {
+			"accepted": false,
+			"method": method,
+			"ruleset_id": ruleset_id,
+			"allowed_methods": allowed.duplicate(),
+		}
+		victory_rejected.emit(candidate.duplicate(true), ruleset_id)
+		return rejected
+	var winner := str(candidate.get("winner_id", ""))
+	var loser := str(candidate.get("loser_id", ""))
+	_finish(winner, loser, method)
+	return {"accepted": true, "method": method, "ruleset_id": ruleset_id, "winner_id": winner, "loser_id": loser}
+
+func apply_external_focus_drain(fighter_id: String, amount: float, _source: String = "arena") -> float:
+	var passive := get_passive_snapshot(fighter_id)
+	var applied := maxf(0.0, amount) * float(passive.get("dreno_foco_arena_mult", 1.0))
+	_adjust(fighter_id, "foco", -applied)
+	return applied
+
+func get_passive_snapshot(fighter_id: String) -> Dictionary:
+	return passive_snapshots.get(fighter_id, PassiveSnapshotScript.empty()).duplicate(true)
 
 func get_contextual_hand(fighter_id: String) -> Array:
 	var result: Array = []
@@ -215,9 +286,10 @@ func get_contextual_hand(fighter_id: String) -> Array:
 		if not cards.has(card_id):
 			continue
 		var view: Dictionary = cards[card_id].duplicate(true)
-		var validation := can_play_card(fighter_id, card_id)
+		var validation := pode_jogar(fighter_id, card_id)
 		view["playable"] = bool(validation.get("ok", false))
 		view["blocked_reason"] = str(validation.get("reason", ""))
+		view["playability"] = validation
 		result.append(view)
 	return result
 
@@ -233,6 +305,7 @@ func snapshot() -> Dictionary:
 		"scores": scores.duplicate(true),
 		"hands": hands.duplicate(true),
 		"pending_action": pending_action.duplicate(true),
+		"passive_snapshots": passive_snapshots.duplicate(true),
 	}
 
 func _resolve_pending(defended: bool, defense_label: String) -> Dictionary:
@@ -257,6 +330,8 @@ func _resolve_card_success(attacker: String, defender: String, card: Dictionary)
 	_adjust(defender, "integridade", -float(card.get("dano_pos", 0.0)))
 	_adjust(defender, "guarda", -maxf(3.0, float(card.get("dano_pos", 0.0)) * 1.2))
 	_adjust(attacker, "pressao", 10.0)
+	if str(card.get("tipo", "")) == "pegada" or str(card.get("tecnica", "")).contains("grip"):
+		_adjust(attacker, "grip", float(get_passive_snapshot(attacker).get("grip_por_pegada", 0.0)))
 	_apply_extra(attacker, defender, card.get("efeito_extra", {}))
 	if bool(rulesets[ruleset_id].get("pontos_ativos", false)):
 		scores[attacker] = int(scores.get(attacker, 0)) + int(card.get("pontos", 0))
@@ -265,10 +340,29 @@ func _resolve_card_success(attacker: String, defender: String, card: Dictionary)
 	_draw_all_hands()
 	var result := {"ok": true, "success": true, "card_id": card.get("id", ""), "attacker_id": attacker, "defender_id": defender, "snapshot": snapshot()}
 	card_resolved.emit(result)
-	if float(fighters[defender].get("integridade", 0.0)) <= 0.0 and rulesets[ruleset_id].get("caminhos_vitoria", []).has("desistencia"):
-		_finish(attacker, defender, "desistencia")
+	if float(fighters[defender].get("integridade", 0.0)) <= 0.0:
+		result["victory"] = try_resolve_victory({"method": "desistencia", "winner_id": attacker, "loser_id": defender})
 	_emit_snapshot()
 	return result
+
+func _playability_result(allowed: bool, reason_code: String, reason: String, card: Dictionary = {}) -> Dictionary:
+	var cost: Dictionary = card.get("custo", {}).duplicate(true)
+	return {
+		"ok": allowed,
+		"allowed": allowed,
+		"reason_code": reason_code,
+		"reason": reason,
+		"localized_reason_key": "combat.playability.%s" % reason_code.to_lower(),
+		"specialized_slot": str(card.get("slot", card.get("tipo", ""))),
+		"resource_preview": cost,
+		"predicted_transition": {
+			"position": str(card.get("destino", "keep")),
+			"set_side": str(card.get("set_side", "keep")),
+		},
+	}
+
+func _blocked(reason_code: String, reason: String, card: Dictionary = {}) -> Dictionary:
+	return _playability_result(false, reason_code, reason, card)
 
 func _matches_position(fighter_id: String, card: Dictionary) -> bool:
 	if not card.get("origem", []).has(position):
@@ -276,14 +370,24 @@ func _matches_position(fighter_id: String, card: Dictionary) -> bool:
 	var required_side := str(card.get("lado", "any"))
 	return required_side == "any" or required_side == _side_for(fighter_id)
 
+func _profile_allows(fighter_id: String, card: Dictionary) -> bool:
+	var policies: Dictionary = flags.get("owner_policies", {})
+	var policy: Dictionary = policies.get(fighter_id, {})
+	var forbidden: Array = policy.get("forbidden_morals", [])
+	return not forbidden.has(str(card.get("moral", "limpa")))
+
 func _has_cost(fighter_id: String, cost: Dictionary) -> bool:
 	var res: Dictionary = fighters.get(fighter_id, {})
-	return float(res.get("grip", 0.0)) >= float(cost.get("grip", 0.0)) and float(res.get("gas", 0.0)) >= float(cost.get("gas", 0.0)) and float(res.get("foco", 0.0)) >= float(cost.get("foco", 0.0))
+	var passive := get_passive_snapshot(fighter_id)
+	var gas_cost := float(cost.get("gas", 0.0)) * float(passive.get("gas_cost_mult", 1.0))
+	var focus_cost := float(cost.get("foco", 0.0)) * float(passive.get("focus_cost_mult", 1.0))
+	return float(res.get("grip", 0.0)) >= float(cost.get("grip", 0.0)) and float(res.get("gas", 0.0)) >= gas_cost and float(res.get("foco", 0.0)) >= focus_cost
 
 func _consume_cost(fighter_id: String, cost: Dictionary) -> void:
+	var passive := get_passive_snapshot(fighter_id)
 	_adjust(fighter_id, "grip", -float(cost.get("grip", 0.0)))
-	_adjust(fighter_id, "gas", -float(cost.get("gas", 0.0)))
-	_adjust(fighter_id, "foco", -float(cost.get("foco", 0.0)))
+	_adjust(fighter_id, "gas", -float(cost.get("gas", 0.0)) * float(passive.get("gas_cost_mult", 1.0)))
+	_adjust(fighter_id, "foco", -float(cost.get("foco", 0.0)) * float(passive.get("focus_cost_mult", 1.0)))
 
 func _apply_side(attacker: String, set_side: String) -> void:
 	match set_side:
@@ -309,11 +413,13 @@ func _apply_extra(attacker: String, defender: String, extra: Dictionary) -> void
 			_adjust(defender, "grip", -float(value))
 
 func _parse_delta(value: Variant) -> float:
-	if typeof(value) in [TYPE_INT, TYPE_FLOAT]: return float(value)
+	if typeof(value) in [TYPE_INT, TYPE_FLOAT]:
+		return float(value)
 	return float(str(value).replace("+", ""))
 
 func _flag_requirement_met(requirement: String) -> bool:
-	if requirement == "": return true
+	if requirement == "":
+		return true
 	if requirement.contains(">="):
 		var parts := requirement.split(">=")
 		return float(flags.get(parts[0], 0)) >= float(parts[1])
@@ -324,10 +430,13 @@ func _draw_hand(fighter_id: String) -> void:
 	var pool: Array = []
 	for card_id_value in deck:
 		var card_id := str(card_id_value)
-		if cards.has(card_id) and _matches_position(fighter_id, cards[card_id]):
+		if cards.has(card_id) and _profile_allows(fighter_id, cards[card_id]) and _matches_position(fighter_id, cards[card_id]):
 			pool.append(card_id)
 	if pool.is_empty():
-		pool = deck.duplicate()
+		for card_id_value in deck:
+			var fallback_id := str(card_id_value)
+			if cards.has(fallback_id) and _profile_allows(fighter_id, cards[fallback_id]):
+				pool.append(fallback_id)
 	var hand: Array = []
 	if not pool.is_empty():
 		var cursor := int(draw_cursor.get(fighter_id, 0))
@@ -336,7 +445,8 @@ func _draw_hand(fighter_id: String) -> void:
 			var card_id := str(pool[cursor % pool.size()])
 			cursor += 1
 			attempts += 1
-			if not hand.has(card_id): hand.append(card_id)
+			if not hand.has(card_id):
+				hand.append(card_id)
 		draw_cursor[fighter_id] = cursor
 	hands[fighter_id] = hand
 
@@ -351,21 +461,50 @@ func _regenerate(delta: float) -> void:
 		_adjust(fighter_id, "foco", 1.0 * delta)
 		_adjust(fighter_id, "pressao", -1.5 * delta)
 		if float(fighters[fighter_id].get("gas", 0.0)) <= 0.0:
-			_adjust(fighter_id, "integridade", -1.0 * delta)
+			var fatigue_mult := float(get_passive_snapshot(fighter_id).get("fadiga_dano_mult", 1.0))
+			_adjust(fighter_id, "integridade", -1.0 * fatigue_mult * delta)
+
+func _initial_resources(fighter_id: String) -> Dictionary:
+	var resources := DEFAULT_RESOURCES.duplicate(true)
+	var passive := get_passive_snapshot(fighter_id)
+	resources["integridade"] = 100.0 + float(passive.get("vida_max_bonus", 0.0))
+	resources["gas"] = 100.0 + float(passive.get("gas_max_bonus", 0.0))
+	resources["foco"] = 100.0 + float(passive.get("foco_max_bonus", 0.0))
+	resources["grip"] = clampf(float(passive.get("grip_inicial", 0.0)), 0.0, 3.0)
+	return resources
 
 func _adjust(fighter_id: String, key: String, delta: float) -> void:
-	if not fighters.has(fighter_id): return
-	var maximum := 3.0 if key == "grip" else 100.0
-	fighters[fighter_id][key] = clampf(float(fighters[fighter_id].get(key, 0.0)) + delta, 0.0, maximum)
+	if not fighters.has(fighter_id):
+		return
+	fighters[fighter_id][key] = clampf(float(fighters[fighter_id].get(key, 0.0)) + delta, 0.0, _maximum_for(fighter_id, key))
+
+func _maximum_for(fighter_id: String, key: String) -> float:
+	var passive := get_passive_snapshot(fighter_id)
+	match key:
+		"grip": return 3.0
+		"integridade": return 100.0 + float(passive.get("vida_max_bonus", 0.0))
+		"gas": return 100.0 + float(passive.get("gas_max_bonus", 0.0))
+		"foco": return 100.0 + float(passive.get("foco_max_bonus", 0.0))
+		_: return 100.0
 
 func _finish_by_points() -> void:
-	if not bool(rulesets[ruleset_id].get("pontos_ativos", false)): return
+	if not bool(rulesets[ruleset_id].get("pontos_ativos", false)):
+		return
 	if int(scores[player_id]) == int(scores[opponent_id]):
-		_finish("", "", "empate")
+		try_resolve_victory({"method": "pontos", "winner_id": "", "loser_id": ""})
 	elif int(scores[player_id]) > int(scores[opponent_id]):
-		_finish(player_id, opponent_id, "pontos")
+		try_resolve_victory({"method": "pontos", "winner_id": player_id, "loser_id": opponent_id})
 	else:
-		_finish(opponent_id, player_id, "pontos")
+		try_resolve_victory({"method": "pontos", "winner_id": opponent_id, "loser_id": player_id})
+
+func _reset_after_blocked_submission(attacker: String, defender: String) -> void:
+	position = "GUARD"
+	player_side = "bottom" if attacker == player_id else "top"
+	phase = "decision"
+	pending_action.clear()
+	_adjust(attacker, "gas", -15.0)
+	_adjust(defender, "gas", -10.0)
+	_draw_all_hands()
 
 func _finish(winner: String, loser: String, method: String) -> void:
 	phase = "finished"
@@ -373,12 +512,15 @@ func _finish(winner: String, loser: String, method: String) -> void:
 	combat_finished.emit(result)
 
 func _side_for(fighter_id: String) -> String:
-	if player_side == "any": return "any"
+	if player_side == "any":
+		return "any"
 	return player_side if fighter_id == player_id else _opposite_side(player_side)
 
 func _opposite_side(side: String) -> String:
-	if side == "top": return "bottom"
-	if side == "bottom": return "top"
+	if side == "top":
+		return "bottom"
+	if side == "bottom":
+		return "top"
 	return "any"
 
 func _other(fighter_id: String) -> String:

--- a/src/hub/SkillHubLoadoutV41.gd
+++ b/src/hub/SkillHubLoadoutV41.gd
@@ -4,6 +4,7 @@ extends Node
 signal card_unlocked(card_id: String, source: String)
 signal card_trained(card_id: String, mastery: int)
 signal loadout_changed(owner_id: String, deck: Array[String])
+signal owner_policy_changed(owner_id: String, policy: Dictionary)
 
 const DECK_SIZE := 12
 const MAX_DUPLICATES := 2
@@ -13,10 +14,12 @@ var unlocked: Dictionary = {}
 var mastery: Dictionary = {}
 var loadouts: Dictionary = {}
 var deck_points_by_owner: Dictionary = {}
+var owner_policies: Dictionary = {}
 
 func configure(cards_payload: Dictionary, starter_decks: Dictionary = {}) -> Dictionary:
 	catalog.clear()
 	unlocked.clear()
+	owner_policies.clear()
 	for raw in cards_payload.get("cartas", []):
 		if typeof(raw) != TYPE_DICTIONARY:
 			continue
@@ -35,6 +38,29 @@ func configure(cards_payload: Dictionary, starter_decks: Dictionary = {}) -> Dic
 func set_deck_points(owner_id: String, points: int) -> void:
 	deck_points_by_owner[owner_id] = maxi(points, 0)
 
+func set_owner_policy(owner_id: String, policy: Dictionary) -> Dictionary:
+	if owner_id == "":
+		return {"ok": false, "error": "owner_missing"}
+	var normalized := {
+		"forbidden_morals": _normalized_strings(policy.get("forbidden_morals", [])),
+	}
+	owner_policies[owner_id] = normalized
+	loadouts[owner_id] = _sanitize_deck(loadouts.get(owner_id, []), owner_id)
+	owner_policy_changed.emit(owner_id, normalized.duplicate(true))
+	loadout_changed.emit(owner_id, get_loadout(owner_id))
+	return {"ok": true, "owner_id": owner_id, "policy": normalized.duplicate(true), "deck": get_loadout(owner_id)}
+
+func forbid_moral_for_owner(owner_id: String, moral_class: String) -> Dictionary:
+	var policy: Dictionary = owner_policies.get(owner_id, {}).duplicate(true)
+	var forbidden: Array = policy.get("forbidden_morals", []).duplicate()
+	if moral_class != "" and not forbidden.has(moral_class):
+		forbidden.append(moral_class)
+	policy["forbidden_morals"] = forbidden
+	return set_owner_policy(owner_id, policy)
+
+func get_owner_policy(owner_id: String) -> Dictionary:
+	return owner_policies.get(owner_id, {"forbidden_morals": []}).duplicate(true)
+
 func unlock(card_id: String, source: String) -> Dictionary:
 	if not catalog.has(card_id):
 		return {"ok": false, "error": "card_missing"}
@@ -43,6 +69,22 @@ func unlock(card_id: String, source: String) -> Dictionary:
 	unlocked[card_id] = true
 	card_unlocked.emit(card_id, source)
 	return {"ok": true, "card_id": card_id, "source": source}
+
+func unlock_for_owner(owner_id: String, card_id: String, source: String) -> Dictionary:
+	if not catalog.has(card_id):
+		return {"ok": false, "error": "card_missing"}
+	if not _card_allowed_by_policy(owner_id, card_id):
+		return {"ok": false, "error": "card_forbidden_by_profile", "owner_id": owner_id, "card_id": card_id}
+	return unlock(card_id, source)
+
+func can_include(owner_id: String, card_id: String) -> Dictionary:
+	if not catalog.has(card_id):
+		return {"ok": false, "error": "card_missing"}
+	if not _card_allowed_by_policy(owner_id, card_id):
+		return {"ok": false, "error": "card_forbidden_by_profile"}
+	if not bool(unlocked.get(card_id, false)) and str(catalog[card_id].get("raridade", "base")) != "base":
+		return {"ok": false, "error": "card_locked"}
+	return {"ok": true}
 
 func train(card_id: String, repetitions: int, cria_cost: int, available_criacoin: int) -> Dictionary:
 	if not bool(unlocked.get(card_id, false)):
@@ -69,10 +111,9 @@ func set_loadout(owner_id: String, requested_cards: Array) -> Dictionary:
 	return {"ok": true, "deck": sanitized.duplicate(), "deck_cost": cost}
 
 func add_to_loadout(owner_id: String, card_id: String) -> Dictionary:
-	if not catalog.has(card_id):
-		return {"ok": false, "error": "card_missing"}
-	if not bool(unlocked.get(card_id, false)):
-		return {"ok": false, "error": "card_locked"}
+	var inclusion := can_include(owner_id, card_id)
+	if not bool(inclusion.get("ok", false)):
+		return inclusion
 	var deck: Array = loadouts.get(owner_id, []).duplicate()
 	if deck.size() >= DECK_SIZE:
 		return {"ok": false, "error": "deck_full"}
@@ -101,13 +142,14 @@ func get_loadout(owner_id: String) -> Array[String]:
 		output.append(str(value))
 	return output
 
-func get_hub_collection() -> Array:
+func get_hub_collection(owner_id: String = "") -> Array:
 	var output: Array = []
 	for card_id_value in catalog.keys():
 		var card_id := str(card_id_value)
 		var card: Dictionary = catalog[card_id].duplicate(true)
 		card["unlocked"] = bool(unlocked.get(card_id, false))
 		card["mastery"] = int(mastery.get(card_id, 0))
+		card["allowed_for_owner"] = owner_id == "" or _card_allowed_by_policy(owner_id, card_id)
 		output.append(card)
 	output.sort_custom(func(a: Dictionary, b: Dictionary) -> bool:
 		return str(a.get("raridade", "")) + str(a.get("nome", "")) < str(b.get("raridade", "")) + str(b.get("nome", ""))
@@ -120,12 +162,14 @@ func export_state() -> Dictionary:
 		"mastery": mastery.duplicate(true),
 		"loadouts": loadouts.duplicate(true),
 		"deck_points": deck_points_by_owner.duplicate(true),
+		"owner_policies": owner_policies.duplicate(true),
 	}
 
 func import_state(state: Dictionary) -> void:
 	unlocked.merge(state.get("unlocked", {}), true)
 	mastery = state.get("mastery", {}).duplicate(true)
 	deck_points_by_owner = state.get("deck_points", {}).duplicate(true)
+	owner_policies = state.get("owner_policies", {}).duplicate(true)
 	loadouts.clear()
 	for owner_value in state.get("loadouts", {}).keys():
 		var owner_id := str(owner_value)
@@ -135,15 +179,31 @@ func _sanitize_deck(values: Array, owner_id: String) -> Array[String]:
 	var output: Array[String] = []
 	for value in values:
 		var card_id := str(value)
-		if not catalog.has(card_id):
-			continue
-		if not bool(unlocked.get(card_id, false)) and str(catalog[card_id].get("raridade", "base")) != "base":
+		var inclusion := can_include(owner_id, card_id)
+		if not bool(inclusion.get("ok", false)):
 			continue
 		if output.count(card_id) >= MAX_DUPLICATES:
 			continue
 		if output.size() >= DECK_SIZE:
 			break
 		output.append(card_id)
+	return output
+
+func _card_allowed_by_policy(owner_id: String, card_id: String) -> bool:
+	if owner_id == "" or not catalog.has(card_id):
+		return catalog.has(card_id)
+	var policy: Dictionary = owner_policies.get(owner_id, {})
+	var forbidden: Array = policy.get("forbidden_morals", [])
+	return not forbidden.has(str(catalog[card_id].get("moral", "limpa")))
+
+func _normalized_strings(values: Variant) -> Array[String]:
+	var output: Array[String] = []
+	if typeof(values) != TYPE_ARRAY:
+		return output
+	for value in values:
+		var item := str(value)
+		if item != "" and not output.has(item):
+			output.append(item)
 	return output
 
 func _deck_cost(deck: Array) -> int:

--- a/src/progression/ProgressionEffects.gd
+++ b/src/progression/ProgressionEffects.gd
@@ -1,0 +1,65 @@
+class_name ProgressionEffects
+extends RefCounted
+
+## Fachada sem UI para publicar os efeitos da árvore nos sistemas consumidores.
+## O chamador continua responsável por validar custo, pré-requisitos e persistência do nó.
+
+static func apply_skill_node(
+	node_id: String,
+	effect: Dictionary,
+	owner_id: String,
+	skill_hub: Node,
+	world_state: Node
+) -> Dictionary:
+	var effect_type := str(effect.get("type", ""))
+	match effect_type:
+		"deck_points":
+			if skill_hub == null or not skill_hub.has_method("set_deck_points"):
+				return {"ok": false, "error": "skill_hub_missing"}
+			var points := int(effect.get("value", effect.get("points", 0)))
+			skill_hub.call("set_deck_points", owner_id, points)
+			return {"ok": true, "effect": effect_type, "points": points}
+		"desbloqueia_carta":
+			if skill_hub == null or not skill_hub.has_method("unlock_for_owner"):
+				return {"ok": false, "error": "skill_hub_missing"}
+			return skill_hub.call("unlock_for_owner", owner_id, str(effect.get("card_id", "")), "skill_tree")
+		"remove_cartas_sujas":
+			if skill_hub == null or not skill_hub.has_method("forbid_moral_for_owner"):
+				return {"ok": false, "error": "skill_hub_missing"}
+			var result: Dictionary = skill_hub.call("forbid_moral_for_owner", owner_id, "suja")
+			if bool(result.get("ok", false)) and world_state != null and world_state.has_method("set_narrative_flag"):
+				world_state.call("set_narrative_flag", "dirty_cards_forbidden", true)
+			return result
+		"path_gate_final":
+			if world_state == null or not world_state.has_method("set_narrative_flag"):
+				return {"ok": false, "error": "world_state_missing"}
+			var flag_key := str(effect.get("flag", "moral_nao_humilhar"))
+			world_state.call("set_narrative_flag", flag_key, true)
+			return {"ok": true, "effect": effect_type, "flag": flag_key}
+		"passivo_stat":
+			return _apply_passive_stat(effect, owner_id, world_state)
+		_:
+			# Compatibilidade para os dois nós morais antes de tree.json estabilizar.
+			if node_id == "respeito_nao_humilhar":
+				return apply_skill_node(node_id, {"type": "path_gate_final", "flag": "moral_nao_humilhar"}, owner_id, skill_hub, world_state)
+			if node_id == "respeito_codigo_do_cria":
+				return apply_skill_node(node_id, {"type": "remove_cartas_sujas"}, owner_id, skill_hub, world_state)
+			return {"ok": false, "error": "unsupported_effect", "node_id": node_id, "effect_type": effect_type}
+
+static func _apply_passive_stat(effect: Dictionary, owner_id: String, world_state: Node) -> Dictionary:
+	if world_state == null or not world_state.has_method("get_narrative_flag") or not world_state.has_method("set_narrative_flag"):
+		return {"ok": false, "error": "world_state_missing"}
+	var stat := str(effect.get("stat", ""))
+	if stat == "":
+		return {"ok": false, "error": "passive_stat_missing"}
+	var all_passives: Dictionary = world_state.call("get_narrative_flag", "combat_passives", {}).duplicate(true)
+	var owner_passives: Dictionary = all_passives.get(owner_id, {}).duplicate(true)
+	var mode := str(effect.get("mode", "set"))
+	var value := float(effect.get("value", 0.0))
+	match mode:
+		"add": owner_passives[stat] = float(owner_passives.get(stat, 0.0)) + value
+		"multiply": owner_passives[stat] = float(owner_passives.get(stat, 1.0)) * value
+		_: owner_passives[stat] = value
+	all_passives[owner_id] = owner_passives
+	world_state.call("set_narrative_flag", "combat_passives", all_passives)
+	return {"ok": true, "effect": "passivo_stat", "owner_id": owner_id, "stat": stat, "value": owner_passives[stat]}

--- a/tests/test_combat_integration_contract.py
+++ b/tests/test_combat_integration_contract.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load(path: str) -> dict:
+    return json.loads((ROOT / path).read_text(encoding="utf-8"))
+
+
+def test_playability_reason_codes_are_canonical() -> None:
+    payload = load("data/combat/playability_reason_codes.json")
+    assert set(payload["reason_codes"]) == {
+        "OK",
+        "DECISION_LOCKED",
+        "FIGHTER_MISSING",
+        "CARD_MISSING",
+        "CARD_NOT_IN_LOADOUT",
+        "CARD_FORBIDDEN_BY_PROFILE",
+        "CARD_NOT_IN_HAND",
+        "POSITION_INVALID",
+        "STORY_REQUIREMENT",
+        "RULESET_FORBIDS_CARD",
+        "RESOURCE_INSUFFICIENT",
+    }
+
+
+def test_rulesets_are_authoritative_about_victory() -> None:
+    rulesets = load("data/combat/rulesets.json")["rulesets"]
+    assert rulesets["OFICIAL"]["caminhos_vitoria"] == ["finalizacao", "pontos", "desistencia"]
+    assert rulesets["CLANDESTINA"]["caminhos_vitoria"] == ["finalizacao", "desistencia"]
+    assert rulesets["RITO"]["caminhos_vitoria"] == ["ceder"]
+    assert rulesets["FESTIVAL"]["caminhos_vitoria"] == ["finalizacao", "pontos"]
+    assert rulesets["DOJO"]["caminhos_vitoria"] == []
+    assert rulesets["MORAL"]["caminhos_vitoria"] == ["resistir_discurso"]
+
+
+def test_ruan_kimura_binding_matches_card_catalog() -> None:
+    cards = {card["id"]: card for card in load("data/combat/cards.json")["cartas"]}
+    manifest = load("data/characters/ruan/animation_manifest.json")
+    binding = manifest["bindings"]["kimura"]
+    assert binding["card_id"] == "kimura"
+    assert binding["move_number"] == 23
+    assert binding["technique_id"] == cards["kimura"]["tecnica"]
+    assert binding["animation_state"] == cards["kimura"]["frames_anim"]
+
+
+def test_runtime_contains_single_playability_authority() -> None:
+    runtime = (ROOT / "src/combat/PositionalCardCombatV41.gd").read_text(encoding="utf-8")
+    assert "func pode_jogar(" in runtime
+    assert "func can_play_card(" in runtime
+    assert "return pode_jogar(fighter_id, card_id)" in runtime
+    assert "func try_resolve_victory(" in runtime
+    assert 'get("caminhos_vitoria"' in runtime
+
+
+def test_owner_policy_guards_unlock_loadout_and_migration() -> None:
+    hub = (ROOT / "src/hub/SkillHubLoadoutV41.gd").read_text(encoding="utf-8")
+    for method in (
+        "func unlock_for_owner(",
+        "func can_include(",
+        "func forbid_moral_for_owner(",
+        "func _sanitize_deck(",
+        "func import_state(",
+    ):
+        assert method in hub
+    assert '"owner_policies"' in hub
+    assert '"card_forbidden_by_profile"' in hub
+
+
+def test_moral_gate_is_persistent_and_read_by_ending() -> None:
+    world = (ROOT / "src/autoloads/WorldStateV4.gd").read_text(encoding="utf-8")
+    endings = (ROOT / "src/autoloads/EndingResolverV4.gd").read_text(encoding="utf-8")
+    progression = (ROOT / "src/progression/ProgressionEffects.gd").read_text(encoding="utf-8")
+    assert '"moral_nao_humilhar": false' in world
+    assert 'flags.get("moral_nao_humilhar", false)' in endings
+    assert "and moral_nao_humilhar" in endings
+    assert '"respeito_nao_humilhar"' in progression
+
+
+def test_contract_documents_the_full_chain() -> None:
+    contract = (ROOT / "docs/COMBAT_INTEGRATION_CONTRACT.md").read_text(encoding="utf-8")
+    for phrase in (
+        "progressão → acesso → loadout",
+        "Regra canônica de carta jogável",
+        "Autoridade dos rulesets sobre vitória",
+        "Binding de animação",
+        "Definition of Done",
+    ):
+        assert phrase in contract

--- a/tests/v4_combat_smoke.gd
+++ b/tests/v4_combat_smoke.gd
@@ -1,6 +1,9 @@
 extends SceneTree
 
 const PositionalAdapterScript = preload("res://src/compat/PositionalCombatAdapter.gd")
+const PositionalRuntimeScript = preload("res://src/combat/PositionalCardCombatV41.gd")
+const SkillHubScript = preload("res://src/hub/SkillHubLoadoutV41.gd")
+const AnimationResolverScript = preload("res://src/combat/AnimationBindingResolver.gd")
 
 var failures: Array[String] = []
 var checks := 0
@@ -13,6 +16,41 @@ func _assert(condition: bool, message: String) -> void:
 	if not condition:
 		failures.append(message)
 		push_error("[V4CombatSmoke] " + message)
+
+func _load_json(path: String) -> Dictionary:
+	var file := FileAccess.open(path, FileAccess.READ)
+	if file == null:
+		return {}
+	var parsed = JSON.parse_string(file.get_as_text())
+	file.close()
+	return parsed if typeof(parsed) == TYPE_DICTIONARY else {}
+
+func _new_runtime(ruleset_id: String, deck: Array, passives: Dictionary = {}) -> PositionalCardCombatV41:
+	var runtime: PositionalCardCombatV41 = PositionalRuntimeScript.new()
+	root.add_child(runtime)
+	var report := runtime.configure(
+		DataRegistry.combat_cards_v41,
+		DataRegistry.combat_positions_v41,
+		DataRegistry.combat_rulesets_v41,
+		{"ruan_macacao": deck, "davi_relampago": deck},
+		{},
+		{"ruan_macacao": passives}
+	)
+	_assert(bool(report.get("ok", false)), "runtime local deve configurar dados v4.1")
+	var start := runtime.start_combat("ruan_macacao", "davi_relampago", ruleset_id)
+	_assert(bool(start.get("ok", false)), "runtime local deve iniciar ruleset %s" % ruleset_id)
+	return runtime
+
+func _force_submission(runtime: PositionalCardCombatV41) -> void:
+	runtime.position = "SUBMISSION"
+	runtime.player_side = "top"
+	runtime.phase = "submission"
+	runtime.pending_action = {
+		"attacker_id": "ruan_macacao",
+		"defender_id": "davi_relampago",
+		"card_id": "kimura",
+	}
+	runtime.fighters["ruan_macacao"]["grip"] = 3.0
 
 func _run() -> void:
 	await process_frame
@@ -28,6 +66,22 @@ func _run() -> void:
 		"knee_cut_pass", "cem_quilos", "montada", "kimura",
 		"triangulo", "mata_leao", "grip_de_ferro", "baiana",
 	]
+
+	# Ponte progressão → política por dono.
+	var local_hub: SkillHubLoadoutV41 = SkillHubScript.new()
+	root.add_child(local_hub)
+	local_hub.configure(DataRegistry.combat_cards_v41)
+	local_hub.forbid_moral_for_owner("ruan_macacao", "suja")
+	var dirty_unlock := local_hub.unlock_for_owner("ruan_macacao", "dedo_no_olho", "skill_tree")
+	_assert(not bool(dirty_unlock.get("ok", false)), "Código do Cria deve bloquear desbloqueio sujo por dono")
+	_assert(str(dirty_unlock.get("error", "")) == "card_forbidden_by_profile", "bloqueio sujo deve usar erro canônico")
+	local_hub.queue_free()
+
+	# Ponte passivo → combate e política persistente → fachada oficial.
+	WorldState.set_narrative_flag("dirty_cards_forbidden", true)
+	WorldState.set_narrative_flag("combat_passives", {
+		"ruan_macacao": {"sweet_spot_mult": 1.15, "grip_inicial": 1.0}
+	})
 	var start_result: Dictionary = CombatManager.start_positional_combat_v41(
 		"terreiro_da_luta",
 		"ruan_macacao",
@@ -40,6 +94,8 @@ func _run() -> void:
 	var first_snapshot: Dictionary = CombatManager.get_positional_snapshot_v41()
 	_assert(str(first_snapshot.get("position", "")) == "STANDING", "combate inicia em STANDING")
 	_assert(str(CombatManager.get_current_state_name()) == "PLAYER_STANDING_NEUTRAL", "estado v4 deve sincronizar a máquina legada")
+	_assert(is_equal_approx(float(first_snapshot.get("passive_snapshots", {}).get("ruan_macacao", {}).get("sweet_spot_mult", 0.0)), 1.15), "sweet spot passivo deve chegar ao runtime")
+	_assert(is_equal_approx(float(first_snapshot.get("fighters", {}).get("ruan_macacao", {}).get("grip", 0.0)), 1.0), "grip inicial passivo deve alterar recursos")
 	var hand: Array = CombatManager.get_contextual_hand_v41("ruan_macacao")
 	_assert(not hand.is_empty(), "mão contextual oficial não pode estar vazia")
 	_assert(hand.size() <= 3, "mão contextual não pode ultrapassar três cartas")
@@ -61,6 +117,39 @@ func _run() -> void:
 	var exported: Dictionary = CombatManager.export_v41_state()
 	_assert(exported.has("hub"), "CombatManager deve exportar estado persistível do Hub")
 	_assert(exported.get("hub", {}).get("loadouts", {}).get("ruan_macacao", []).size() == 12, "loadout v4.1 deve persistir 12 cartas")
+	_assert(exported.get("hub", {}).get("owner_policies", {}).get("ruan_macacao", {}).get("forbidden_morals", []).has("suja"), "política moral deve persistir no hub")
+
+	# Regra única pode_jogar deve explicar posição inválida.
+	var official_runtime := _new_runtime("OFICIAL", deck)
+	official_runtime.hands["ruan_macacao"] = ["kimura"]
+	var invalid_position := official_runtime.pode_jogar("ruan_macacao", "kimura")
+	_assert(str(invalid_position.get("reason_code", "")) == "POSITION_INVALID", "Kimura em STANDING deve retornar POSITION_INVALID")
+	_force_submission(official_runtime)
+	var official_submission := official_runtime.resolve_submission(1.0, 0.0)
+	_assert(bool(official_submission.get("victory", {}).get("accepted", false)), "Kimura no OFICIAL deve aceitar vitória")
+	_assert(official_runtime.phase == "finished", "OFICIAL deve encerrar após finalização aceita")
+	official_runtime.queue_free()
+
+	var moral_runtime := _new_runtime("MORAL", deck, {"sweet_spot_mult": 1.15})
+	_force_submission(moral_runtime)
+	var moral_submission := moral_runtime.resolve_submission(1.0, 0.0)
+	_assert(bool(moral_submission.get("victory_blocked", false)), "Kimura no MORAL não pode vencer")
+	_assert(moral_runtime.phase != "finished", "MORAL deve continuar após finalização técnica")
+	moral_runtime.queue_free()
+
+	var rito_runtime := _new_runtime("RITO", deck)
+	_force_submission(rito_runtime)
+	var rito_submission := rito_runtime.resolve_submission(1.0, 0.0)
+	_assert(bool(rito_submission.get("victory_blocked", false)), "finalização convencional no RITO deve ser bloqueada")
+	_assert(rito_runtime.phase != "finished", "RITO não pode terminar por finalização convencional")
+	rito_runtime.queue_free()
+
+	# Binding semântico carta ↔ CPS ↔ estado de animação.
+	var resolver: AnimationBindingResolver = AnimationResolverScript.new()
+	var manifest := _load_json("res://data/characters/ruan/animation_manifest.json")
+	_assert(bool(resolver.configure(manifest).get("ok", false)), "animation manifest do Ruan deve configurar")
+	_assert(bool(resolver.validate_against_cards(DataRegistry.combat_cards_v41).get("ok", false)), "binding Kimura deve bater com cards.json")
+	_assert(str(resolver.resolve("kimura").get("animation_state", "")) == "ruan_kimura_right", "Kimura deve resolver estado de animação canônico")
 
 	var adapter_report: Dictionary = PositionalAdapterScript.validate_contract()
 	_assert(bool(adapter_report.get("ok", false)), "adapter legado deve cobrir as 8 posições")


### PR DESCRIPTION
## Objetivo

Fecha as pontes críticas entre progressão, loadout, combate posicional, rulesets, finais e pipeline de animação sobre `release/v4-integration`.

## Incluído

- contrato canônico em `docs/COMBAT_INTEGRATION_CONTRACT.md`;
- `pode_jogar()` como autoridade única de elegibilidade;
- códigos estruturados de bloqueio;
- políticas morais por dono no `SkillHubLoadoutV41`;
- persistência de `dirty_cards_forbidden`, `moral_nao_humilhar` e snapshots de passivos;
- aplicação de passivos no custo, recursos, fadiga e submissão;
- `try_resolve_victory()` governado por `caminhos_vitoria` do ruleset;
- gate `Não Humilhar` no final `Cria de Verdade`;
- `AnimationBindingResolver`, schema e primeiro binding canônico da Kimura do Ruan;
- ponte `ProgressionEffects` para deck, passivos e flags mundiais;
- testes Python e smoke Godot ampliado para políticas, passivos, MORAL, RITO e binding.

## Limites honestos

- não cria a UI completa da árvore 4×6;
- não declara todos os manifests de animação concluídos: inicia com o binding validável da Kimura;
- mantém o deck legado como compatibilidade; a remoção depende dos gates existentes;
- permanece draft até import/parser, pytest e smoke Godot ficarem verdes.

## Base

PR empilhado sobre `release/v4-integration` (#32), sem ação direta na `main`.