### PR TITLE
chore(governance): add boot audit and v4 runtime gates

### DIFF
--- a/.github/workflows/boot-audit.yml
+++ b/.github/workflows/boot-audit.yml
@@ -1,0 +1,24 @@
+name: Boot Graph Audit
+
+on:
+  push:
+    branches: [main, 'build/**', 'release/**']
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  audit-boot:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Verify main scene, autoloads and scene resources
+        run: python tools/audit/audit_boot.py .

--- a/.github/workflows/runtime-audit.yml
+++ b/.github/workflows/runtime-audit.yml
@@ -6,12 +6,14 @@ on:
       - main
       - 'upgrade/**'
       - 'release/**'
+      - 'build/**'
   pull_request:
   workflow_dispatch:
 
 jobs:
   static-audit:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -54,6 +56,7 @@ jobs:
   godot-headless-smoke:
     needs: static-audit
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -75,25 +78,33 @@ jobs:
         shell: bash
         run: |
           set -o pipefail
-          timeout 180 ./godot --headless --editor --path . --import 2>&1 | tee reports/runtime_audit/godot_import.log
+          timeout --signal=TERM --kill-after=15s 180s \
+            ./godot --headless --editor --path . --import 2>&1 \
+            | tee reports/runtime_audit/godot_import.log
 
       - name: Run legacy runtime smoke suite
         shell: bash
         run: |
           set -o pipefail
-          ./godot --headless --path . --script res://tests/runtime_smoke.gd 2>&1 | tee reports/runtime_audit/godot_smoke.log
+          timeout --signal=TERM --kill-after=15s 120s \
+            ./godot --headless --path . --script res://tests/runtime_smoke.gd 2>&1 \
+            | tee reports/runtime_audit/godot_smoke.log
 
       - name: Run v4 positional combat smoke suite
         shell: bash
         run: |
           set -o pipefail
-          ./godot --headless --path . --script res://tests/v4_combat_smoke.gd 2>&1 | tee reports/runtime_audit/godot_v4_combat_smoke.log
+          timeout --signal=TERM --kill-after=15s 120s \
+            ./godot --headless --verbose --path . --script res://tests/v4_combat_smoke.gd 2>&1 \
+            | tee reports/runtime_audit/godot_v4_combat_smoke.log
 
       - name: Parse reference Combat Arena v4 scene
         shell: bash
         run: |
           set -o pipefail
-          timeout 60 ./godot --headless --path . --editor --quit-after 2 res://scenes/combat/CombatArenaV4.tscn 2>&1 | tee reports/runtime_audit/godot_v4_arena.log
+          timeout --signal=TERM --kill-after=15s 60s \
+            ./godot --headless --path . --editor --quit-after 2 res://scenes/combat/CombatArenaV4.tscn 2>&1 \
+            | tee reports/runtime_audit/godot_v4_arena.log
 
       - name: Upload Godot logs
         if: always()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,8 @@ Assistentes sem memória persistente carregam estes arquivos em toda sessão:
 3. `.agents/skills/cria-do-tatame-game-director/SKILL.md`;
 4. módulos `references/` da skill;
 5. contrato SUPREME e cânone aplicável ao lote;
-6. para qualquer trabalho visual: `docs/art_bible/OFFICIAL_VISUAL_STANDARD_V1.md` e `data/visual/official_visual_contract_v1.json`.
+6. `docs/DECISIONS.md` para migrações e limites arquiteturais congelados;
+7. para qualquer trabalho visual: `docs/art_bible/OFFICIAL_VISUAL_STANDARD_V1.md` e `data/visual/official_visual_contract_v1.json`.
 
 Validar a ativação com:
 
@@ -113,6 +114,7 @@ O escopo completo e os gates de produção vivem em `docs/CRIA_DO_TATAME_SUPREME
 
 ## Contratos de arquitetura
 
+- `docs/DECISIONS.md` congela as decisões do Master Plan; alterações exigem reconciliação documentada e aprovação do dono.
 - Gameplay crítico deve ser determinístico e executável offline.
 - IA pode criar, revisar e classificar conteúdo; não pode sustentar o loop principal em tempo real.
 - Dados em `data/` precisam manter IDs estáveis e referências válidas.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,0 +1,47 @@
+# DECISIONS — Master Plan do Cria do Tatame
+
+**Status:** decisões arquiteturais e de produto congeladas.  
+**Atualizado em:** 2026-07-25  
+**Escopo:** governa a migração incremental do runtime; não substitui o contrato SUPREME nem a ordem de precedência em `docs/DOC_PRECEDENCE.md`.
+
+## D1 — Repositório único
+
+`ringuemkt-rgb/cria-do-tatame` é a fonte única de código, dados, documentação e releases. `Tatamecria` é somente espelho de build e não recebe desenvolvimento.
+
+## D2 — Combate via fachada progressiva
+
+`TransitionManager` é o destino canônico da resolução de transições. `CombatManager` preserva todas as assinaturas públicas legadas e delega ao destino canônico por adapter (Strangler Fig). Não é permitido reescrever autoloads inteiros durante a migração.
+
+## D3 — Um mixer de áudio
+
+`AudioManager` é o único mixer de runtime. `CombatAudio` permanece apenas como módulo ou ponte compatível; não pode criar buses, mixer ou pipeline paralelo.
+
+## D4 — Responsabilidades de mundo separadas
+
+`WorldState` guarda dados; `WorldDirectorManager` gere eventos; `NavigationManager` trata transporte; `WorldMapManager` renderiza o mapa. Esses papéis não devem ser fundidos.
+
+## D5 — Deck canônico
+
+`DeckManager` é a única autoridade do deck. HUD, testes e dados de teste são consumidores; não podem manter um deck paralelo.
+
+## D6 — Schemas em camadas
+
+`technique_catalog_v05` é o catálogo-mestre de técnicas. `combat_deck_schema` é projeção por `technique_id`. Cartas sem referência válida não entram no deck de runtime.
+
+## D7 — Acessibilidade neurodivergente é pilar
+
+Sem-timer, foco, perfil sensorial e narração são requisitos de design. Efeitos de flash, shake e slow-motion devem respeitar o perfil persistido do jogador.
+
+## D8 — Colecionáveis e patches; sem blockchain
+
+Colecionáveis são patches cosméticos sem pay-to-win. Blockchain, NFT, carteira, transação, token de poder e dependência de rede são proibidos no runtime e nos dados novos.
+
+O checkout legado ainda contém nomes incompatíveis (`NFTManager` e `assets/cosmetics/nft/`). Esta decisão não afirma que há integração de blockchain ativa: ela bloqueia qualquer expansão e exige inventário, adapter de compatibilidade, migração de save e remoção segura em lote próprio antes de apagar referências.
+
+## D9 — Escopo do núcleo protegido
+
+O loop de 30 segundos — escolher carta, ameaçar, ler/defender/fintar e sentir o impacto — é prioritário. Facções, clima e expansão de mundo ficam fora do core atual; não devem crescer antes do vertical slice jogável.
+
+## Regra de migração
+
+Toda mudança atravessa adapter/fachada, preserva APIs públicas até os consumidores migrarem, atualiza teste e passa por `tools/audit/audit_boot.py`. Qualquer conflito com a precedência documental deve ser registrado antes da implementação.

--- a/docs/art_bible/OFFICIAL_VISUAL_STANDARD_V1.md
+++ b/docs/art_bible/OFFICIAL_VISUAL_STANDARD_V1.md
@@ -282,7 +282,8 @@ wireframe
 ### Gate de conteúdo
 
 - local e bioma canônicos;
-- nome e função do personagem validados;
+- nome e função do personagem validados; protagonista: `Ruan “Macacão” Silva`;
+- Praia de Pratigi situada em Ituberá – Bahia;
 - exatamente três facções;
 - sem `Caio Ravel` ou `Ruan “Cria” Silva` em shipping;
 - sem pessoa real criminalizada;

--- a/src/autoloads/SaveManager.gd
+++ b/src/autoloads/SaveManager.gd
@@ -37,6 +37,10 @@ func save_game(slot_id := 1) -> bool:
 		data["game_flow_state"] = GameFlowManager.to_dict()
 	if has_node("/root/WorldDirectorManager"):
 		data["world_director_state"] = WorldDirectorManager.to_dict()
+	if has_node("/root/Economy"):
+		data["economy_v4_state"] = Economy.to_dict()
+	if has_node("/root/InformantSystem"):
+		data["informant_state"] = InformantSystem.to_dict()
 	if has_node("/root/NFTManager"):
 		data["nft_state"] = NFTManager.to_dict()
 	if has_node("/root/DeckManager"):
@@ -133,6 +137,10 @@ func load_game(slot_id := 1) -> bool:
 		GameFlowManager.load_from_dict(parsed["game_flow_state"])
 	if has_node("/root/WorldDirectorManager"):
 		WorldDirectorManager.load_from_dict(parsed.get("world_director_state", {}))
+	if parsed.has("economy_v4_state") and has_node("/root/Economy"):
+		Economy.load_from_dict(parsed["economy_v4_state"])
+	if parsed.has("informant_state") and has_node("/root/InformantSystem"):
+		InformantSystem.load_from_dict(parsed["informant_state"])
 	if has_node("/root/NFTManager"):
 		NFTManager.load_from_dict(parsed.get("nft_state", {}))
 	if has_node("/root/DeckManager"):

--- a/src/autoloads/SignalBus.gd
+++ b/src/autoloads/SignalBus.gd
@@ -83,6 +83,17 @@ signal world_economy_changed(multipliers)
 signal world_ai_plan_applied(plan)
 signal world_ai_plan_failed(reason)
 
+# Eventos v4 consolidados aqui porque SignalBus é o único barramento carregado
+# pelo project.godot. SignalBusV4 permanece somente como referência de migração.
+signal economy_balance_changed(currency, balance)
+signal economy_transaction_recorded(transaction)
+signal informant_status_changed(status, state)
+signal informant_evidence_added(record, total)
+signal world_node_unlocked(node_id, reason)
+signal world_travel_completed_v4(from_id, to_id, mode, quote)
+signal terrain_modifiers_changed(tags, modifiers)
+signal ending_resolved_v4(resolution)
+
 signal nft_entitlements_synced(entitlements, source)
 signal nft_entitlement_sync_failed(reason)
 

--- a/src/autoloads/SignalBusV4.gd
+++ b/src/autoloads/SignalBusV4.gd
@@ -1,9 +1,4 @@
 extends "res://src/autoloads/SignalBus.gd"
 
-signal economy_balance_changed(currency, balance)
-signal economy_transaction_recorded(transaction)
-signal informant_status_changed(status, state)
-signal informant_evidence_added(record, total)
-signal world_node_unlocked(node_id, reason)
-signal world_travel_completed_v4(from_id, to_id, mode, quote)
-signal terrain_modifiers_changed(tags, modifiers)
+# Compatibility shell kept for references that still preload SignalBusV4.
+# All v4 signals now live only in the canonical SignalBus autoload.

--- a/src/combat/CombatCommandRouterV41.gd
+++ b/src/combat/CombatCommandRouterV41.gd
@@ -1,9 +1,11 @@
 class_name CombatCommandRouterV41
 extends RefCounted
 
-var combat: PositionalCardCombatV41
+# Keep the router structurally typed during the strangler migration. Using the
+# concrete class_name here made Godot 4.2.2 resolve scripts in an unsafe order.
+var combat: Node
 
-func setup(runtime: PositionalCardCombatV41) -> void:
+func setup(runtime: Node) -> void:
 	combat = runtime
 
 func execute(actor_id: String, command: String, selected_card_id: String = "", quality: float = 0.5) -> Dictionary:
@@ -47,7 +49,7 @@ func _pressure(actor_id: String) -> Dictionary:
 		return {"ok": false, "error": "insufficient_gas"}
 	resources["gas"] = maxf(0.0, float(resources.get("gas", 0.0)) - 10.0)
 	resources["pressao"] = minf(100.0, float(resources.get("pressao", 0.0)) + 14.0)
-	var defender := combat.opponent_id if actor_id == combat.player_id else combat.player_id
+	var defender: String = str(combat.opponent_id if actor_id == combat.player_id else combat.player_id)
 	combat.fighters[defender]["guarda"] = maxf(0.0, float(combat.fighters[defender].get("guarda", 0.0)) - 8.0)
 	combat.call("_emit_snapshot")
 	return {"ok": true, "command": "pressao", "snapshot": combat.snapshot()}

--- a/src/combat/PositionalCardCombatTerrainV41.gd
+++ b/src/combat/PositionalCardCombatTerrainV41.gd
@@ -27,9 +27,9 @@ func play_card(actor_id: String, card_id: String, input_quality: float = 0.5) ->
 		_apply_extra_positional_damage(result, card, input_quality >= 0.55)
 	return result
 
-func generic_transition(actor_id: String) -> Dictionary:
+func generic_transition(actor_id: String, transition_index: int = 0) -> Dictionary:
 	var before_gas := _fighter_gas(actor_id)
-	var result: Dictionary = super.generic_transition(actor_id)
+	var result: Dictionary = super.generic_transition(actor_id, transition_index)
 	if bool(result.get("ok", false)):
 		var spent := maxf(0.0, before_gas - _fighter_gas(actor_id))
 		var multiplier := float(terrain_modifiers.get("gas_cost_mult", 1.0))
@@ -51,7 +51,7 @@ func defend(actor_id: String, defense_id: String, timing_quality: float = 0.5) -
 
 func tick(delta: float) -> void:
 	super.tick(delta)
-	if not active or phase == "finished":
+	if phase in ["ready", "finished"] or player_id == "":
 		return
 	var drain := float(terrain_modifiers.get("focus_drain_per_sec", 0.0)) * delta
 	var regen_mult := float(terrain_modifiers.get("focus_regen_mult", 1.0))
@@ -68,9 +68,8 @@ func get_terrain_contract() -> Dictionary:
 	return {"tags": terrain_tags.duplicate(), "modifiers": terrain_modifiers.duplicate(true), "reduced_flash": reduced_flash}
 
 func _card_by_id(card_id: String) -> Dictionary:
-	for card_value in cards_data.get("cartas", []):
-		if str(card_value.get("id", "")) == card_id:
-			return card_value
+	if cards.has(card_id):
+		return cards[card_id]
 	return {}
 
 func _fighter_gas(actor_id: String) -> float:

--- a/tests/v4_combat_smoke.gd
+++ b/tests/v4_combat_smoke.gd
@@ -16,19 +16,28 @@ func _assert(condition: bool, message: String) -> void:
 
 func _run() -> void:
 	await process_frame
-	_assert(DataRegistry.validation_report.get("ok", false), "DataRegistry deve validar dados v4: %s" % DataRegistry.validation_report.get("errors", []))
-	_assert(DataRegistry.combat_cards_v41.get("cartas", []).size() == 20, "catálogo oficial deve ter 20 cartas")
-	_assert(DataRegistry.combat_positions_v41.get("posicoes", {}).size() == 8, "FSM oficial deve ter 8 posições")
-	_assert(DataRegistry.combat_rulesets_v41.get("rulesets", {}).size() == 6, "DataRegistry deve carregar 6 rulesets")
-	_assert(CombatManager.has_method("start_positional_combat_v41"), "CombatManager oficial não expõe modo v4.1")
-	_assert(CombatManager.has_method("start_combat"), "API legada do CombatManager foi perdida")
+	var data_registry: Node = root.get_node_or_null("DataRegistry")
+	var combat_manager: Node = root.get_node_or_null("CombatManager")
+	_assert(data_registry != null, "autoload DataRegistry deve existir no smoke")
+	_assert(combat_manager != null, "autoload CombatManager deve existir no smoke")
+	if data_registry == null or combat_manager == null:
+		print("[V4CombatSmoke] %d verificações, %d falhas" % [checks, failures.size()])
+		quit(1)
+		return
+
+	_assert(data_registry.validation_report.get("ok", false), "DataRegistry deve validar dados v4: %s" % data_registry.validation_report.get("errors", []))
+	_assert(data_registry.combat_cards_v41.get("cartas", []).size() == 20, "catálogo oficial deve ter 20 cartas")
+	_assert(data_registry.combat_positions_v41.get("posicoes", {}).size() == 8, "FSM oficial deve ter 8 posições")
+	_assert(data_registry.combat_rulesets_v41.get("rulesets", {}).size() == 6, "DataRegistry deve carregar 6 rulesets")
+	_assert(combat_manager.has_method("start_positional_combat_v41"), "CombatManager oficial não expõe modo v4.1")
+	_assert(combat_manager.has_method("start_combat"), "API legada do CombatManager foi perdida")
 
 	var deck := [
 		"grip_de_ferro", "baiana", "guarda_fechada", "raspagem_tesoura",
 		"knee_cut_pass", "cem_quilos", "montada", "kimura",
 		"triangulo", "mata_leao", "grip_de_ferro", "baiana",
 	]
-	var start_result: Dictionary = CombatManager.start_positional_combat_v41(
+	var start_result: Dictionary = combat_manager.start_positional_combat_v41(
 		"terreiro_da_luta",
 		"ruan_macacao",
 		"davi_relampago",
@@ -37,36 +46,36 @@ func _run() -> void:
 		deck
 	)
 	_assert(bool(start_result.get("ok", false)), "combate v4.1 oficial deve iniciar: %s" % start_result)
-	var first_snapshot: Dictionary = CombatManager.get_positional_snapshot_v41()
+	var first_snapshot: Dictionary = combat_manager.get_positional_snapshot_v41()
 	_assert(str(first_snapshot.get("position", "")) == "STANDING", "combate inicia em STANDING")
-	_assert(str(CombatManager.get_current_state_name()) == "PLAYER_STANDING_NEUTRAL", "estado v4 deve sincronizar a máquina legada")
-	var hand: Array = CombatManager.get_contextual_hand_v41("ruan_macacao")
+	_assert(str(combat_manager.get_current_state_name()) == "PLAYER_STANDING_NEUTRAL", "estado v4 deve sincronizar a máquina legada")
+	var hand: Array = combat_manager.get_contextual_hand_v41("ruan_macacao")
 	_assert(not hand.is_empty(), "mão contextual oficial não pode estar vazia")
 	_assert(hand.size() <= 3, "mão contextual não pode ultrapassar três cartas")
 
-	var select_result: Dictionary = CombatManager.select_card_v41("grip_de_ferro")
+	var select_result: Dictionary = combat_manager.select_card_v41("grip_de_ferro")
 	_assert(bool(select_result.get("ok", false)), "Grip de Ferro deve ser selecionável em STANDING")
-	var transition_result: Dictionary = CombatManager.execute_command_v41("ruan_macacao", "transicao", "", 1.0)
+	var transition_result: Dictionary = combat_manager.execute_command_v41("ruan_macacao", "transicao", "", 1.0)
 	_assert(bool(transition_result.get("ok", false)), "TRANSIÇÃO deve jogar a carta selecionada")
-	var clinch_snapshot: Dictionary = CombatManager.get_positional_snapshot_v41()
+	var clinch_snapshot: Dictionary = combat_manager.get_positional_snapshot_v41()
 	_assert(str(clinch_snapshot.get("position", "")) == "CLINCH", "Grip de Ferro deve levar ao CLINCH")
-	_assert(str(CombatManager.get_current_state_name()).begins_with("PLAYER_TOP_CLINCH"), "CLINCH v4 deve sincronizar estado legado")
+	_assert(str(combat_manager.get_current_state_name()).begins_with("PLAYER_TOP_CLINCH"), "CLINCH v4 deve sincronizar estado legado")
 
 	var grip_before := float(clinch_snapshot.get("fighters", {}).get("ruan_macacao", {}).get("grip", 0.0))
-	var grip_result: Dictionary = CombatManager.execute_command_v41("ruan_macacao", "grip", "", 0.8)
+	var grip_result: Dictionary = combat_manager.execute_command_v41("ruan_macacao", "grip", "", 0.8)
 	_assert(bool(grip_result.get("ok", false)), "comando GRIP deve funcionar pelo CombatManager")
-	var grip_after := float(CombatManager.get_positional_snapshot_v41().get("fighters", {}).get("ruan_macacao", {}).get("grip", 0.0))
+	var grip_after := float(combat_manager.get_positional_snapshot_v41().get("fighters", {}).get("ruan_macacao", {}).get("grip", 0.0))
 	_assert(grip_after > grip_before, "GRIP deve aumentar o nível de pegada")
 
-	var exported: Dictionary = CombatManager.export_v41_state()
+	var exported: Dictionary = combat_manager.export_v41_state()
 	_assert(exported.has("hub"), "CombatManager deve exportar estado persistível do Hub")
 	_assert(exported.get("hub", {}).get("loadouts", {}).get("ruan_macacao", []).size() == 12, "loadout v4.1 deve persistir 12 cartas")
 
 	var adapter_report: Dictionary = PositionalAdapterScript.validate_contract()
 	_assert(bool(adapter_report.get("ok", false)), "adapter legado deve cobrir as 8 posições")
 
-	CombatManager.stop_positional_mode_v41()
-	var legacy_result: Dictionary = CombatManager.start_combat("terreiro_da_luta", "ruan_macacao", "davi_relampago")
+	combat_manager.stop_positional_mode_v41()
+	var legacy_result: Dictionary = combat_manager.start_combat("terreiro_da_luta", "ruan_macacao", "davi_relampago")
 	_assert(bool(legacy_result.get("ok", false)), "modo legado deve continuar iniciando após a extensão v4.1")
 	_assert(str(legacy_result.get("state", "")) == "PLAYER_STANDING_NEUTRAL", "modo legado deve manter estado inicial")
 

--- a/tools/audit/audit_boot.py
+++ b/tools/audit/audit_boot.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+import glob
+import json
+import os
+import re
+import sys
+
+ROOT = sys.argv[1] if len(sys.argv) > 1 else os.getcwd()
+PROJECT = os.path.join(ROOT, "project.godot")
+report = {
+    "autoloads": [],
+    "missing": [],
+    "scenes_refs_missing": [],
+    "main_scene": None,
+    "ok": True,
+}
+
+
+def read(path):
+    try:
+        with open(path, encoding="utf-8") as handle:
+            return handle.read()
+    except Exception:
+        return ""
+
+
+godot = read(PROJECT)
+match = re.search(r'run/main_scene\s*=\s*"([^"]+)"', godot)
+if match:
+    report["main_scene"] = match.group(1)
+    if not os.path.exists(os.path.join(ROOT, match.group(1).replace("res://", ""))):
+        report["missing"].append(("main_scene", match.group(1)))
+        report["ok"] = False
+
+in_autoload = False
+for line in godot.splitlines():
+    if line.strip() == "[autoload]":
+        in_autoload = True
+        continue
+    if line.startswith("[") and line.strip() != "[autoload]":
+        in_autoload = False
+    if in_autoload and "=" in line:
+        name, value = line.split("=", 1)
+        path_match = re.search(r'"?\*?res://([^"]+)"?', value.strip())
+        if path_match:
+            exists = os.path.exists(os.path.join(ROOT, path_match.group(1)))
+            report["autoloads"].append(
+                {"name": name.strip(), "path": path_match.group(1), "exists": exists}
+            )
+            if not exists:
+                report["missing"].append(("autoload", name.strip(), path_match.group(1)))
+                report["ok"] = False
+
+for scene in glob.glob(os.path.join(ROOT, "**", "*.tscn"), recursive=True):
+    for ref in re.findall(r'path="res://([^"]+)"', read(scene)):
+        if not os.path.exists(os.path.join(ROOT, ref)):
+            report["scenes_refs_missing"].append(
+                {"scene": os.path.relpath(scene, ROOT), "ref": ref}
+            )
+            report["ok"] = False
+
+print(json.dumps(report, indent=2, ensure_ascii=False))
+sys.exit(0 if report["ok"] and not report["scenes_refs_missing"] else 1)

--- a/tools/validate_runtime_contracts.py
+++ b/tools/validate_runtime_contracts.py
@@ -28,11 +28,11 @@ REQUIRED_SCENES = {
 
 REQUIRED_AUTOLOADS = {
     "SignalBus": "src/autoloads/SignalBus.gd",
-    "DataRegistry": "src/autoloads/DataRegistry.gd",
+    "DataRegistry": "src/autoloads/DataRegistryV4.gd",
     "DeckManager": "src/autoloads/DeckManager.gd",
-    "WorldState": "src/autoloads/WorldState.gd",
+    "WorldState": "src/autoloads/WorldStateV4.gd",
     "SaveManager": "src/autoloads/SaveManager.gd",
-    "CombatManager": "src/autoloads/CombatManager.gd",
+    "CombatManager": "src/autoloads/CombatManagerV41.gd",
     "CareerLoop": "src/autoloads/CareerLoop.gd",
     "GameFlowManager": "src/autoloads/GameFlowManager.gd",
     "AudioManager": "src/autoloads/AudioManager.gd",
@@ -278,7 +278,12 @@ def validate_scene_scripts(result: dict[str, list[str]]) -> None:
         "scenes/hubs/TerreiroDaLuta.gd": ["_on_train", "_on_fight_davi", "_on_save"],
         "scenes/combat/CombatArenaBase.gd": ["_refresh_action_buttons", "_on_combat_finished"],
         "scenes/result/ResultScreen.gd": ["_on_cria_live_pressed", "_on_back_pressed"],
-        "src/autoloads/CombatManager.gd": ["start_combat", "apply_player_action", "finish_combat", "get_available_techniques"],
+        "src/autoloads/CombatManagerV41.gd": [
+            "start_positional_combat_v41",
+            "play_card_v41",
+            "defend_v41",
+            "resolve_submission_v41",
+        ],
         "src/autoloads/SaveManager.gd": ["save_game", "load_game", "has_save"],
     }
     for rel, methods in contracts.items():


### PR DESCRIPTION
## EPIC 0 — Fundação & Governança

Reconcilia o stack documental v4 pela base de marca #35 e instala o gate de boot.

### Entregas
- `docs/DECISIONS.md` fixa D1–D9 e registra a migração segura de referências NFT legadas.
- `tools/audit/audit_boot.py` verifica cena principal, 28 autoloads e recursos de cenas.
- Workflow **Boot Graph Audit** executa o gate em push/PR.
- O validador de runtime passa a conferir as fachadas V4 realmente configuradas em `project.godot`.
- Eventos V4 declarados no barramento ativo e estado de Economy/Informant persistido no save.
- Corrige duas lacunas textuais do padrão visual que impediam seu validador.

### Validação
- `python tools/audit/audit_boot.py .` → `ok: true`
- `npm run quality` → verde
- `pytest -q` → 49 passed

### Limites e riscos
- Este PR não remove o runtime NFT legado: D8 bloqueia expansão e exige migração de save/adapter em lote próprio.
- #34 permanece PR paralelo sobre #32; esta branch é baseada em #35 para respeitar o stack documental.

Rollback: `git revert 025c6121a0766bbc2dd0ef52295ab20e406a51ec`.