### PR TITLE
feat(visual): adicionar CRIA Visual Forge v1.0

### DIFF
--- a/.github/workflows/visual-forge-quality.yml
+++ b/.github/workflows/visual-forge-quality.yml
@@ -1,0 +1,37 @@
+name: Visual Forge Quality
+on:
+  push:
+    paths:
+      - 'data/visual/**'
+      - 'tools/visual_forge_v10/**'
+      - 'src/tools/VisualAssetRegistry.gd'
+      - 'docs/production/CRIA_VISUAL_FORGE_V10.md'
+  workflow_dispatch:
+jobs:
+  build-queue:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Build canonical visual queue
+        run: python tools/visual_forge_v10/build_visual_queue.py
+      - name: Validate generated JSONL
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          path = Path('data/visual/generated/visual_jobs_v10.jsonl')
+          rows = [json.loads(line) for line in path.read_text(encoding='utf-8').splitlines() if line.strip()]
+          assert rows, 'visual queue is empty'
+          assert len({row['job_id'] for row in rows}) == len(rows), 'duplicate job_id'
+          required = {'job_id','asset_type','subject_id','variant','status','output','prompt_contract','qa_gates'}
+          for row in rows:
+              assert required.issubset(row), row
+          print(f'validated {len(rows)} visual jobs')
+          PY
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cria-visual-jobs-v10
+          path: data/visual/generated/visual_jobs_v10.jsonl

--- a/data/visual/visual_forge_config_v10.json
+++ b/data/visual/visual_forge_config_v10.json
@@ -1,0 +1,59 @@
+{
+  "schema_version": 1,
+  "project": "cria_do_tatame_pressao",
+  "engine": "Godot 4.3+",
+  "platforms": ["android_arm64", "windows_x86_64", "web"],
+  "canon": {
+    "protagonist": "ruan_macacao",
+    "region": "Baixo Sul da Bahia",
+    "tagline": "De cria pra cria. Luta. Disciplina. Evolução.",
+    "faccoes": ["la_ele_mil_vezes", "nos_tem_um_molho", "os_aleluiados"]
+  },
+  "style": {
+    "name": "Pixel Art 16-bit 2.5D Regional Premium",
+    "rules": [
+      "contorno preto grosso e consistente",
+      "cel-shading legível",
+      "rim light dourado controlado",
+      "grade de pixel visível",
+      "sem fotografia, 3D ou cartoon infantil",
+      "silhueta legível em 2 segundos",
+      "sem texto incorporado salvo quando o job exigir",
+      "sem marcas reais ou pessoa real"
+    ],
+    "palette": {
+      "black": "#0A0A0A",
+      "charcoal": "#1A1A1A",
+      "burnished_gold": "#B8860B",
+      "honor_yellow": "#F2C230",
+      "dirty_white": "#F2F2F2",
+      "conflict_red": "#D92323",
+      "river_blue": "#1E3A5F",
+      "mangrove_green": "#2D5016",
+      "shadow_purple": "#4B0082"
+    }
+  },
+  "dimensions": {
+    "combat_frame": [256, 256],
+    "hub_frame": [128, 128],
+    "portrait": [1024, 1024],
+    "technique_icon": [256, 256],
+    "technique_card": [768, 1024],
+    "arena_layer": [1920, 1080],
+    "ui_reference": [1920, 1080],
+    "marketing_key_art": [3840, 2160]
+  },
+  "anchors": {
+    "combat": "bottom_center",
+    "hub": "bottom_center",
+    "portrait": "center"
+  },
+  "quality_gates": {
+    "required_character_files": ["spritesheet.png", "frames", "preview.gif", "contact_sheet.png", "metadata.json", "qa_report.json"],
+    "required_arena_files": ["bg_far.png", "bg_mid.png", "play_area.png", "foreground.png", "overlay_particles.png", "collision.json", "camera_bounds.json", "metadata.json"],
+    "min_alpha_coverage": 0.01,
+    "max_alpha_coverage": 0.85,
+    "forbid_generic_names": ["image1.png", "new_sprite.png", "final_final.png"],
+    "mobile_safe_area_percent": 7
+  }
+}

--- a/docs/production/CRIA_VISUAL_FORGE_V10.md
+++ b/docs/production/CRIA_VISUAL_FORGE_V10.md
@@ -1,0 +1,109 @@
+# CRIA VISUAL FORGE v1.0 — Sistema Mestre de Produção Gráfica
+
+## 1. Missão
+
+Converter o cânone do **Cria do Tatame** em material visual implementável, versionado e testável. O sistema não entrega apenas pranchas bonitas: entrega arquivos com dimensões, pivôs, camadas, metadados, hashes, licença, preview, importação e QA.
+
+## 2. Contrato de produção
+
+```text
+briefing canônico
+-> job estruturado
+-> seed aprovado
+-> faixa completa em uma geração
+-> normalização por âncora compartilhada
+-> preview GIF/contact sheet
+-> QA automático + revisão humana
+-> catálogo runtime
+-> importação Godot
+```
+
+## 3. Hierarquia de verdade
+
+1. Cânone mais recente do repositório.
+2. `visual_forge_config_v10.json`.
+3. `production_manifest_v02.json`.
+4. Job individual.
+5. Prompt de geração.
+
+Prompts nunca podem alterar protagonista, facções, paleta, silhueta ou função mecânica.
+
+## 4. Famílias de assets
+
+### Personagens
+
+- portrait 1024²;
+- turnaround;
+- sprites de hub 8 direções;
+- fighter core;
+- clinch;
+- chão;
+- técnicas pareadas;
+- reações, vitória e derrota;
+- metadata, pivô, eventos e hitbox references.
+
+### Técnicas
+
+Cada técnica precisa de:
+
+- ícone 256²;
+- card art 768×1024;
+- thumbnail;
+- sequência pareada;
+- `sync_map.json`;
+- `hitbox.json`;
+- nota segura de representação;
+- VFX e SFX keys.
+
+### Arenas
+
+Cada variante precisa de:
+
+- `bg_far.png`;
+- `bg_mid.png`;
+- `play_area.png`;
+- `foreground.png`;
+- `overlay_particles.png`;
+- `collision.json`;
+- `camera_bounds.json`;
+- preview composto;
+- cena `.tscn`.
+
+### UI
+
+A UI deve manter o centro do combate limpo, safe area de 7% no Android, botões de ação com mínimo de 80 px e contraste AA/AAA sempre que possível.
+
+### VFX
+
+VFX ficam separados dos sprites. Isso permite reduzir partículas, shaders e resolução no mobile sem substituir o personagem.
+
+## 5. Produção de sprites
+
+A produção quadro a quadro isolada é proibida por padrão, porque gera deriva. A sequência completa deve ser gerada em uma única faixa, usando um seed aprovado, mesma direção, mesma escala e fundo transparente. Depois o normalizador aplica uma escala compartilhada e âncora inferior central.
+
+## 6. Quality gates
+
+- silhueta reconhecível em escala de jogo;
+- proporções estáveis;
+- alpha limpo;
+- nenhum frame vazio;
+- contato com chão constante;
+- ação tecnicamente compreensível;
+- sem marca real, pessoa real ou cópia de frame protegido;
+- paleta e contraste conformes;
+- nomes ASCII snake_case;
+- hash e licença registrados;
+- preview aprovado antes do runtime.
+
+## 7. Estados
+
+- `queued`: job criado;
+- `generated`: saída bruta existe;
+- `normalized`: frames e dimensões padronizados;
+- `qa_pass`: automação aprovada;
+- `approved`: direção humana aprovou;
+- `qa_fail`: bloqueado, sem importação.
+
+## 8. Critério de finalização
+
+Um personagem não está pronto por possuir concept art. Está pronto quando o pacote visual exigido existe, passa QA, possui catálogo e funciona no Godot. A mesma regra vale para técnica, arena, HUD e VFX.

--- a/src/tools/VisualAssetRegistry.gd
+++ b/src/tools/VisualAssetRegistry.gd
@@ -1,0 +1,34 @@
+extends Node
+class_name VisualAssetRegistry
+
+const CATALOG_PATH := "res://data/visual/runtime_visual_catalog_v1.json"
+var entries: Dictionary = {}
+
+func load_catalog(path: String = CATALOG_PATH) -> bool:
+    if not FileAccess.file_exists(path):
+        push_warning("Visual catalog not found: %s" % path)
+        return false
+    var file := FileAccess.open(path, FileAccess.READ)
+    var parsed: Variant = JSON.parse_string(file.get_as_text())
+    if typeof(parsed) != TYPE_DICTIONARY:
+        push_error("Invalid visual catalog JSON")
+        return false
+    entries.clear()
+    for item in parsed.get("entries", []):
+        entries[item.get("asset_id", "")] = item
+    return true
+
+func has_asset(asset_id: String) -> bool:
+    return entries.has(asset_id)
+
+func get_asset(asset_id: String) -> Dictionary:
+    return entries.get(asset_id, {})
+
+func get_file_path(asset_id: String, file_key: String) -> String:
+    var item: Dictionary = get_asset(asset_id)
+    if item.is_empty():
+        return ""
+    var rel: String = item.get("files", {}).get(file_key, "")
+    if rel.is_empty():
+        return ""
+    return "res://%s/%s" % [item.get("base_path", ""), rel]

--- a/tools/visual_forge_v10/build_visual_queue.py
+++ b/tools/visual_forge_v10/build_visual_queue.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Build the canonical Cria Visual Forge production queue.
+
+Reads the existing production manifest and emits deterministic JSONL jobs for
+characters, signatures, techniques, arenas, UI and audio-adjacent VFX.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+CONFIG = ROOT / "data" / "visual" / "visual_forge_config_v10.json"
+MANIFEST = ROOT / "data" / "visual" / "production_manifest_v02.json"
+OUTPUT = ROOT / "data" / "visual" / "generated" / "visual_jobs_v10.jsonl"
+
+
+def read(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def job(asset_type: str, subject_id: str, variant: str, output: dict[str, Any], must_preserve: list[str], qa: list[str]) -> dict[str, Any]:
+    return {
+        "job_id": "__".join([asset_type, subject_id, variant]).replace(" ", "_").lower(),
+        "asset_type": asset_type,
+        "subject_id": subject_id,
+        "variant": variant,
+        "status": "queued",
+        "output": output,
+        "prompt_contract": {
+            "must_preserve": must_preserve,
+            "negative": [
+                "photography",
+                "3D render",
+                "cartoon infantil",
+                "pessoa real",
+                "marca real",
+                "blur",
+                "texto longo incorporado",
+                "deriva anatômica"
+            ]
+        },
+        "qa_gates": qa
+    }
+
+
+def build() -> list[dict[str, Any]]:
+    config = read(CONFIG)
+    manifest = read(MANIFEST)
+    dims = config["dimensions"]
+    profiles = manifest["animation_profiles"]
+    jobs: list[dict[str, Any]] = []
+
+    for character in manifest["characters"]:
+        cid = character["id"]
+        jobs.append(job(
+            "character_portrait", cid, "default",
+            {"size": dims["portrait"], "transparent": True, "anchor": "center"},
+            ["identidade", "silhueta", "roupa", "função narrativa"],
+            ["canon_identity", "transparent_background", "mobile_readability", "palette_compliance"]
+        ))
+        seen: set[str] = set()
+        for profile in character["profiles"]:
+            for animation in profiles[profile]:
+                if animation in seen:
+                    continue
+                seen.add(animation)
+                jobs.append(job(
+                    "character_animation", cid, animation,
+                    {"frame_count": 8, "frame_size": dims["combat_frame"], "transparent": True, "anchor": "bottom_center"},
+                    ["mesmo personagem", "mesma direção", "mesma escala", "mesma paleta", "faixa inteira em uma geração"],
+                    ["stable_proportions", "shared_anchor", "transparent_background", "clear_action", "no_frame_drift"]
+                ))
+        for signature in character.get("signature", []):
+            jobs.append(job(
+                "paired_technique", cid, signature,
+                {"frame_count": 12, "frame_size": dims["combat_frame"], "transparent": True, "anchor": "bottom_center", "paired": True},
+                ["atacante canônico", "oponente adulto neutro", "representação segura", "contato legível", "sincronização pareada"],
+                ["bjj_coherence", "paired_sync", "safe_representation", "shared_anchor"]
+            ))
+
+    for technique in manifest["paired_techniques"]:
+        tid = technique["id"]
+        jobs.append(job(
+            "technique_icon", tid, "default",
+            {"size": dims["technique_icon"], "transparent": True},
+            ["uma silhueta técnica", "sem texto", "leitura em 48 px"],
+            ["icon_readability_48px", "transparent_background", "palette_compliance"]
+        ))
+        jobs.append(job(
+            "technique_card", tid, "default",
+            {"size": dims["technique_card"], "transparent": False, "text_reserved": True},
+            ["ação focal", "zona de título vazia", "zona de estatísticas vazia", "sem copy incorporada"],
+            ["composition", "reserved_text_zones", "safe_representation", "palette_compliance"]
+        ))
+
+    for arena in manifest["arenas"]:
+        for variant in arena["variants"]:
+            for layer, transparent in [
+                ("bg_far", False), ("bg_mid", True), ("play_area", True),
+                ("foreground", True), ("overlay_particles", True)
+            ]:
+                jobs.append(job(
+                    "arena_layer", arena["id"], f"{variant}_{layer}",
+                    {"size": dims["arena_layer"], "transparent": transparent, "layer": layer},
+                    ["Baixo Sul", "parallax separado", "área de combate limpa", "horizonte consistente", "sem texto"],
+                    ["parallax_separation", "horizon_consistency", "mobile_readability", "palette_compliance"]
+                ))
+
+    for screen in manifest["ui_screens"]:
+        jobs.append(job(
+            "ui_screen", screen, "landscape_16_9",
+            {"size": dims["ui_reference"], "safe_area_percent": config["quality_gates"]["mobile_safe_area_percent"]},
+            ["centro limpo", "touch targets grandes", "contraste AA", "painéis modulares", "texto no Godot"],
+            ["safe_area", "touch_target_80px", "contrast", "one_second_readability"]
+        ))
+
+    OUTPUT.parent.mkdir(parents=True, exist_ok=True)
+    with OUTPUT.open("w", encoding="utf-8") as file:
+        for item in jobs:
+            file.write(json.dumps(item, ensure_ascii=False) + "\n")
+    return jobs
+
+
+if __name__ == "__main__":
+    queue = build()
+    print(f"Visual queue generated: {len(queue)} jobs -> {OUTPUT}")


### PR DESCRIPTION
## Entrega

Adiciona o sistema profissional de produção gráfica do Cria do Tatame.

### Incluído
- contrato mestre de produção visual;
- configuração canônica de estilo, dimensões, paleta e quality gates;
- gerador determinístico de fila JSONL baseado no manifesto visual existente;
- registry runtime para localizar assets no Godot;
- workflow de CI que gera e valida a fila visual.

### Fluxo

`canon -> catálogo -> jobs -> geração -> normalização -> QA -> catálogo runtime -> Godot`

### Regras protegidas
- Ruan Macacão permanece protagonista;
- três facções canônicas preservadas;
- Pixel Art 16-bit 2.5D Regional Premium;
- sem pessoa real, marca real, fotografia, 3D ou cartoon infantil;
- UI mobile-first com safe area de 7% e touch targets grandes;
- sprite strip gerado como faixa completa para evitar deriva.

### Validação esperada
O workflow `Visual Forge Quality` gera `data/visual/generated/visual_jobs_v10.jsonl`, verifica IDs únicos e contratos obrigatórios e publica o arquivo como artifact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a visual asset registry for loading catalogs, checking availability, and resolving asset files.
  * Added automated generation of standardized visual production jobs and metadata.
  * Added visual configuration covering supported platforms, art direction, asset standards, and quality checks.

* **Documentation**
  * Added production guidance for the visual asset pipeline, including QA, accessibility, licensing, and import requirements.

* **Chores**
  * Added automated validation and artifact publishing for generated visual queues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->