### PR TITLE
fix(runtime): restaurar smoke verde na main

### DIFF
--- a/.github/workflows/runtime-audit.yml
+++ b/.github/workflows/runtime-audit.yml
@@ -63,7 +63,7 @@ jobs:
         shell: bash
         run: |
           set -o pipefail
-          ./godot --headless --editor --path . --quit 2>&1 | tee reports/runtime_audit/godot_import.log
+          timeout 180 ./godot --headless --editor --path . --import 2>&1 | tee reports/runtime_audit/godot_import.log
 
       - name: Run runtime smoke suite
         shell: bash

--- a/src/characters/FighterPlaceholder.gd
+++ b/src/characters/FighterPlaceholder.gd
@@ -1,7 +1,7 @@
 extends Node2D
 class_name FighterPlaceholder
 
-const AnimationLibrary = preload("res://src/animation/CharacterAnimationLibrary.gd")
+const CharacterAnimationFactory = preload("res://src/animation/CharacterAnimationLibrary.gd")
 
 @export var fighter_id := "ruan_macacao"
 @export var display_name := "Ruan Macacao"
@@ -69,7 +69,7 @@ func _load_clip(action: String) -> bool:
 	var path := _manifest_path(action)
 	if not FileAccess.file_exists(path):
 		return false
-	var frames: SpriteFrames = AnimationLibrary.build_sprite_frames(path)
+	var frames: SpriteFrames = CharacterAnimationFactory.build_sprite_frames(path)
 	if not frames.has_animation(action) or frames.get_frame_count(action) == 0:
 		return false
 	animated_sprite.sprite_frames = frames


### PR DESCRIPTION
## Objetivo

Corrigir dois bloqueadores P0 já presentes na `main` e revelados pela auditoria do PR #39.

## Problemas confirmados

1. `FighterPlaceholder.gd` declarava `AnimationLibrary` como constante, sombreando a classe nativa do Godot 4.2.2 e quebrando a compilação da arena.
2. O workflow executava o smoke antes de concluir a importação dos PNGs; por isso `ResourceLoader.exists()` não reconhecia o atlas idle do Ruan, embora o arquivo estivesse versionado.

## Correções

- renomeia a constante para `CharacterAnimationFactory`;
- usa `--import` com timeout de 180 segundos antes do smoke;
- não altera gameplay, dados, save ou assets.

## Evidência anterior

O run do PR #39 registrou:

```text
Parse Error: The member "AnimationLibrary" shadows a native class.
[RuntimeSmoke] FAIL: Atlas idle de Ruan nao existe
```

## Validação esperada

- import/parser Godot 4.2.2;
- `runtime_smoke.gd` com zero falhas;
- pipelines antigos sem regressão.

## Ordem de merge

Este PR deve ser mesclado antes do PR #39. Depois, o PR de governança deve atualizar sua base e repetir os checks.