### PR TITLE
chore(sync): atualizar governança com a main corrigida

### DIFF
--- a/.github/workflows/runtime-audit.yml
+++ b/.github/workflows/runtime-audit.yml
@@ -63,7 +63,7 @@ jobs:
         shell: bash
         run: |
           set -o pipefail
-          ./godot --headless --editor --path . --quit 2>&1 | tee reports/runtime_audit/godot_import.log
+          timeout 180 ./godot --headless --editor --path . --import 2>&1 | tee reports/runtime_audit/godot_import.log
 
       - name: Run runtime smoke suite
         shell: bash

--- a/src/characters/FighterPlaceholder.gd
+++ b/src/characters/FighterPlaceholder.gd
@@ -1,7 +1,7 @@
 extends Node2D
 class_name FighterPlaceholder
 
-const AnimationLibrary = preload("res://src/animation/CharacterAnimationLibrary.gd")
+const CharacterAnimationFactory = preload("res://src/animation/CharacterAnimationLibrary.gd")
 
 @export var fighter_id := "ruan_macacao"
 @export var display_name := "Ruan Macacao"
@@ -69,7 +69,7 @@ func _load_clip(action: String) -> bool:
 	var path := _manifest_path(action)
 	if not FileAccess.file_exists(path):
 		return false
-	var frames: SpriteFrames = AnimationLibrary.build_sprite_frames(path)
+	var frames: SpriteFrames = CharacterAnimationFactory.build_sprite_frames(path)
 	if not frames.has_animation(action) or frames.get_frame_count(action) == 0:
 		return false
 	animated_sprite.sprite_frames = frames


### PR DESCRIPTION
Sincroniza `chore/repository-professionalization-v1` com a `main` após o merge do PR #40. Não adiciona escopo novo; apenas incorpora a correção de runtime e o ajuste do workflow para permitir nova validação completa do PR #39.