### PR TITLE
docs(v4): fixar cânone e contratos executáveis do lote V4.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,11 +8,13 @@ Antes de criar, editar, apagar, mover ou integrar qualquer arquivo:
 
 1. leia `README.md`;
 2. leia `docs/REPOSITORY_GOVERNANCE.md`;
-3. leia `docs/ROADMAP.md`;
-4. leia `docs/INDEX.md` e a fonte canônica da área;
-5. consulte `data/production/supreme_build_contract_v01.json`;
-6. procure implementação, issue ou PR equivalente;
-7. defina um lote vertical pequeno, testável e reversível.
+3. leia `docs/DECISIONS.md`;
+4. leia `docs/ROADMAP.md`;
+5. leia `docs/INDEX.md` e a fonte canônica da área;
+6. consulte `data/production/canon_contract_v4_1.json`;
+7. consulte `data/production/supreme_build_contract_v01.json`;
+8. procure implementação, issue ou PR equivalente;
+9. defina um lote vertical pequeno, testável e reversível.
 
 Não comece implementando apenas porque a solicitação parece clara. Primeiro confirme a posição da tarefa na arquitetura e no roadmap.
 
@@ -46,7 +48,9 @@ O repositório não é galeria de prompts, depósito de concept art ou cemitéri
 - estilo: pressão, grip de ferro e top game dominante;
 - poder: Silverback Grip;
 - frase eixo: Ser forte é ser gentil;
-- facções ativas do cânone v4: LEM, NTM e ALE.
+- facções ativas do cânone v4: LEM, NTM e ALE;
+- nome de exibição de ALE: **Os Aleluiado**;
+- ID legado `os_aleluia` é alias de migração e não deve ser renomeado em lugar.
 
 Caio Ravel, Ruan “Cria” e uma quarta facção ativa são bloqueados em shipping.
 
@@ -55,7 +59,7 @@ Caio Ravel, Ruan “Cria” e uma quarta facção ativa são bloqueados em shipp
 Quando houver conflito:
 
 1. contratos executáveis em `data/production/` e contratos canônicos mais recentes;
-2. `docs/canon/` e decisões aprovadas;
+2. `docs/DECISIONS.md`, `docs/canon/` e decisões aprovadas;
 3. runtime, cenas e dados realmente consumidos;
 4. `docs/REPOSITORY_GOVERNANCE.md` e este arquivo;
 5. documentação técnica ativa;

--- a/data/factions.json
+++ b/data/factions.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.3.0",
+  "version": "0.3.1",
   "language": "pt-BR",
   "design_note": "Faccoes 100% ficcionais. Crime e corrupcao aparecem como consequencia narrativa, nao como tutorial operacional nem glorificacao.",
   "factions": [
@@ -40,7 +40,7 @@
     },
     {
       "id": "os_aleluia",
-      "name": "Os Aleluia",
+      "name": "Os Aleluiado",
       "axis": "honra_sombra",
       "tagline": "Fe, Disciplina e Honra",
       "colors": ["azul", "dourado", "branco"],

--- a/data/production/canon_contract_v4_1.json
+++ b/data/production/canon_contract_v4_1.json
@@ -1,0 +1,68 @@
+{
+  "schema_version": "4.1.0",
+  "contract_id": "cria_do_tatame_canon_v4_1",
+  "status": "canonical_contract",
+  "effective_date": "2026-08-01",
+  "source_repository": "ringuemkt-rgb/cria-do-tatame",
+  "integration_source_pr": 32,
+  "integration_policy": {
+    "monolithic_merge_forbidden": true,
+    "port_in_small_batches": true,
+    "stable_runtime_must_remain_bootable": true
+  },
+  "runtime_authorities": {
+    "combat": "CombatManager",
+    "deck": "DeckManager",
+    "audio": "AudioManager",
+    "world_state": "WorldState",
+    "world_events": "WorldDirectorManager",
+    "world_map": "WorldMapManager"
+  },
+  "active_factions_future_domain": [
+    {
+      "id": "LEM",
+      "display_name": "Lá Ele Mil Vezes",
+      "legacy_ids": ["la_ele_mil_vezes"]
+    },
+    {
+      "id": "NTM",
+      "display_name": "Nós Tem Um Molho",
+      "legacy_ids": ["nos_tem_um_molho"]
+    },
+    {
+      "id": "ALE",
+      "display_name": "Os Aleluiado",
+      "legacy_ids": ["os_aleluia"]
+    }
+  ],
+  "legacy_domain_policy": {
+    "stable_ids_must_not_be_renamed_in_place": true,
+    "aliases_are_migration_only": true,
+    "legacy_catalog_may_temporarily_contain_non_faction_domains": true,
+    "runtime_three_faction_migration_deferred_to_v4_2": true
+  },
+  "non_faction_domains": {
+    "institutions": ["circuito_oficial", "cria_live"],
+    "community_or_narrative": ["terreiro", "raiz", "atalhos"],
+    "retired_lore": ["dragao_vermelho", "fantasma"]
+  },
+  "d10": {
+    "canonical_display_name": "Os Aleluiado",
+    "canonical_future_id": "ALE",
+    "preserved_legacy_id": "os_aleluia",
+    "religious_context_must_not_be_rewritten": true,
+    "ambiguous_occurrences_require_human_review": true,
+    "supersedes_source_branch_display": "Os Aleluiados"
+  },
+  "forbidden_in_this_batch": [
+    "project_godot_changes",
+    "autoload_changes",
+    "combat_runtime_changes",
+    "deck_runtime_changes",
+    "audio_runtime_changes",
+    "save_migration",
+    "new_runtime_faction_manager",
+    "new_characters_or_story_acts",
+    "binary_asset_changes"
+  ]
+}

--- a/data/production/repository_governance_v01.json
+++ b/data/production/repository_governance_v01.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "1.0.0",
+  "schema_version": "1.0.1",
   "repository": "ringuemkt-rgb/cria-do-tatame",
   "default_branch": "main",
   "single_source_of_truth": true,
@@ -23,8 +23,10 @@
     ".github/ISSUE_TEMPLATE/work_item.yml",
     ".github/ISSUE_TEMPLATE/config.yml",
     "docs/INDEX.md",
+    "docs/DECISIONS.md",
     "docs/REPOSITORY_GOVERNANCE.md",
     "docs/ROADMAP.md",
+    "data/production/canon_contract_v4_1.json",
     "data/production/release_gate_status_v01.json"
   ],
   "canonical_directories": [
@@ -58,6 +60,16 @@
     "main_scene": "res://scenes/main_menu/MainMenu.tscn",
     "protagonist_id": "ruan_macacao",
     "active_factions": ["LEM", "NTM", "ALE"],
+    "active_faction_display_names": {
+      "LEM": "Lá Ele Mil Vezes",
+      "NTM": "Nós Tem Um Molho",
+      "ALE": "Os Aleluiado"
+    },
+    "legacy_faction_aliases": {
+      "la_ele_mil_vezes": "LEM",
+      "nos_tem_um_molho": "NTM",
+      "os_aleluia": "ALE"
+    },
     "critical_gameplay_offline": true,
     "second_runtime_forbidden": true,
     "secrets_in_repository_forbidden": true

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,0 +1,92 @@
+# Decisões Arquiteturais e Canônicas
+
+**Status:** CANONICAL  
+**Atualizado:** 2026-08-01  
+**Escopo:** integração v4 incremental sobre a `main` estável.
+
+Este registro documenta decisões vinculantes para agentes, revisores e contribuições. Em conflito, prevalecem os contratos executáveis em `data/production/`, seguidos deste documento e das demais fontes conforme a hierarquia definida em `AGENTS.md`.
+
+## D1 — Fonte única
+
+`ringuemkt-rgb/cria-do-tatame` é o único repositório oficial de código, dados, documentação e builds do jogo.
+
+- Não criar segundo runtime, segundo `project.godot` ou frontend concorrente.
+- Repositórios antigos não são espelhos de desenvolvimento nem de build.
+- Trabalho fora da `main` só conta como produto depois de integrado e validado.
+
+## D2 — Combate
+
+O `CombatManager` atual permanece o runtime estável durante a migração v4.
+
+- Não substituir seu corpo por uma fachada reduzida.
+- Não quebrar assinaturas públicas existentes.
+- Funcionalidades v4 entram por adapter e migração incremental de consumidores, com teste de regressão por lote.
+- Um eventual `TransitionManager` não se torna canônico antes de port, integração real e validação.
+
+## D3 — Áudio
+
+`AudioManager` é o único manager de áudio.
+
+Uma ponte de combate só pode ser adicionada depois de existir contrato explícito para eventos, buses, layers e volumes. Nenhum segundo mixer ou singleton de áudio pode competir com o manager canônico.
+
+## D4 — Mundo
+
+`WorldState`, `WorldDirectorManager`, `WorldMapManager` e os demais managers de mundo possuem responsabilidades distintas. Eles não devem ser fundidos sem ADR específica, migração e testes de compatibilidade.
+
+## D5 — Deck
+
+`DeckManager` permanece único. Cartas referenciam técnicas por `technique_id`; HUD, IA e cenas são consumidores, não fontes mestras.
+
+## D6 — Dados
+
+O catálogo de técnicas é a fonte mestre. Deck, HUD, animação e IA são projeções ou consumidores.
+
+- IDs persistíveis são estáveis.
+- Renome exige alias ou mapper.
+- Schema novo não substitui dados ativos sem migração validada.
+
+## D7 — Acessibilidade
+
+Acessibilidade neurodivergente é requisito de produto: perfil sensorial, redução de flash e tremor, modo foco, modo sem timer e narração. A implementação de runtime deve ocorrer em lote próprio, integrada aos efeitos existentes e testada em dispositivo.
+
+## D8 — Colecionáveis
+
+Colecionáveis e patches são exclusivamente cosméticos.
+
+- Sem blockchain.
+- Sem NFT como dependência de produto.
+- Sem pay-to-win.
+- Identificadores legados podem permanecer apenas até migração segura de save e assets.
+
+## D9 — Prioridade
+
+O vertical slice ouro Ruan × Davi tem precedência sobre expansão massiva de mundo, elenco, facções, ferramentas ou serviços remotos.
+
+## D10 — Nome canônico da facção ALE
+
+O nome de exibição aprovado é exatamente **Os Aleluiado**.
+
+- ID canônico futuro: `ALE`.
+- ID legado preservado: `os_aleluia`.
+- O ID legado deve funcionar como alias de migração, nunca como quarta facção.
+- Alterações são restritas a `name`, `display_name` e lore inequivocamente referente à facção ficcional.
+- A palavra “aleluia” em contexto religioso real não deve ser alterada automaticamente.
+- Ocorrências ambíguas permanecem intactas e devem ser registradas para revisão humana.
+
+Esta decisão substitui, para o nome de exibição, a forma plural “Os Aleluiados” encontrada na branch-fonte do PR #32.
+
+## D11 — Integração v4
+
+O PR #32 (`release/v4-integration`) é branch-fonte e não deve ser mesclado monoliticamente.
+
+A ordem oficial de port é:
+
+1. cânone e contratos executáveis;
+2. migração das três facções e save;
+3. cartas, posições e rulesets;
+4. adapter de combate preservando o runtime estável;
+5. Arena v4 e Submission HUD;
+6. mundo, economia, informante e finais;
+7. terreno e acessibilidade.
+
+Cada lote deve partir da `main` mais recente, ter escopo vertical pequeno, rollback claro e checks verdes antes do próximo.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -7,11 +7,13 @@ Este arquivo é a porta de entrada da documentação ativa. Antes de criar um do
 - [`../README.md`](../README.md) — visão do produto, instalação e comandos principais;
 - [`../AGENTS.md`](../AGENTS.md) — regras obrigatórias para agentes;
 - [`../CONTRIBUTING.md`](../CONTRIBUTING.md) — fluxo de contribuição;
+- [`DECISIONS.md`](DECISIONS.md) — decisões arquiteturais e canônicas D1–D11;
 - [`REPOSITORY_GOVERNANCE.md`](REPOSITORY_GOVERNANCE.md) — fonte única, branches, PRs e gates;
 - [`ROADMAP.md`](ROADMAP.md) — sequência oficial de construção.
 
 ## Contratos executáveis
 
+- [`../data/production/canon_contract_v4_1.json`](../data/production/canon_contract_v4_1.json) — cânone v4.1, autoridades de runtime, facções e aliases;
 - [`../data/production/supreme_build_contract_v01.json`](../data/production/supreme_build_contract_v01.json) — metas e release gates;
 - [`../data/production/release_gate_status_v01.json`](../data/production/release_gate_status_v01.json) — ledger único com evidências e pendências de release;
 - [`../data/visual/production_manifest_v02.json`](../data/visual/production_manifest_v02.json) — inventário audiovisual;
@@ -36,7 +38,8 @@ Este arquivo é a porta de entrada da documentação ativa. Antes de criar um do
 - `architecture/` — decisões e integrações técnicas;
 - `qa/` — auditorias e evidências;
 - [`qa/RUNTIME_AUDIT_V08.md`](qa/RUNTIME_AUDIT_V08.md) — auditoria do fluxo central;
-- [`../tools/audit/validate_repository_governance.py`](../tools/audit/validate_repository_governance.py) — gate de organização.
+- [`../tools/audit/validate_repository_governance.py`](../tools/audit/validate_repository_governance.py) — gate de organização;
+- [`../tools/audit/validate_canon_contract_v4_1.py`](../tools/audit/validate_canon_contract_v4_1.py) — gate do cânone e da D10.
 
 ## Status dos documentos
 

--- a/docs/qa/STATE_SNAPSHOT_V4_1.md
+++ b/docs/qa/STATE_SNAPSHOT_V4_1.md
@@ -1,0 +1,197 @@
+# State Snapshot — Lote V4.1
+
+**Status:** ACTIVE EVIDENCE  
+**Capturado:** 2026-08-01  
+**Base:** `main` em `068cbad979986baf09f870cc6580b7c88f10794f`  
+**Branch:** `docs/v4-1-canon-contracts`
+
+## 1. Histórico recente da base
+
+```text
+068cbad chore(repo): profissionalizar governança e fonte única do jogo
+246201e fix(runtime): restaurar smoke verde na main
+f098ab5 feat(combat): implementar Deck de Combate e disputas de nível
+8469035 feat: integrar apresentação premium e contrato supremo de produção
+f3e8584 fix: concluir auditoria integral e validar APK Android
+d97e565 feat: adicionar Faction Director v2 com territórios, guerras e sucessão
+21f6b78 feat: adicionar Cria World Director com clima, NPCs, rivais e NFTs
+167043c feat: adicionar IA local opcional com fallback offline
+21081cc feat: tornar a IA de Davi funcional no combate
+67cb8b7 fix: fechar bloqueadores P0 do vertical slice
+0fb5495 build: preparar export APK e pipeline audiovisual v0.9
+54b13bf feat: consolidar runtime, combate posicional e QA headless
+e8ba0a5 Consolidar Cria do Tatame em repositório único
+256003e feat: Add ai_config.json - Davi's behavioral and technique database (2/3)
+6cb4b09 Add graphic material pipeline guide
+```
+
+## 2. Pull requests
+
+### Abertos no início do lote
+
+| PR | Título resumido | Base | Estado |
+|---:|---|---|---|
+| #24 | marco audiovisual e mundo v10 | `release/v4-integration` | draft, não mergeável |
+| #25 | unificação e game feel | `release/v4-integration` | draft, não mergeável |
+| #26 | Open Pixel Forge | `release/unify-and-feel` | draft, mergeável na base empilhada |
+| #32 | integração v4 monolítica | `main` | draft, não mergeável; branch-fonte |
+| #33 | protocolo de construção | `release/v4-integration` | draft, mergeável na base empilhada |
+| #34 | árvore/deck/rulesets/bindings | `release/v4-integration` | draft, mergeável na base empilhada |
+| #35 | padrão visual e logo | `docs/game-build-protocol-v1` | draft, mergeável na base empilhada |
+| #37 | governança/boot legado | `docs/visual-quality-and-logo-v1` | draft, mergeável na base empilhada |
+| #38 | Visual Forge | `main` | draft, mergeável |
+
+### Integrados imediatamente antes deste lote
+
+- #40 — correção do runtime smoke;
+- #39 — profissionalização do repositório;
+- #42 — sincronização técnica usada para atualizar a branch da profissionalização.
+
+## 3. Inventário de extensões
+
+A API conectada usada para este snapshot não expõe uma listagem recursiva completa da árvore. O ambiente de execução local também não conseguiu resolver o host do GitHub para clonar o repositório. Portanto, este documento **não inventa contagens exatas**.
+
+Último inventário histórico disponível, apenas como orientação e não como gate:
+
+| Extensão | Referência histórica | Situação |
+|---|---:|---|
+| `.gd` | aproximadamente 86 | requer contagem em checkout completo |
+| `.tscn` | aproximadamente 14 | requer contagem em checkout completo |
+| `.json` | 105 ou mais | cresceu com contratos de produção |
+| `.png` | não afirmado | requer contagem em checkout completo |
+| `.wav/.ogg/.mp3` | próximo de zero na `main` estável | áudio atual é majoritariamente procedural; validar em checkout |
+
+Comando de evidência para ambiente com checkout completo:
+
+```bash
+find . -type f -name '*.gd' | wc -l
+find . -type f -name '*.tscn' | wc -l
+find . -type f -name '*.json' | wc -l
+find . -type f -name '*.png' | wc -l
+find . -type f \( -name '*.wav' -o -name '*.ogg' -o -name '*.mp3' \) | wc -l
+```
+
+## 4. Autoloads da `main`
+
+Foram encontrados **26 autoloads**, não 30. Todos os caminhos estavam presentes e os smokes da base `068cbad` ficaram verdes.
+
+| Nome | Caminho |
+|---|---|
+| SignalBus | `src/autoloads/SignalBus.gd` |
+| DataRegistry | `src/autoloads/DataRegistry.gd` |
+| DeckManager | `src/autoloads/DeckManager.gd` |
+| LocalAIManager | `src/autoloads/LocalAIManager.gd` |
+| WorldState | `src/autoloads/WorldState.gd` |
+| WorldDirectorManager | `src/autoloads/WorldDirectorManager.gd` |
+| NFTManager | `src/autoloads/NFTManager.gd` |
+| SaveManager | `src/autoloads/SaveManager.gd` |
+| CombatManager | `src/autoloads/CombatManager.gd` |
+| CareerLoop | `src/autoloads/CareerLoop.gd` |
+| ReputationMatrix | `src/autoloads/ReputationMatrix.gd` |
+| CriaLiveManager | `src/autoloads/CriaLiveManager.gd` |
+| AudioManager | `src/autoloads/AudioManager.gd` |
+| TinkerBondManager | `src/autoloads/TinkerBondManager.gd` |
+| MissionManager | `src/autoloads/MissionManager.gd` |
+| StorySceneDirector | `src/autoloads/StorySceneDirector.gd` |
+| FactionManager | `src/autoloads/FactionManager.gd` |
+| FactionDirectorManager | `src/autoloads/FactionDirectorManager.gd` |
+| FactionAIPlanBridge | `src/autoloads/FactionAIPlanBridge.gd` |
+| WorldMapManager | `src/autoloads/WorldMapManager.gd` |
+| GearManager | `src/autoloads/GearManager.gd` |
+| TrainingManager | `src/autoloads/TrainingManager.gd` |
+| HubActivityManager | `src/autoloads/HubActivityManager.gd` |
+| CriaLiveInteractionManager | `src/autoloads/CriaLiveInteractionManager.gd` |
+| GameFlowManager | `src/autoloads/GameFlowManager.gd` |
+| CutsceneRuntime | `src/autoloads/CutsceneRuntime.gd` |
+
+## 5. Cena principal e versão
+
+- `run/main_scene`: `res://scenes/main_menu/MainMenu.tscn`;
+- cabeçalho de `project.godot`: Godot `4.2+`;
+- contrato supremo: mínimo `4.2.2`, produção `4.3+`;
+- roadmap: validação final em Godot 4.3;
+- decisão: upgrade 4.2 → 4.3 permanece fora deste lote e deve ocorrer em PR separado.
+
+## 6. Estado dos gates da base
+
+O commit base `068cbad` foi integrado após aprovação dos workflows de governança, dados, runtime smoke, full game hardening e exportação/inspeção do APK Android.
+
+Os resultados deste branch devem ser obtidos pela CI do PR. Nenhum sucesso local é alegado porque o checkout completo não estava disponível no ambiente conectado.
+
+## 7. Arquivos-chave
+
+| Alvo | Estado na `main` |
+|---|---|
+| `src/autoloads/CombatManager.gd` | presente; runtime estável |
+| `src/autoloads/DeckManager.gd` | presente; único deck manager |
+| `src/autoloads/AudioManager.gd` | presente; único audio manager |
+| `src/combat/transition_manager.gd` | ausente; não criar neste lote |
+| `data/factions.json` | presente; catálogo legado |
+| Bíblia narrativa | `docs/narrative/MASTER_CANON_BIBLE_V01.md` |
+| `data/characters.json` | presente |
+| `data/story/story_scenes_v01.json` | presente |
+| `data/finais_adultos.json` | presente |
+| manifests de Ruan | presentes sob `assets/sprites/ruan_macacao/` |
+
+## 8. Reconciliação com o PR #32
+
+O PR #32 possui 90 commits e 83 arquivos alterados. Ele inclui cânone, facções/save, combate v4, mundo, economia, finais e acessibilidade, por isso não deve ser mesclado diretamente.
+
+Portado neste lote:
+
+- IDs futuros `LEM`, `NTM`, `ALE`;
+- aliases legados;
+- política de exatamente três facções futuras;
+- classificação de instituições/eixos/grupos aposentados;
+- integração incremental e proibição de merge monolítico.
+
+Não portado:
+
+- runtime de facções;
+- save v5;
+- managers v4;
+- cartas/posições/rulesets;
+- Arena e Submission HUD;
+- economia, mapa, finais e terreno;
+- alteração de `project.godot`.
+
+Divergência resolvida por autoridade superior deste lote:
+
+- PR #32 usa “Os Aleluiados”;
+- D10 aprovada usa **“Os Aleluiado”**.
+
+## 9. Inventário D10
+
+### Alteração segura aplicada
+
+| Arquivo | Classificação | Ação |
+|---|---|---|
+| `data/factions.json` | `FACTION_DISPLAY` | `Os Aleluia` → `Os Aleluiado`; ID `os_aleluia` preservado |
+
+### Ocorrências preservadas para revisão semântica
+
+A busca na `main` encontrou referências em:
+
+- `docs/FACTION_DIRECTOR_V2.md`;
+- `docs/narrative/MASTER_CANON_BIBLE_V01.md`;
+- `data/factions/faction_director_v02.json`;
+- `data/factions/faction_drama_bible_v01.json`;
+- `src/autoloads/FactionManager.gd`;
+- `data/lore/character_bible_v01.json`;
+- `data/lore/world_bible_v01.json`;
+- `data/story/faction_scenes_v01.json`;
+- `data/player/player_progression.json`;
+- `data/missions/faction_missions_v01.json`;
+- `data/world/faction_territories_v02.json`;
+- `data/world/world_director_config_v01.json`;
+- `data/customization/customization_options.json`;
+- `src/autoloads/MissionManager.gd`;
+- `tests/faction_director_smoke.gd`;
+- `tests/test_world_director_data.py`;
+- `tests/test_faction_director_data.py`.
+
+Essas ocorrências permanecem `D10_AMBIGUO` neste lote porque várias combinam display, IDs, testes e estado persistível. A correção em massa poderia quebrar referências. Elas devem ser tratadas no V4.2 com mapper, migração de save e atualização coordenada dos testes.
+
+## 10. Conclusão do snapshot
+
+O Lote V4.1 pode alterar documentação, contratos, validadores e o display inequívoco da entrada legada. Runtime, autoloads, save e estrutura ativa de facções permanecem congelados até o V4.2.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "validate:governance": "python tools/audit/validate_repository_governance.py",
+    "validate:canon": "python tools/audit/validate_canon_contract_v4_1.py",
     "validate:python": "python tools/validate_json.py",
     "validate:node": "node tools/node/validate_json.mjs",
     "validate:data": "node tools/node/validate_game_data.mjs",
@@ -18,7 +19,7 @@
     "assets:queue": "python tools/ai_asset_pipeline/build_production_queue_v02.py",
     "animations:generate": "python tools/animation/generate_character_animation_pack.py",
     "validate:animations": "python tools/animation/generate_character_animation_pack.py --validate-only",
-    "quality": "npm run validate:governance && npm run validate:python && npm run validate:node && npm run validate:data && npm run validate:animations && npm run validate:repository && npm run validate:runtime && npm run validate:release && npm run validate:supreme && npm run validate:deck",
+    "quality": "npm run validate:governance && npm run validate:canon && npm run validate:python && npm run validate:node && npm run validate:data && npm run validate:animations && npm run validate:repository && npm run validate:runtime && npm run validate:release && npm run validate:supreme && npm run validate:deck",
     "build:android:windows": "powershell -ExecutionPolicy Bypass -File tools/build/build_android_debug.ps1",
     "build:android:linux": "bash tools/build/build_android_debug.sh",
     "build:windows": "powershell -ExecutionPolicy Bypass -File tools/build/build_windows_debug.ps1"

--- a/tests/test_canon_contract_v4_1.py
+++ b/tests/test_canon_contract_v4_1.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+VALIDATOR = ROOT / "tools" / "audit" / "validate_canon_contract_v4_1.py"
+
+spec = importlib.util.spec_from_file_location("validate_canon_contract_v4_1", VALIDATOR)
+assert spec is not None and spec.loader is not None
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+
+def test_contract_structure() -> None:
+    module.validate_contract()
+
+
+def test_d10_is_display_only_in_legacy_catalog() -> None:
+    module.validate_legacy_catalog_display_only()
+
+
+def test_decisions_are_linked_from_authority_documents() -> None:
+    module.validate_document_authority()
+
+
+def test_runtime_authorities_remain_unchanged() -> None:
+    module.validate_runtime_untouched_contract()

--- a/tools/audit/validate_canon_contract_v4_1.py
+++ b/tools/audit/validate_canon_contract_v4_1.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Validate the V4.1 canon/contract batch without migrating runtime systems."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+CONTRACT_PATH = ROOT / "data" / "production" / "canon_contract_v4_1.json"
+FACTIONS_PATH = ROOT / "data" / "factions.json"
+DECISIONS_PATH = ROOT / "docs" / "DECISIONS.md"
+INDEX_PATH = ROOT / "docs" / "INDEX.md"
+AGENTS_PATH = ROOT / "AGENTS.md"
+PROJECT_PATH = ROOT / "project.godot"
+
+EXPECTED_IDS = ["LEM", "NTM", "ALE"]
+EXPECTED_DISPLAY = "Os Aleluiado"
+LEGACY_ID = "os_aleluia"
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise AssertionError(f"arquivo ausente: {path.relative_to(ROOT)}") from exc
+    except json.JSONDecodeError as exc:
+        raise AssertionError(f"JSON invalido em {path.relative_to(ROOT)}: {exc}") from exc
+    assert isinstance(value, dict), f"objeto raiz deve ser dicionario: {path.relative_to(ROOT)}"
+    return value
+
+
+def read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise AssertionError(f"arquivo ausente: {path.relative_to(ROOT)}") from exc
+
+
+def validate_contract() -> None:
+    contract = load_json(CONTRACT_PATH)
+    assert contract.get("contract_id") == "cria_do_tatame_canon_v4_1"
+    assert contract.get("status") == "canonical_contract"
+    assert contract.get("integration_source_pr") == 32
+
+    policy = contract.get("integration_policy", {})
+    assert policy.get("monolithic_merge_forbidden") is True
+    assert policy.get("port_in_small_batches") is True
+    assert policy.get("stable_runtime_must_remain_bootable") is True
+
+    authorities = contract.get("runtime_authorities", {})
+    assert authorities.get("combat") == "CombatManager"
+    assert authorities.get("deck") == "DeckManager"
+    assert authorities.get("audio") == "AudioManager"
+
+    factions = contract.get("active_factions_future_domain", [])
+    ids = [str(item.get("id", "")) for item in factions]
+    assert ids == EXPECTED_IDS, f"dominio futuro deve ser exatamente {EXPECTED_IDS}, recebido {ids}"
+    assert len(set(ids)) == 3, "IDs de faccao duplicados"
+
+    ale = next(item for item in factions if item.get("id") == "ALE")
+    assert ale.get("display_name") == EXPECTED_DISPLAY
+    assert LEGACY_ID in ale.get("legacy_ids", [])
+
+    d10 = contract.get("d10", {})
+    assert d10.get("canonical_display_name") == EXPECTED_DISPLAY
+    assert d10.get("canonical_future_id") == "ALE"
+    assert d10.get("preserved_legacy_id") == LEGACY_ID
+    assert d10.get("religious_context_must_not_be_rewritten") is True
+    assert d10.get("ambiguous_occurrences_require_human_review") is True
+
+    legacy_policy = contract.get("legacy_domain_policy", {})
+    assert legacy_policy.get("stable_ids_must_not_be_renamed_in_place") is True
+    assert legacy_policy.get("runtime_three_faction_migration_deferred_to_v4_2") is True
+
+
+def validate_legacy_catalog_display_only() -> None:
+    data = load_json(FACTIONS_PATH)
+    entries = [item for item in data.get("factions", []) if item.get("id") == LEGACY_ID]
+    assert len(entries) == 1, f"esperada uma entrada legada {LEGACY_ID}, recebidas {len(entries)}"
+    entry = entries[0]
+    assert entry.get("id") == LEGACY_ID, "D10 nao pode renomear o ID legado"
+    assert entry.get("name") == EXPECTED_DISPLAY, "display D10 incorreto"
+
+    serialized = json.dumps(data, ensure_ascii=False)
+    assert '"id": "ALE"' not in serialized, "V4.1 nao deve migrar o catalogo legado para ALE"
+
+
+def validate_document_authority() -> None:
+    decisions = read_text(DECISIONS_PATH)
+    for decision in range(1, 12):
+        assert f"## D{decision} —" in decisions, f"D{decision} ausente em docs/DECISIONS.md"
+    assert EXPECTED_DISPLAY in decisions
+    assert "PR #32" in decisions
+    assert "não deve ser mesclado monoliticamente" in decisions
+
+    index = read_text(INDEX_PATH)
+    agents = read_text(AGENTS_PATH)
+    assert "DECISIONS.md" in index, "docs/INDEX.md nao referencia DECISIONS.md"
+    assert "canon_contract_v4_1.json" in index, "docs/INDEX.md nao referencia o contrato v4.1"
+    assert "DECISIONS.md" in agents, "AGENTS.md nao referencia DECISIONS.md"
+
+
+def validate_runtime_untouched_contract() -> None:
+    project = read_text(PROJECT_PATH)
+    assert 'run/main_scene="res://scenes/main_menu/MainMenu.tscn"' in project
+    assert 'CombatManager="*res://src/autoloads/CombatManager.gd"' in project
+    assert 'DeckManager="*res://src/autoloads/DeckManager.gd"' in project
+    assert 'AudioManager="*res://src/autoloads/AudioManager.gd"' in project
+    assert "TransitionManager=" not in project, "V4.1 nao deve adicionar TransitionManager como autoload"
+
+
+def main() -> int:
+    checks = [
+        validate_contract,
+        validate_legacy_catalog_display_only,
+        validate_document_authority,
+        validate_runtime_untouched_contract,
+    ]
+    errors: list[str] = []
+    for check in checks:
+        try:
+            check()
+        except (AssertionError, OSError, ValueError, KeyError) as exc:
+            errors.append(f"{check.__name__}: {exc}")
+
+    if errors:
+        print("Canon contract V4.1 validation failed:")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+
+    print("Canon contract V4.1 validation passed.")
+    print("- future active faction IDs: LEM, NTM, ALE")
+    print(f"- ALE display: {EXPECTED_DISPLAY}")
+    print(f"- preserved legacy ID: {LEGACY_ID}")
+    print("- runtime/autoload migration: deferred to V4.2+")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Objetivo

Portar do PR #32 apenas o primeiro lote seguro da integração v4: decisões canônicas, autoridades de runtime, aliases de facção, D10 e gates executáveis.

## Escopo

- cria `docs/DECISIONS.md` com D1–D11;
- cria `data/production/canon_contract_v4_1.json`;
- aplica D10 na entrada inequívoca de `data/factions.json`:
  - display `Os Aleluiado`;
  - ID legado `os_aleluia` preservado;
- vincula decisões e contrato em `AGENTS.md`, `docs/INDEX.md` e na governança executável;
- adiciona `tools/audit/validate_canon_contract_v4_1.py`;
- adiciona testes pytest do contrato e da estabilidade do runtime;
- integra `npm run validate:canon` ao `npm run quality`;
- registra `docs/qa/STATE_SNAPSHOT_V4_1.md`.

## Fora do escopo

Este PR não altera:

- `project.godot` ou autoloads;
- `CombatManager`, `DeckManager` ou `AudioManager`;
- save ou migrações;
- runtime de facções;
- cartas, posições, rulesets, Arena v4 ou Submission HUD;
- mundo, economia, finais, terreno ou acessibilidade de runtime;
- assets binários;
- personagens, atos ou organizações narrativas novas.

## Integração e consumidor real

- `npm run quality` passa a consumir o contrato v4.1;
- `AGENTS.md` obriga agentes a ler decisões e contrato antes de editar;
- `repository_governance_v01.json` torna os novos artefatos obrigatórios;
- o validador confirma as autoridades atuais de combate, deck e áudio e bloqueia a promoção prematura de `TransitionManager` a autoload.

## Reconciliação com o PR #32

Portado:

- domínio futuro `LEM`, `NTM`, `ALE`;
- aliases legados;
- política de três facções;
- classificação de instituições, eixos e grupos aposentados;
- integração em lotes, sem merge monolítico.

Não portado:

- qualquer implementação de runtime ou save do PR #32.

Divergência resolvida:

- branch-fonte usa `Os Aleluiados`;
- D10 aprovada neste lote define **Os Aleluiado**.

## D10

Alterado com segurança:

- `data/factions.json`: `Os Aleluia` → `Os Aleluiado`.

Preservado:

- ID `os_aleluia`;
- demais ocorrências encontradas em docs, dados, runtime e testes, classificadas como `D10_AMBIGUO` até o V4.2, quando haverá mapper e migração coordenada.

## Testes e gates

Comandos exigidos:

```bash
python tools/audit/validate_repository_governance.py
python tools/audit/validate_canon_contract_v4_1.py
npm run quality
python -m pytest -q tests/test_canon_contract_v4_1.py
```

Os checks Godot e Android continuam sendo executados pelos workflows existentes. O ambiente conectado não permitiu clone local por falha de resolução DNS; portanto, nenhum resultado local é inventado. A decisão de merge depende da CI deste PR.

## Riscos

- referências legadas de display permanecem em vários arquivos e precisam de migração coordenada no V4.2;
- o catálogo legado ainda contém mais de três domínios sob `factions`; este PR apenas congela o contrato futuro e não realiza a migração estrutural;
- contagens exatas de extensões dependem de checkout completo e estão explicitamente marcadas como pendência de evidência no snapshot.

## Rollback

Reverter os commits deste PR restaura o display legado e remove decisões, contrato e validator sem tocar no runtime.

## Próximo lote

V4.2 — migrar facções e save com aliases, mapper, três facções ativas, atualização coordenada dos consumidores e testes de roundtrip.

Relaciona-se a #31 e usa #32 apenas como branch-fonte.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Data Updates**
  * Renamed the faction display name to “Os Aleluiado” while preserving its legacy identity.
  * Added canonical faction, migration, naming, and governance rules for version 4.1.

* **Documentation**
  * Added architectural decisions, governance references, and a V4.1 QA snapshot.
  * Updated the documentation index with new reference and validation links.

* **Quality & Validation**
  * Added automated validation for canonical rules, legacy naming, documentation authority, and unchanged runtime configuration.
  * Integrated canonical validation into the standard quality-check workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->