### PR TITLE
feat(v4.3a): estabelecer contratos GI e No-Gi e filtro de deck

### DIFF
--- a/.github/workflows/full-game-hardening.yml
+++ b/.github/workflows/full-game-hardening.yml
@@ -29,6 +29,7 @@ jobs:
           python tools/cria_forge/cria_forge.py validate
           python tools/validate_complete_game.py
           python tools/validate_runtime_contracts.py
+          python tools/audit/validate_rulesets_v4_3.py
       - name: Python compile check
         run: python -m compileall -q tools tests
       - name: Ruff critical errors
@@ -77,6 +78,11 @@ jobs:
         run: |
           set -o pipefail
           ./godot --headless --path . --script res://tests/faction_director_smoke.gd 2>&1 | tee reports/full_game_audit/faction_smoke.log
+      - name: GI and No-Gi ruleset smoke
+        shell: bash
+        run: |
+          set -o pipefail
+          ./godot --headless --path . --script res://tests/ruleset_smoke.gd 2>&1 | tee reports/full_game_audit/ruleset_smoke.log
       - name: Full game smoke
         shell: bash
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,12 @@ Antes de criar, editar, apagar, mover ou integrar qualquer arquivo:
 4. leia `docs/ROADMAP.md`;
 5. leia `docs/INDEX.md` e a fonte canônica da área;
 6. consulte `data/production/canon_contract_v4_1.json`;
-7. consulte `data/production/supreme_build_contract_v01.json`;
-8. procure implementação, issue ou PR equivalente;
-9. defina um lote vertical pequeno, testável e reversível.
+7. consulte `data/production/faction_migration_v4_2.json` quando tocar facções ou save;
+8. consulte `data/production/combat_master_contract_v2.json` quando tocar combate, progressão, arenas ou pipeline visual;
+9. consulte `data/production/ruleset_contract_v4_3.json`, `data/combat/rulesets_v01.json` e `data/combat/technique_rulesets_v01.json` quando tocar GI, No-Gi, técnicas, cartas, uniformes ou animações;
+10. consulte `data/production/supreme_build_contract_v01.json`;
+11. procure implementação, issue ou PR equivalente;
+12. defina um lote vertical pequeno, testável e reversível.
 
 Não comece implementando apenas porque a solicitação parece clara. Primeiro confirme a posição da tarefa na arquitetura e no roadmap.
 
@@ -50,9 +53,12 @@ O repositório não é galeria de prompts, depósito de concept art ou cemitéri
 - frase eixo: Ser forte é ser gentil;
 - facções ativas do cânone v4: LEM, NTM e ALE;
 - nome de exibição de ALE: **Os Aleluiado**;
-- ID legado `os_aleluia` é alias de migração e não deve ser renomeado em lugar.
+- ID legado `os_aleluia` é alias de migração e não deve ser renomeado em lugar;
+- rulesets canônicos: `GI` e `NO_GI`;
+- `GI` permanece padrão para compatibilidade enquanto a seleção completa não estiver integrada;
+- No-Gi não pode ser apenas troca cosmética de uniforme.
 
-Caio Ravel, Ruan “Cria” e uma quarta facção ativa são bloqueados em shipping.
+Caio Ravel, Ruan “Cria”, uma quarta facção ativa, `instant_finish=true` e técnica fora de `data/techniques.json` são bloqueados em shipping.
 
 ## Hierarquia de autoridade
 
@@ -73,12 +79,28 @@ Nunca escolha a versão “mais bonita” ou “mais completa” sem verificar i
 - Godot é o único runtime.
 - `main` deve permanecer bootável.
 - Gameplay crítico é determinístico e offline.
-- `CombatManager`, `DeckManager`, `AudioManager` e managers de mundo existentes não podem ser duplicados.
+- `CombatManager`, `DeckManager`, `DataRegistry`, `TechniqueClashResolver`, `SaveManager`, `AudioManager` e managers de mundo existentes não podem ser duplicados.
 - Migrações usam adapter/fachada e testes de compatibilidade.
 - Alteração de autoload exige auditoria de boot.
 - Dados persistíveis exigem versão e migração de save.
 - IDs de dados são estáveis; renome só com mapper.
+- Técnicas vêm exclusivamente de `data/techniques.json`; catálogos auxiliares são projeções e contratos, não segunda fonte.
+- O modificador final de clash deve permanecer entre `-0.30` e `+0.35`.
+- `instant_finish` é sempre falso.
+- Finalizações terminam em tap, escape ou intervenção técnica.
+- Controle posicional e fluxo são recursos distintos.
 - Uma classe, JSON ou asset sem consumidor real não conta como feature integrada.
+
+## GrappleMap
+
+`Eelis/GrappleMap` pode ser usado como referência de domínio público para:
+
+- grafo dirigido de posições;
+- taxonomia e tags;
+- poses e entanglements;
+- sequência esquemática de transições.
+
+Não pode ser tratado como fonte autoritativa de timing real, cobertura específica de Gi, validação biomecânica ou arte final. Técnicas de tecido exigem referência separada e revisão humana.
 
 ## Fluxo que não pode regredir
 
@@ -119,9 +141,12 @@ PR empilhado deve declarar dependência, ordem de merge e base ativa. Se a base 
 
 - Concept art, mockup, geração bruta e fila de produção são candidatos.
 - Asset final exige origem/licença, metadata, preview, QA, aprovação humana e integração Godot.
-- Técnica pareada exige atacante, defensor, pivô compartilhado, timing e `sync_map`.
+- Técnica pareada exige atacante, defensor, pivô compartilhado, timing validado, `sync_map` e correspondência entre estado lógico e visual.
+- GI e No-Gi exigem variantes quando pegadas, roupa, contato ou áudio divergem.
+- Nenhum tecido de kimono pode aparecer em animação No-Gi.
 - Não copiar pessoa, marca, frame, aula, logo ou áudio de terceiro sem licença.
 - Não promover automaticamente saída de IA para caminhos de shipping.
+- Sem teleporte, clipping, pegada invisível antes de projeção ou defensor dessincronizado.
 
 ## Segurança
 
@@ -129,6 +154,8 @@ PR empilhado deve declarar dependência, ordem de merge e base ativa. Se a base 
 - Serviços externos são opcionais e tratados como não confiáveis.
 - Nenhuma LLM controla o loop de combate.
 - Conteúdo cosmético opcional não concede poder jogável.
+- Sem animação de lesão como prêmio.
+- Sem referência a liga comercial real.
 
 ## Gates mínimos
 
@@ -143,6 +170,7 @@ Quando aplicável:
 ```bash
 godot --headless --editor --path . --quit
 godot --headless --path . --script res://tests/runtime_smoke.gd
+godot --headless --path . --script res://tests/ruleset_smoke.gd
 ```
 
 Mudanças de release Android exigem instalação e teste em aparelho físico. Desempenho estimado não é evidência.

--- a/data/combat/rulesets_v01.json
+++ b/data/combat/rulesets_v01.json
@@ -59,7 +59,7 @@
       "description": "Jiu-jitsu sem kimono, baseado em controles corporais, punhos, cabeça, underhooks, overhooks e body locks.",
       "attire": {
         "required": ["rashguard", "shorts_no_gi"],
-        "forbidden": ["kimono", "faixa_soltaa", "pegada_em_tecido"],
+        "forbidden": ["kimono", "faixa_solta", "pegada_em_tecido"],
         "visual_variant": "no_gi"
       },
       "grip_model": {

--- a/data/combat/rulesets_v01.json
+++ b/data/combat/rulesets_v01.json
@@ -1,0 +1,102 @@
+{
+  "version": "1.0.0",
+  "language": "pt-BR",
+  "default_ruleset_id": "GI",
+  "rulesets": [
+    {
+      "id": "GI",
+      "display_name": "Com kimono (Gi)",
+      "short_name": "GI",
+      "aliases": ["gi", "kimono", "com_kimono"],
+      "description": "Jiu-jitsu com kimono, pegadas de tecido e controle posicional de maior estabilidade.",
+      "attire": {
+        "required": ["kimono", "faixa"],
+        "forbidden": ["rashguard_sem_kimono_como_uniforme_principal"],
+        "visual_variant": "gi"
+      },
+      "grip_model": {
+        "fabric_grips_allowed": true,
+        "body_grips_allowed": true,
+        "allowed_types": [
+          "lapel",
+          "sleeve",
+          "belt",
+          "pants",
+          "wrist",
+          "collar_tie",
+          "underhook",
+          "overhook",
+          "body_lock",
+          "head_control"
+        ],
+        "default_visual_contact": "lapela_e_manga"
+      },
+      "gameplay": {
+        "transition_speed_multiplier": 1.0,
+        "grip_stability_multiplier": 1.12,
+        "grip_break_cost_multiplier": 1.0,
+        "gas_cost_multiplier": 1.0,
+        "focus_cost_multiplier": 1.0,
+        "scramble_frequency_multiplier": 0.92
+      },
+      "audio_profile": "gi_fabric",
+      "accessibility": {
+        "same_input_windows_as_base": true,
+        "sensory_profile_required": true,
+        "slow_motion_training_allowed": true
+      },
+      "runtime_policy": {
+        "offline_required": true,
+        "automatic_submission_forbidden": true,
+        "fabric_techniques_must_declare_requirement": true
+      }
+    },
+    {
+      "id": "NO_GI",
+      "display_name": "No-Gi (sem kimono)",
+      "short_name": "NO-GI",
+      "aliases": ["no_gi", "no-gi", "nogi", "sem_kimono"],
+      "description": "Jiu-jitsu sem kimono, baseado em controles corporais, punhos, cabeça, underhooks, overhooks e body locks.",
+      "attire": {
+        "required": ["rashguard", "shorts_no_gi"],
+        "forbidden": ["kimono", "faixa_soltaa", "pegada_em_tecido"],
+        "visual_variant": "no_gi"
+      },
+      "grip_model": {
+        "fabric_grips_allowed": false,
+        "body_grips_allowed": true,
+        "allowed_types": [
+          "wrist",
+          "two_on_one",
+          "collar_tie",
+          "underhook",
+          "overhook",
+          "whizzer",
+          "body_lock",
+          "head_control",
+          "ankle_control"
+        ],
+        "default_visual_contact": "punho_e_collar_tie"
+      },
+      "gameplay": {
+        "transition_speed_multiplier": 1.06,
+        "grip_stability_multiplier": 0.86,
+        "grip_break_cost_multiplier": 0.86,
+        "gas_cost_multiplier": 1.02,
+        "focus_cost_multiplier": 1.0,
+        "scramble_frequency_multiplier": 1.12
+      },
+      "audio_profile": "no_gi_contact",
+      "accessibility": {
+        "same_input_windows_as_base": true,
+        "sensory_profile_required": true,
+        "slow_motion_training_allowed": true
+      },
+      "runtime_policy": {
+        "offline_required": true,
+        "automatic_submission_forbidden": true,
+        "fabric_grips_forbidden": true
+      }
+    }
+  ]
+}

--- a/data/combat/technique_rulesets_v01.json
+++ b/data/combat/technique_rulesets_v01.json
@@ -1,0 +1,152 @@
+{
+  "version": "1.0.0",
+  "language": "pt-BR",
+  "source_catalog": "data/techniques.json",
+  "default_policy": {
+    "rulesets": ["GI", "NO_GI"],
+    "requires_fabric": false,
+    "grip_type": "body_control",
+    "blocked_reason": ""
+  },
+  "techniques": {
+    "pegada_lapela_manga": {
+      "rulesets": ["GI"],
+      "requires_fabric": true,
+      "grip_type": "lapel_sleeve",
+      "blocked_reason": "Esta técnica exige pegada na lapela e na manga e não pode ser usada no No-Gi.",
+      "visual_variants": {
+        "GI": "pegada_lapela_manga_gi"
+      }
+    },
+    "grip_de_ferro": {
+      "rulesets": ["GI", "NO_GI"],
+      "requires_fabric": false,
+      "grip_type": "adaptive_grip",
+      "visual_variants": {
+        "GI": "grip_de_ferro_lapela_manga",
+        "NO_GI": "grip_de_ferro_punho_collar_tie"
+      },
+      "contact_anchors": {
+        "GI": ["lapel", "sleeve"],
+        "NO_GI": ["wrist", "neck"]
+      }
+    },
+    "silverback_grip": {
+      "rulesets": ["GI", "NO_GI"],
+      "requires_fabric": false,
+      "grip_type": "adaptive_power_grip",
+      "visual_variants": {
+        "GI": "silverback_grip_gi",
+        "NO_GI": "silverback_body_lock"
+      },
+      "contact_anchors": {
+        "GI": ["lapel", "sleeve", "torso"],
+        "NO_GI": ["wrist", "torso", "head_control"]
+      }
+    },
+    "pressao_cabeca": {
+      "rulesets": ["GI", "NO_GI"],
+      "requires_fabric": false,
+      "grip_type": "head_control"
+    },
+    "quebra_base": {
+      "rulesets": ["GI", "NO_GI"],
+      "requires_fabric": false,
+      "grip_type": "adaptive_clinch"
+    },
+    "baiana": {
+      "rulesets": ["GI", "NO_GI"],
+      "requires_fabric": false,
+      "grip_type": "leg_and_body_lock"
+    },
+    "sprawl": {
+      "rulesets": ["GI", "NO_GI"],
+      "requires_fabric": false,
+      "grip_type": "head_and_hip_control"
+    },
+    "puxada_guarda": {
+      "rulesets": ["GI", "NO_GI"],
+      "requires_fabric": false,
+      "grip_type": "adaptive_guard_pull",
+      "visual_variants": {
+        "GI": "puxada_guarda_lapela_manga",
+        "NO_GI": "puxada_guarda_punho_collar_tie"
+      }
+    },
+    "corte_joelho": {
+      "rulesets": ["GI", "NO_GI"],
+      "requires_fabric": false,
+      "grip_type": "underhook_head_control",
+      "visual_variants": {
+        "GI": "corte_joelho_gi",
+        "NO_GI": "corte_joelho_no_gi"
+      }
+    },
+    "crossface": {
+      "rulesets": ["GI", "NO_GI"],
+      "requires_fabric": false,
+      "grip_type": "head_and_shoulder_control"
+    },
+    "raspagem_tesoura": {
+      "rulesets": ["GI", "NO_GI"],
+      "requires_fabric": false,
+      "grip_type": "adaptive_guard_control"
+    },
+    "raspagem_borboleta": {
+      "rulesets": ["GI", "NO_GI"],
+      "requires_fabric": false,
+      "grip_type": "underhook_or_overhook"
+    },
+    "cem_quilos": {
+      "rulesets": ["GI", "NO_GI"],
+      "requires_fabric": false,
+      "grip_type": "torso_control"
+    },
+    "montada_pesada": {
+      "rulesets": ["GI", "NO_GI"],
+      "requires_fabric": false,
+      "grip_type": "hip_and_head_control"
+    },
+    "saida_montada": {
+      "rulesets": ["GI", "NO_GI"],
+      "requires_fabric": false,
+      "grip_type": "frame_and_hip_escape"
+    },
+    "saida_cem_quilos": {
+      "rulesets": ["GI", "NO_GI"],
+      "requires_fabric": false,
+      "grip_type": "frame_and_hip_escape"
+    },
+    "chave_braco": {
+      "rulesets": ["GI", "NO_GI"],
+      "requires_fabric": false,
+      "grip_type": "arm_control"
+    },
+    "mata_leao": {
+      "rulesets": ["GI", "NO_GI"],
+      "requires_fabric": false,
+      "grip_type": "neck_and_torso_control"
+    },
+    "encerramento_tecnico": {
+      "rulesets": ["GI", "NO_GI"],
+      "requires_fabric": false,
+      "grip_type": "submission_resolution"
+    }
+  },
+  "planned_no_gi_techniques": [
+    "collar_tie",
+    "pummel",
+    "underhook",
+    "overhook",
+    "whizzer",
+    "body_lock",
+    "two_on_one",
+    "arm_drag_no_gi"
+  ],
+  "policy": {
+    "missing_technique_uses_default_policy": true,
+    "deck_cards_are_never_deleted_by_ruleset": true,
+    "incompatible_cards_are_filtered_from_combat_hand": true,
+    "visual_variant_is_required_before_shipping": true
+  }
+}

--- a/data/combat/technique_rulesets_v01.json
+++ b/data/combat/technique_rulesets_v01.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0",
+  "version": "1.0.1",
   "language": "pt-BR",
   "source_catalog": "data/techniques.json",
   "default_policy": {
@@ -8,16 +8,13 @@
     "grip_type": "body_control",
     "blocked_reason": ""
   },
+  "fabric_technique_template": {
+    "rulesets": ["GI"],
+    "requires_fabric": true,
+    "grip_type": "lapel_or_sleeve",
+    "blocked_reason": "Esta técnica exige pegada no tecido e não pode ser usada no No-Gi."
+  },
   "techniques": {
-    "pegada_lapela_manga": {
-      "rulesets": ["GI"],
-      "requires_fabric": true,
-      "grip_type": "lapel_sleeve",
-      "blocked_reason": "Esta técnica exige pegada na lapela e na manga e não pode ser usada no No-Gi.",
-      "visual_variants": {
-        "GI": "pegada_lapela_manga_gi"
-      }
-    },
     "grip_de_ferro": {
       "rulesets": ["GI", "NO_GI"],
       "requires_fabric": false,
@@ -144,6 +141,7 @@
     "arm_drag_no_gi"
   ],
   "policy": {
+    "projection_ids_must_exist_in_source_catalog": true,
     "missing_technique_uses_default_policy": true,
     "deck_cards_are_never_deleted_by_ruleset": true,
     "incompatible_cards_are_filtered_from_combat_hand": true,

--- a/data/production/combat_master_contract_v2.json
+++ b/data/production/combat_master_contract_v2.json
@@ -1,0 +1,160 @@
+{
+  "schema_version": "2.0.0",
+  "contract_id": "cria_do_tatame_combat_master_v2",
+  "status": "canonical_specification",
+  "tracking_issue": 46,
+  "repository": "ringuemkt-rgb/cria-do-tatame",
+  "engine": "Godot 4.x",
+  "platform_floor": "Android ARM64",
+  "runtime": {
+    "offline_required": true,
+    "deterministic_required": true,
+    "generative_ai_allowed": false,
+    "critical_loop_network_dependency_allowed": false
+  },
+  "canon": {
+    "protagonist_id": "ruan_macacao",
+    "protagonist_display_name": "Ruan Macacão Silva",
+    "origin": "Ituberá, Baixo Sul da Bahia",
+    "symbol": "Silverback",
+    "motto": "Ser forte é ser gentil.",
+    "combat_identity": "jiu_jitsu_posicional",
+    "beat_em_up_forbidden": true
+  },
+  "runtime_authorities": {
+    "combat": "CombatManager",
+    "deck": "DeckManager",
+    "data": "DataRegistry",
+    "clash": "TechniqueClashResolver",
+    "save": "SaveManager",
+    "audio": "AudioManager"
+  },
+  "combat_invariants": {
+    "technique_source": "data/techniques.json",
+    "position_before_submission": true,
+    "submission_control_threshold": 75,
+    "instant_finish": false,
+    "clash_modifier_min": -0.3,
+    "clash_modifier_max": 0.35,
+    "submission_end_states": ["tap", "escape", "technical_intervention"],
+    "injury_reward_animation_forbidden": true,
+    "real_commercial_league_reference_forbidden": true,
+    "control_and_flow_are_distinct_resources": true,
+    "health_is_not_primary_victory_resource": true
+  },
+  "rulesets": {
+    "source": "data/combat/rulesets_v01.json",
+    "ids": ["GI", "NO_GI"],
+    "default": "GI",
+    "no_gi_cosmetic_only_forbidden": true
+  },
+  "grapplemap": {
+    "repository": "Eelis/GrappleMap",
+    "declared_license": "public_domain",
+    "license_evidence": "README.md FAQ",
+    "approved_uses": [
+      "directed_position_graph_reference",
+      "pose_and_entanglement_reference",
+      "taxonomy_and_tags",
+      "schematic_transition_sequence"
+    ],
+    "forbidden_claims": [
+      "authoritative_real_world_timing",
+      "gi_specific_coverage",
+      "final_art_asset",
+      "biomechanical_validation_without_human_review"
+    ],
+    "gi_reference_policy": "GI-specific grips and cloth interactions require separate licensed reference and human review."
+  },
+  "existing_states_to_preserve": [
+    "PLAYER_STANDING_NEUTRAL",
+    "PLAYER_TOP_CLINCH",
+    "PLAYER_TOP_GUARD",
+    "PLAYER_TOP_SIDE",
+    "PLAYER_TOP_MOUNT",
+    "PLAYER_BOTTOM_GUARD",
+    "PLAYER_BOTTOM_MOUNT",
+    "PLAYER_BOTTOM_SIDE",
+    "PLAYER_BACK_ATTACK",
+    "PLAYER_SUBMISSION_ATTACK",
+    "RESET"
+  ],
+  "planned_states": [
+    "PLAYER_TOP_HALF_GUARD",
+    "PLAYER_BOTTOM_HALF_GUARD",
+    "PLAYER_TURTLE",
+    "PLAYER_50_50",
+    "PLAYER_KNEE_ON_BELLY"
+  ],
+  "resources": [
+    "health",
+    "gas",
+    "focus",
+    "grip",
+    "positional_control",
+    "flow"
+  ],
+  "deck": {
+    "active_limit": 5,
+    "passive_limit": 3,
+    "hand_size": 3,
+    "deterministic_hand_required": true,
+    "dead_hand_action": {
+      "gas_cost": 5,
+      "effect": "discard_and_draw_next"
+    },
+    "xp_success": 10,
+    "xp_attempt": 3
+  },
+  "position_control": {
+    "range": [0, 100],
+    "bands": {
+      "neutral": [0, 24],
+      "alert": [25, 49],
+      "pressure": [50, 74],
+      "domain": [75, 100]
+    },
+    "submission_enabled_band": "domain"
+  },
+  "flow": {
+    "range": [0, 100],
+    "activation_value": 100,
+    "duration_seconds": 10,
+    "cooldown_rounds": 1,
+    "must_not_break_clash_clamp": true
+  },
+  "finalization_mobile": {
+    "touch_steps": ["grip_point_tap", "fit_direction_drag", "pressure_hold"],
+    "technical_intervention_timeout_seconds": 8,
+    "instant_resolution_forbidden": true,
+    "accessibility_required": true
+  },
+  "visual": {
+    "style": "HD painted pixel art 2D/2.5D",
+    "regional_specificity_required": true,
+    "generic_tropical_favela_forbidden": true,
+    "paired_attacker_defender_required": true,
+    "logical_state_must_match_visual": true,
+    "readable_at_quarter_scale": true
+  },
+  "delivery": {
+    "golden_vertical_slice_before_scale": true,
+    "golden_slice": {
+      "player": "ruan_macacao",
+      "opponent": "davi_relampago",
+      "arena": "arena_do_dique",
+      "rulesets": ["GI", "NO_GI"]
+    },
+    "completion_requires": [
+      "contract",
+      "implementation",
+      "real_consumer",
+      "automated_test",
+      "biomechanical_review",
+      "pt_br_review",
+      "visual_evidence",
+      "android_device_test",
+      "rollback"
+    ]
+  }
+}

--- a/data/production/repository_governance_v01.json
+++ b/data/production/repository_governance_v01.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "1.0.2",
+  "schema_version": "1.0.3",
   "repository": "ringuemkt-rgb/cria-do-tatame",
   "default_branch": "main",
   "single_source_of_truth": true,
@@ -28,8 +28,15 @@
     "docs/ROADMAP.md",
     "data/production/canon_contract_v4_1.json",
     "data/production/faction_migration_v4_2.json",
+    "data/production/ruleset_contract_v4_3.json",
+    "data/production/combat_master_contract_v2.json",
+    "data/combat/rulesets_v01.json",
+    "data/combat/technique_rulesets_v01.json",
     "tools/audit/validate_faction_migration_v4_2.py",
+    "tools/audit/validate_rulesets_v4_3.py",
     "tests/test_faction_migration_v4_2.py",
+    "tests/test_rulesets_v4_3.py",
+    "tests/ruleset_smoke.gd",
     "data/production/release_gate_status_v01.json"
   ],
   "canonical_directories": [
@@ -74,6 +81,11 @@
       "os_aleluia": "ALE"
     },
     "faction_save_version": 5,
+    "combat_rulesets": ["GI", "NO_GI"],
+    "default_combat_ruleset": "GI",
+    "technique_source": "data/techniques.json",
+    "instant_finish": false,
+    "clash_modifier_range": [-0.3, 0.35],
     "critical_gameplay_offline": true,
     "second_runtime_forbidden": true,
     "secrets_in_repository_forbidden": true

--- a/data/production/ruleset_contract_v4_3.json
+++ b/data/production/ruleset_contract_v4_3.json
@@ -1,0 +1,83 @@
+{
+  "schema_version": "4.3.0",
+  "contract_id": "cria_do_tatame_rulesets_v4_3",
+  "status": "candidate_until_merge",
+  "tracking_issue": 44,
+  "source_of_truth": {
+    "techniques": "data/techniques.json",
+    "rulesets": "data/combat/rulesets_v01.json",
+    "compatibility_projection": "data/combat/technique_rulesets_v01.json"
+  },
+  "ruleset_ids": ["GI", "NO_GI"],
+  "default_ruleset_id": "GI",
+  "product_decisions": {
+    "gi_and_no_gi_are_canonical": true,
+    "no_gi_is_not_cosmetic_only": true,
+    "shared_position_graph_allowed": true,
+    "different_grip_models_required": true,
+    "different_visual_variants_required": true,
+    "different_audio_profiles_required": true,
+    "offline_runtime_required": true,
+    "automatic_submission_forbidden": true,
+    "accessibility_profile_required": true
+  },
+  "runtime_authorities": {
+    "combat": "CombatManager",
+    "deck": "DeckManager",
+    "data": "DataRegistry",
+    "save": "SaveManager",
+    "audio": "AudioManager"
+  },
+  "compatibility_policy": {
+    "existing_calls_without_ruleset_use_gi": true,
+    "equipped_cards_must_not_be_deleted": true,
+    "incompatible_cards_must_not_enter_combat_hand": true,
+    "blocked_reason_must_be_available_in_pt_br": true,
+    "unknown_techniques_use_explicit_default_policy": true,
+    "fabric_required_techniques_forbidden_in_no_gi": true
+  },
+  "delivery_batches": [
+    {
+      "id": "v4_3a",
+      "scope": "contrato_dados_registry_filtro_deck",
+      "playable_no_gi": false
+    },
+    {
+      "id": "v4_3b",
+      "scope": "combat_manager_save_missoes_hud",
+      "playable_no_gi": true
+    },
+    {
+      "id": "v4_3c",
+      "scope": "vertical_slice_ruan_davi_arte_audio_qa",
+      "playable_no_gi": true
+    }
+  ],
+  "vertical_slice": {
+    "player": "ruan_macacao",
+    "opponent": "davi_relampago",
+    "ruleset": "NO_GI",
+    "required_flow": [
+      "distancia_media",
+      "collar_tie_ou_pummel",
+      "body_lock_ou_baiana",
+      "sprawl",
+      "guarda_aberta",
+      "corte_joelho",
+      "montada",
+      "costas",
+      "mata_leao",
+      "escape_ou_tap"
+    ]
+  },
+  "forbidden_in_v4_3a": [
+    "project_godot_changes",
+    "new_ruleset_autoload",
+    "second_combat_manager",
+    "second_deck_manager",
+    "binary_asset_claims",
+    "claiming_no_gi_playable_before_v4_3b",
+    "deleting_incompatible_saved_cards",
+    "fabric_grip_in_no_gi"
+  ]
+}

--- a/data/production/ruleset_contract_v4_3.json
+++ b/data/production/ruleset_contract_v4_3.json
@@ -3,6 +3,8 @@
   "contract_id": "cria_do_tatame_rulesets_v4_3",
   "status": "candidate_until_merge",
   "tracking_issue": 44,
+  "master_tracking_issue": 46,
+  "source_contract": "data/production/combat_master_contract_v2.json",
   "source_of_truth": {
     "techniques": "data/techniques.json",
     "rulesets": "data/combat/rulesets_v01.json",
@@ -20,6 +22,21 @@
     "offline_runtime_required": true,
     "automatic_submission_forbidden": true,
     "accessibility_profile_required": true
+  },
+  "reference_policy": {
+    "grapplemap_license_declared": "public_domain",
+    "grapplemap_use": [
+      "directed_graph",
+      "taxonomy",
+      "pose_and_entanglement",
+      "schematic_transition_sequence"
+    ],
+    "grapplemap_not_authoritative_for": [
+      "real_world_timing",
+      "gi_specific_grips",
+      "biomechanical_validation",
+      "final_art"
+    ]
   },
   "runtime_authorities": {
     "combat": "CombatManager",

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -15,6 +15,10 @@ Este arquivo é a porta de entrada da documentação ativa. Antes de criar um do
 
 - [`../data/production/canon_contract_v4_1.json`](../data/production/canon_contract_v4_1.json) — cânone v4.1, autoridades de runtime, facções e aliases;
 - [`../data/production/faction_migration_v4_2.json`](../data/production/faction_migration_v4_2.json) — três facções ativas, aliases e save v5;
+- [`../data/production/combat_master_contract_v2.json`](../data/production/combat_master_contract_v2.json) — invariantes do combate, progressão, arenas e pipeline visual;
+- [`../data/production/ruleset_contract_v4_3.json`](../data/production/ruleset_contract_v4_3.json) — entrega por lotes GI + No-Gi;
+- [`../data/combat/rulesets_v01.json`](../data/combat/rulesets_v01.json) — regras, uniforme, pegadas, áudio e multiplicadores de GI e No-Gi;
+- [`../data/combat/technique_rulesets_v01.json`](../data/combat/technique_rulesets_v01.json) — projeção de compatibilidade e variantes das técnicas;
 - [`../data/production/supreme_build_contract_v01.json`](../data/production/supreme_build_contract_v01.json) — metas e release gates;
 - [`../data/production/release_gate_status_v01.json`](../data/production/release_gate_status_v01.json) — ledger único com evidências e pendências de release;
 - [`../data/visual/production_manifest_v02.json`](../data/visual/production_manifest_v02.json) — inventário audiovisual;
@@ -25,7 +29,9 @@ Este arquivo é a porta de entrada da documentação ativa. Antes de criar um do
 - [`CRIA_DO_TATAME_SUPREME_BUILD_SPEC_V1.md`](CRIA_DO_TATAME_SUPREME_BUILD_SPEC_V1.md) — escopo de produto;
 - [`gameplay/COMBAT_DECK_SYSTEM_V01.md`](gameplay/COMBAT_DECK_SYSTEM_V01.md) — deck atual integrado à `main`;
 - `canon/` — personagens, facções, mundo e narrativa aprovados;
-- `gameplay/` — combate, progressão, regras e economia.
+- `gameplay/` — combate, progressão, regras e economia;
+- EPIC Mestre #46 — programa P0–P11 para combate posicional, progressão, arenas e arte;
+- EPIC #44 — implementação de GI + No-Gi.
 
 ## Migrações ativas
 
@@ -45,7 +51,9 @@ Este arquivo é a porta de entrada da documentação ativa. Antes de criar um do
 - [`qa/RUNTIME_AUDIT_V08.md`](qa/RUNTIME_AUDIT_V08.md) — auditoria do fluxo central;
 - [`../tools/audit/validate_repository_governance.py`](../tools/audit/validate_repository_governance.py) — gate de organização;
 - [`../tools/audit/validate_canon_contract_v4_1.py`](../tools/audit/validate_canon_contract_v4_1.py) — gate do cânone e da D10;
-- [`../tools/audit/validate_faction_migration_v4_2.py`](../tools/audit/validate_faction_migration_v4_2.py) — gate das três facções, aliases e save v5.
+- [`../tools/audit/validate_faction_migration_v4_2.py`](../tools/audit/validate_faction_migration_v4_2.py) — gate das três facções, aliases e save v5;
+- [`../tools/audit/validate_rulesets_v4_3.py`](../tools/audit/validate_rulesets_v4_3.py) — gate de GI, No-Gi, deck, clamp e contrato mestre;
+- [`../tests/ruleset_smoke.gd`](../tests/ruleset_smoke.gd) — smoke Godot de aliases, cartas bloqueadas e preservação da coleção.
 
 ## Status dos documentos
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "validate:governance": "python tools/audit/validate_repository_governance.py",
     "validate:canon": "python tools/audit/validate_canon_contract_v4_1.py",
     "validate:factions-v4": "python tools/audit/validate_faction_migration_v4_2.py",
+    "validate:rulesets": "python tools/audit/validate_rulesets_v4_3.py",
     "validate:python": "python tools/validate_json.py",
     "validate:node": "node tools/node/validate_json.mjs",
     "validate:data": "node tools/node/validate_game_data.mjs",
@@ -20,7 +21,7 @@
     "assets:queue": "python tools/ai_asset_pipeline/build_production_queue_v02.py",
     "animations:generate": "python tools/animation/generate_character_animation_pack.py",
     "validate:animations": "python tools/animation/generate_character_animation_pack.py --validate-only",
-    "quality": "npm run validate:governance && npm run validate:canon && npm run validate:factions-v4 && npm run validate:python && npm run validate:node && npm run validate:data && npm run validate:animations && npm run validate:repository && npm run validate:runtime && npm run validate:release && npm run validate:supreme && npm run validate:deck",
+    "quality": "npm run validate:governance && npm run validate:canon && npm run validate:factions-v4 && npm run validate:rulesets && npm run validate:python && npm run validate:node && npm run validate:data && npm run validate:animations && npm run validate:repository && npm run validate:runtime && npm run validate:release && npm run validate:supreme && npm run validate:deck",
     "build:android:windows": "powershell -ExecutionPolicy Bypass -File tools/build/build_android_debug.ps1",
     "build:android:linux": "bash tools/build/build_android_debug.sh",
     "build:windows": "powershell -ExecutionPolicy Bypass -File tools/build/build_windows_debug.ps1"

--- a/src/autoloads/DataRegistry.gd
+++ b/src/autoloads/DataRegistry.gd
@@ -227,8 +227,13 @@ func validate_core_data():
 		errors.append("ruleset padrao precisa ser GI para compatibilidade")
 	if technique_rulesets.get("default_policy", {}).get("rulesets", []) != ["GI", "NO_GI"]:
 		errors.append("politica padrao de tecnicas deve permitir GI e NO_GI")
-	if technique_allowed_in_ruleset("pegada_lapela_manga", "NO_GI"):
-		errors.append("pegada de lapela e manga nao pode ser permitida no No-Gi")
+	var fabric_template: Dictionary = technique_rulesets.get("fabric_technique_template", {})
+	if fabric_template.get("rulesets", []) != ["GI"] or not bool(fabric_template.get("requires_fabric", false)):
+		errors.append("template de tecnica com tecido precisa ser exclusivo de GI")
+	for technique_id_value in technique_rulesets.get("techniques", {}).keys():
+		var technique_id := str(technique_id_value)
+		if not techniques.has(technique_id):
+			errors.append("projecao de ruleset referencia tecnica fora de data/techniques.json: %s" % technique_id)
 	return {
 		"ok": errors.is_empty(),
 		"errors": errors,

--- a/src/autoloads/DataRegistry.gd
+++ b/src/autoloads/DataRegistry.gd
@@ -41,6 +41,8 @@ var character_animation_catalog := {}
 var apixel_production_briefs := {}
 var arena_animation_flow := {}
 var combat_deck := {}
+var combat_rulesets := {}
+var technique_rulesets := {}
 var validation_report := {}
 
 const DATA_FILES := {
@@ -84,7 +86,9 @@ const DATA_FILES := {
 	"character_animation_catalog": "res://data/visual/character_animation_catalog_v01.json",
 	"apixel_production_briefs": "res://data/visual/apixel_production_briefs_v01.json",
 	"arena_animation_flow": "res://data/visual/arena_animation_flow_v01.json",
-	"combat_deck": "res://data/ruan_deck_inicial.json"
+	"combat_deck": "res://data/ruan_deck_inicial.json",
+	"combat_rulesets": "res://data/combat/rulesets_v01.json",
+	"technique_rulesets": "res://data/combat/technique_rulesets_v01.json"
 }
 
 func _ready():
@@ -132,6 +136,8 @@ func load_all():
 	apixel_production_briefs = _load_raw("apixel_production_briefs")
 	arena_animation_flow = _load_raw("arena_animation_flow")
 	combat_deck = _load_raw("combat_deck")
+	combat_rulesets = _load_raw("combat_rulesets")
+	technique_rulesets = _load_raw("technique_rulesets")
 	validation_report = validate_core_data()
 	SignalBus.data_validation_finished.emit(validation_report)
 	SignalBus.data_loaded.emit()
@@ -211,7 +217,92 @@ func validate_core_data():
 		errors.append("deck de combate inicial possui menos de 10 cartas")
 	if combat_deck.get("owner_id", "") != "ruan_macacao":
 		errors.append("deck de combate inicial nao pertence a ruan_macacao")
-	return {"ok": errors.is_empty(), "errors": errors, "characters": characters.size(), "arenas": arenas.size(), "techniques": techniques.size(), "factions": factions.size()}
+	var ruleset_ids: Array = []
+	for ruleset_value in combat_rulesets.get("rulesets", []):
+		if typeof(ruleset_value) == TYPE_DICTIONARY:
+			ruleset_ids.append(str(ruleset_value.get("id", "")))
+	if ruleset_ids != ["GI", "NO_GI"]:
+		errors.append("rulesets de combate devem ser exatamente GI e NO_GI")
+	if str(combat_rulesets.get("default_ruleset_id", "")) != "GI":
+		errors.append("ruleset padrao precisa ser GI para compatibilidade")
+	if technique_rulesets.get("default_policy", {}).get("rulesets", []) != ["GI", "NO_GI"]:
+		errors.append("politica padrao de tecnicas deve permitir GI e NO_GI")
+	if technique_allowed_in_ruleset("pegada_lapela_manga", "NO_GI"):
+		errors.append("pegada de lapela e manga nao pode ser permitida no No-Gi")
+	return {
+		"ok": errors.is_empty(),
+		"errors": errors,
+		"characters": characters.size(),
+		"arenas": arenas.size(),
+		"techniques": techniques.size(),
+		"factions": factions.size(),
+		"rulesets": ruleset_ids.size()
+	}
+
+func normalize_ruleset_id(value) -> String:
+	var raw := str(value).strip_edges()
+	if raw == "":
+		return ""
+	var upper := raw.to_upper()
+	for ruleset_value in combat_rulesets.get("rulesets", []):
+		if typeof(ruleset_value) != TYPE_DICTIONARY:
+			continue
+		var ruleset: Dictionary = ruleset_value
+		var ruleset_id := str(ruleset.get("id", ""))
+		if upper == ruleset_id.to_upper():
+			return ruleset_id
+		for alias_value in ruleset.get("aliases", []):
+			if raw.to_lower() == str(alias_value).to_lower():
+				return ruleset_id
+	return ""
+
+func get_default_ruleset_id() -> String:
+	var configured := normalize_ruleset_id(combat_rulesets.get("default_ruleset_id", "GI"))
+	return configured if configured != "" else "GI"
+
+func get_combat_ruleset(ruleset_id) -> Dictionary:
+	var normalized := normalize_ruleset_id(ruleset_id)
+	for ruleset_value in combat_rulesets.get("rulesets", []):
+		if typeof(ruleset_value) == TYPE_DICTIONARY and str(ruleset_value.get("id", "")) == normalized:
+			return ruleset_value.duplicate(true)
+	return {}
+
+func get_technique_ruleset_policy(technique_id) -> Dictionary:
+	var policy: Dictionary = technique_rulesets.get("default_policy", {}).duplicate(true)
+	var overrides: Dictionary = technique_rulesets.get("techniques", {})
+	var key := str(technique_id)
+	if overrides.has(key) and typeof(overrides[key]) == TYPE_DICTIONARY:
+		policy.merge(overrides[key], true)
+	return policy
+
+func technique_allowed_in_ruleset(technique_id, ruleset_id) -> bool:
+	var normalized := normalize_ruleset_id(ruleset_id)
+	if normalized == "":
+		return false
+	var policy := get_technique_ruleset_policy(technique_id)
+	var allowed: Array = policy.get("rulesets", [])
+	if not allowed.has(normalized):
+		return false
+	if normalized == "NO_GI" and bool(policy.get("requires_fabric", false)):
+		return false
+	return true
+
+func get_technique_ruleset_block_reason(technique_id, ruleset_id) -> String:
+	if technique_allowed_in_ruleset(technique_id, ruleset_id):
+		return ""
+	var normalized := normalize_ruleset_id(ruleset_id)
+	if normalized == "":
+		return "Ruleset de combate inválido."
+	var policy := get_technique_ruleset_policy(technique_id)
+	var configured := str(policy.get("blocked_reason", ""))
+	if configured != "":
+		return configured
+	return "Esta técnica não está disponível em %s." % str(get_combat_ruleset(normalized).get("display_name", normalized))
+
+func get_technique_visual_variant(technique_id, ruleset_id) -> String:
+	var normalized := normalize_ruleset_id(ruleset_id)
+	var policy := get_technique_ruleset_policy(technique_id)
+	return str(policy.get("visual_variants", {}).get(normalized, str(technique_id)))
 
 func get_character_animation(character_id: String, action_id: String) -> Dictionary:
 	for entry_value in character_animation_catalog.get("entries", []):

--- a/src/autoloads/DeckManager.gd
+++ b/src/autoloads/DeckManager.gd
@@ -3,6 +3,7 @@ extends Node
 const ACTIVE_LIMIT := 5
 const PASSIVE_LIMIT := 3
 const HAND_SIZE := 3
+const DEFAULT_RULESET := "GI"
 const BELT_LEVEL_LIMIT := {
 	"branca": 2,
 	"azul": 3,
@@ -13,6 +14,7 @@ const BELT_LEVEL_LIMIT := {
 
 var owner_id := "ruan_macacao"
 var belt := "branca"
+var current_ruleset := DEFAULT_RULESET
 var cards: Dictionary = {}
 var active_deck: Array[String] = []
 var passive_deck: Array[String] = []
@@ -38,6 +40,7 @@ func configure_from_data(source: Dictionary) -> Dictionary:
 		return {"ok": false, "error": "deck_data_missing"}
 	owner_id = str(source.get("owner_id", "ruan_macacao"))
 	belt = str(source.get("belt", "branca"))
+	current_ruleset = _normalize_ruleset(str(source.get("current_ruleset", current_ruleset)))
 	for value in source.get("cards", []):
 		if typeof(value) != TYPE_DICTIONARY:
 			continue
@@ -48,10 +51,38 @@ func configure_from_data(source: Dictionary) -> Dictionary:
 	var equipped: Dictionary = source.get("equipped", {})
 	active_deck = _valid_equipped(equipped.get("active", []), "active", ACTIVE_LIMIT)
 	passive_deck = _valid_equipped(equipped.get("passive", []), "passive", PASSIVE_LIMIT)
-	start_combat_hand()
-	return {"ok": true, "cards": cards.size(), "active": active_deck.size(), "passive": passive_deck.size()}
+	start_combat_hand(current_ruleset)
+	return {
+		"ok": true,
+		"cards": cards.size(),
+		"active": active_deck.size(),
+		"passive": passive_deck.size(),
+		"ruleset": current_ruleset,
+		"blocked_equipped": get_blocked_equipped_cards().size()
+	}
 
-func start_combat_hand() -> void:
+func set_ruleset(ruleset_id: String) -> Dictionary:
+	var normalized := _normalize_ruleset(ruleset_id)
+	if normalized == "":
+		return {"ok": false, "error": "ruleset_invalid", "ruleset_id": ruleset_id}
+	current_ruleset = normalized
+	start_combat_hand(current_ruleset)
+	SignalBus.deck_configuration_changed.emit(to_dict())
+	return {
+		"ok": true,
+		"ruleset_id": current_ruleset,
+		"hand": get_hand(),
+		"blocked_equipped": get_blocked_equipped_cards()
+	}
+
+func get_ruleset_id() -> String:
+	return current_ruleset
+
+func start_combat_hand(ruleset_id: String = "") -> void:
+	if ruleset_id != "":
+		var normalized := _normalize_ruleset(ruleset_id)
+		if normalized != "":
+			current_ruleset = normalized
 	if has_node("/root/WorldState"):
 		var world_belt := str(WorldState.belt)
 		if BELT_LEVEL_LIMIT.has(world_belt):
@@ -59,27 +90,35 @@ func start_combat_hand() -> void:
 	hand.clear()
 	draw_cursor = 0
 	selected_card_id = ""
-	while hand.size() < mini(HAND_SIZE, active_deck.size()):
-		hand.append(active_deck[draw_cursor])
-		draw_cursor += 1
+	_draw_until_full()
 	_emit_hand_changed()
 
 func get_hand() -> Array:
 	var output: Array = []
 	for card_id in hand:
 		if cards.has(card_id):
-			output.append(cards[card_id].duplicate(true))
+			var card: Dictionary = cards[card_id].duplicate(true)
+			card["ruleset_id"] = current_ruleset
+			card["ruleset_compatible"] = true
+			card["ruleset_block_reason"] = ""
+			output.append(card)
 	return output
 
 func get_collection() -> Array:
 	var output: Array = []
-	for value in cards.values():
-		output.append(value.duplicate(true))
+	for card_id_value in cards.keys():
+		var card_id := str(card_id_value)
+		var card: Dictionary = cards[card_id].duplicate(true)
+		var status := get_card_ruleset_status(card_id)
+		card["ruleset_id"] = current_ruleset
+		card["ruleset_compatible"] = bool(status.get("allowed", false))
+		card["ruleset_block_reason"] = str(status.get("reason", ""))
+		output.append(card)
 	output.sort_custom(func(a: Dictionary, b: Dictionary) -> bool: return str(a.get("name", "")) < str(b.get("name", "")))
 	return output
 
 func select_card(card_id: String) -> bool:
-	if not hand.has(card_id) or not cards.has(card_id):
+	if not hand.has(card_id) or not cards.has(card_id) or not _card_is_allowed(cards[card_id]):
 		return false
 	selected_card_id = card_id
 	SignalBus.combat_card_selected.emit(cards[card_id].duplicate(true))
@@ -95,6 +134,8 @@ func get_attack_card(technique_id: String, resources: Dictionary, current_state:
 			candidates.append(card_id)
 	for card_id in candidates:
 		var card: Dictionary = cards.get(card_id, {})
+		if not _card_is_allowed(card):
+			continue
 		if str(card.get("technique_id", "")) != technique_id:
 			continue
 		if not _state_is_valid(card, current_state) or not can_activate(card, resources):
@@ -106,7 +147,7 @@ func get_defense_card(attack_family: String, resources: Dictionary, current_stat
 	var best: Dictionary = {}
 	for card_id in passive_deck + hand:
 		var card: Dictionary = cards.get(card_id, {})
-		if not bool(card.get("unlocked", false)):
+		if not bool(card.get("unlocked", false)) or not _card_is_allowed(card):
 			continue
 		var responses: Array = card.get("response_to_families", [])
 		if not responses.has(attack_family):
@@ -118,6 +159,8 @@ func get_defense_card(attack_family: String, resources: Dictionary, current_stat
 	return best.duplicate(true)
 
 func can_activate(card: Dictionary, resources: Dictionary) -> bool:
+	if not _card_is_allowed(card):
+		return false
 	var cost: Dictionary = card.get("activation_cost", {})
 	return (
 		float(resources.get("focus", 0.0)) >= float(cost.get("focus", 0.0))
@@ -158,9 +201,14 @@ func equip_card(card_id: String, slot_kind: String, slot_index: int = -1) -> Dic
 		target.append(card_id)
 	else:
 		return {"ok": false, "error": "deck_full"}
-	start_combat_hand()
+	start_combat_hand(current_ruleset)
 	SignalBus.deck_configuration_changed.emit(to_dict())
-	return {"ok": true}
+	var status := get_card_ruleset_status(card_id)
+	return {
+		"ok": true,
+		"ruleset_compatible": bool(status.get("allowed", false)),
+		"ruleset_block_reason": str(status.get("reason", ""))
+	}
 
 func upgrade_card(card_id: String, payment: String = "xp") -> Dictionary:
 	var card: Dictionary = cards.get(card_id, {})
@@ -199,17 +247,51 @@ func unlock_card(card_id: String) -> Dictionary:
 func passive_modifiers() -> Dictionary:
 	var output: Dictionary = {}
 	for card_id in passive_deck:
-		var effect: Dictionary = cards.get(card_id, {}).get("passive_effect", {})
+		var card: Dictionary = cards.get(card_id, {})
+		if not _card_is_allowed(card):
+			continue
+		var effect: Dictionary = card.get("passive_effect", {})
 		for key_value in effect.keys():
 			var key := str(key_value)
 			output[key] = float(output.get(key, 0.0)) + float(effect[key_value])
 	return output
 
+func get_card_ruleset_status(card_id: String, ruleset_id: String = "") -> Dictionary:
+	var card: Dictionary = cards.get(card_id, {})
+	if card.is_empty():
+		return {"allowed": false, "reason": "Carta não encontrada.", "ruleset_id": current_ruleset}
+	var resolved_ruleset := current_ruleset if ruleset_id == "" else _normalize_ruleset(ruleset_id)
+	if resolved_ruleset == "":
+		return {"allowed": false, "reason": "Ruleset de combate inválido.", "ruleset_id": ruleset_id}
+	var technique_id := str(card.get("technique_id", ""))
+	if technique_id == "":
+		return {"allowed": true, "reason": "", "ruleset_id": resolved_ruleset}
+	var allowed := bool(DataRegistry.technique_allowed_in_ruleset(technique_id, resolved_ruleset))
+	return {
+		"allowed": allowed,
+		"reason": "" if allowed else str(DataRegistry.get_technique_ruleset_block_reason(technique_id, resolved_ruleset)),
+		"ruleset_id": resolved_ruleset,
+		"technique_id": technique_id,
+		"visual_variant": str(DataRegistry.get_technique_visual_variant(technique_id, resolved_ruleset))
+	}
+
+func get_blocked_equipped_cards(ruleset_id: String = "") -> Array:
+	var output: Array = []
+	for card_id in active_deck + passive_deck:
+		var status := get_card_ruleset_status(card_id, ruleset_id)
+		if not bool(status.get("allowed", false)):
+			var item := status.duplicate(true)
+			item["card_id"] = card_id
+			item["name"] = str(cards.get(card_id, {}).get("name", card_id))
+			output.append(item)
+	return output
+
 func to_dict() -> Dictionary:
 	return {
-		"schema_version": "1.0.0",
+		"schema_version": "1.1.0",
 		"owner_id": owner_id,
 		"belt": belt,
+		"current_ruleset": current_ruleset,
 		"limits": {"active": ACTIVE_LIMIT, "passive": PASSIVE_LIMIT, "hand": HAND_SIZE},
 		"cards": get_collection(),
 		"equipped": {"active": active_deck.duplicate(), "passive": passive_deck.duplicate()}
@@ -234,15 +316,37 @@ func _valid_equipped(values: Array, kind: String, limit: int) -> Array[String]:
 	return output
 
 func _draw_until_full() -> void:
-	if active_deck.is_empty():
+	var compatible := _compatible_active_deck()
+	if compatible.is_empty():
 		return
 	var attempts := 0
-	while hand.size() < mini(HAND_SIZE, active_deck.size()) and attempts < active_deck.size() * 2:
-		var card_id := active_deck[draw_cursor % active_deck.size()]
-		draw_cursor = (draw_cursor + 1) % active_deck.size()
+	while hand.size() < mini(HAND_SIZE, compatible.size()) and attempts < compatible.size() * 2:
+		var card_id := compatible[draw_cursor % compatible.size()]
+		draw_cursor = (draw_cursor + 1) % compatible.size()
 		if not hand.has(card_id):
 			hand.append(card_id)
 		attempts += 1
+
+func _compatible_active_deck() -> Array[String]:
+	var output: Array[String] = []
+	for card_id in active_deck:
+		if cards.has(card_id) and _card_is_allowed(cards[card_id]):
+			output.append(card_id)
+	return output
+
+func _card_is_allowed(card: Dictionary) -> bool:
+	if card.is_empty():
+		return false
+	var technique_id := str(card.get("technique_id", ""))
+	if technique_id == "":
+		return true
+	return bool(DataRegistry.technique_allowed_in_ruleset(technique_id, current_ruleset))
+
+func _normalize_ruleset(ruleset_id: String) -> String:
+	var normalized := str(DataRegistry.normalize_ruleset_id(ruleset_id)) if DataRegistry != null else ""
+	if normalized == "":
+		normalized = str(DataRegistry.get_default_ruleset_id()) if DataRegistry != null else DEFAULT_RULESET
+	return normalized if normalized != "" else DEFAULT_RULESET
 
 func _state_is_valid(card: Dictionary, current_state: String) -> bool:
 	var states: Array = card.get("valid_states", [])

--- a/src/autoloads/DeckManager.gd
+++ b/src/autoloads/DeckManager.gd
@@ -40,7 +40,7 @@ func configure_from_data(source: Dictionary) -> Dictionary:
 		return {"ok": false, "error": "deck_data_missing"}
 	owner_id = str(source.get("owner_id", "ruan_macacao"))
 	belt = str(source.get("belt", "branca"))
-	current_ruleset = _normalize_ruleset(str(source.get("current_ruleset", current_ruleset)))
+	current_ruleset = _normalize_ruleset(str(source.get("current_ruleset", "")), true)
 	for value in source.get("cards", []):
 		if typeof(value) != TYPE_DICTIONARY:
 			continue
@@ -62,7 +62,7 @@ func configure_from_data(source: Dictionary) -> Dictionary:
 	}
 
 func set_ruleset(ruleset_id: String) -> Dictionary:
-	var normalized := _normalize_ruleset(ruleset_id)
+	var normalized := _normalize_ruleset(ruleset_id, false)
 	if normalized == "":
 		return {"ok": false, "error": "ruleset_invalid", "ruleset_id": ruleset_id}
 	current_ruleset = normalized
@@ -80,7 +80,7 @@ func get_ruleset_id() -> String:
 
 func start_combat_hand(ruleset_id: String = "") -> void:
 	if ruleset_id != "":
-		var normalized := _normalize_ruleset(ruleset_id)
+		var normalized := _normalize_ruleset(ruleset_id, false)
 		if normalized != "":
 			current_ruleset = normalized
 	if has_node("/root/WorldState"):
@@ -260,7 +260,7 @@ func get_card_ruleset_status(card_id: String, ruleset_id: String = "") -> Dictio
 	var card: Dictionary = cards.get(card_id, {})
 	if card.is_empty():
 		return {"allowed": false, "reason": "Carta não encontrada.", "ruleset_id": current_ruleset}
-	var resolved_ruleset := current_ruleset if ruleset_id == "" else _normalize_ruleset(ruleset_id)
+	var resolved_ruleset := current_ruleset if ruleset_id == "" else _normalize_ruleset(ruleset_id, false)
 	if resolved_ruleset == "":
 		return {"allowed": false, "reason": "Ruleset de combate inválido.", "ruleset_id": ruleset_id}
 	var technique_id := str(card.get("technique_id", ""))
@@ -342,11 +342,14 @@ func _card_is_allowed(card: Dictionary) -> bool:
 		return true
 	return bool(DataRegistry.technique_allowed_in_ruleset(technique_id, current_ruleset))
 
-func _normalize_ruleset(ruleset_id: String) -> String:
+func _normalize_ruleset(ruleset_id: String, allow_default: bool) -> String:
 	var normalized := str(DataRegistry.normalize_ruleset_id(ruleset_id)) if DataRegistry != null else ""
-	if normalized == "":
-		normalized = str(DataRegistry.get_default_ruleset_id()) if DataRegistry != null else DEFAULT_RULESET
-	return normalized if normalized != "" else DEFAULT_RULESET
+	if normalized != "":
+		return normalized
+	if not allow_default:
+		return ""
+	var fallback := str(DataRegistry.get_default_ruleset_id()) if DataRegistry != null else DEFAULT_RULESET
+	return fallback if fallback != "" else DEFAULT_RULESET
 
 func _state_is_valid(card: Dictionary, current_state: String) -> bool:
 	var states: Array = card.get("valid_states", [])

--- a/tests/ruleset_smoke.gd
+++ b/tests/ruleset_smoke.gd
@@ -25,12 +25,21 @@ func _run() -> void:
 
 	_assert(str(registry.call("normalize_ruleset_id", "kimono")) == "GI", "Alias kimono não normalizou para GI")
 	_assert(str(registry.call("normalize_ruleset_id", "no-gi")) == "NO_GI", "Alias no-gi não normalizou para NO_GI")
+	_assert(str(registry.call("normalize_ruleset_id", "vale_tudo")) == "", "Ruleset desconhecido foi aceito")
 	_assert(str(registry.call("get_default_ruleset_id")) == "GI", "Ruleset padrão não é GI")
 	_assert(bool(registry.call("technique_allowed_in_ruleset", "baiana", "GI")), "Baiana deveria funcionar no GI")
 	_assert(bool(registry.call("technique_allowed_in_ruleset", "baiana", "NO_GI")), "Baiana deveria funcionar no No-Gi")
-	_assert(not bool(registry.call("technique_allowed_in_ruleset", "pegada_lapela_manga", "NO_GI")), "Pegada de lapela foi permitida no No-Gi")
-	_assert(str(registry.call("get_technique_ruleset_block_reason", "pegada_lapela_manga", "NO_GI")).find("lapela") >= 0, "Bloqueio No-Gi não possui explicação em português")
 	_assert(str(registry.call("get_technique_visual_variant", "grip_de_ferro", "NO_GI")) == "grip_de_ferro_punho_collar_tie", "Variante visual No-Gi do Grip de Ferro incorreta")
+
+	var original_rulesets: Dictionary = registry.get("technique_rulesets").duplicate(true)
+	var fixture_rulesets: Dictionary = original_rulesets.duplicate(true)
+	var fixture_policies: Dictionary = fixture_rulesets.get("techniques", {}).duplicate(true)
+	fixture_policies["test_fabric_grip"] = fixture_rulesets.get("fabric_technique_template", {}).duplicate(true)
+	fixture_rulesets["techniques"] = fixture_policies
+	registry.set("technique_rulesets", fixture_rulesets)
+
+	_assert(not bool(registry.call("technique_allowed_in_ruleset", "test_fabric_grip", "NO_GI")), "Fixture de pegada de tecido foi permitida no No-Gi")
+	_assert(str(registry.call("get_technique_ruleset_block_reason", "test_fabric_grip", "NO_GI")).find("tecido") >= 0, "Bloqueio No-Gi não possui explicação em português")
 
 	var fixture := {
 		"schema_version": "1.1.0",
@@ -49,10 +58,10 @@ func _run() -> void:
 				"unlocked": true
 			},
 			{
-				"id": "card_lapela_test",
-				"name": "Pegada Lapela e Manga",
+				"id": "card_tecido_test",
+				"name": "Pegada de Tecido — Fixture",
 				"kind": "active",
-				"technique_id": "pegada_lapela_manga",
+				"technique_id": "test_fabric_grip",
 				"level": 1,
 				"activation_cost": {},
 				"valid_states": ["PLAYER_STANDING_NEUTRAL"],
@@ -60,7 +69,7 @@ func _run() -> void:
 			}
 		],
 		"equipped": {
-			"active": ["card_baiana_test", "card_lapela_test"],
+			"active": ["card_baiana_test", "card_tecido_test"],
 			"passive": []
 		}
 	}
@@ -69,6 +78,11 @@ func _run() -> void:
 	_assert(str(deck.call("get_ruleset_id")) == "GI", "Deck não iniciou em GI")
 	_assert(deck.call("get_hand").size() == 2, "GI não carregou as duas cartas compatíveis")
 
+	var invalid: Dictionary = deck.call("set_ruleset", "vale_tudo")
+	_assert(not bool(invalid.get("ok", true)), "Deck aceitou ruleset explícito inválido")
+	_assert(str(invalid.get("error", "")) == "ruleset_invalid", "Erro de ruleset inválido incorreto")
+	_assert(str(deck.call("get_ruleset_id")) == "GI", "Ruleset inválido alterou o estado atual")
+
 	var no_gi: Dictionary = deck.call("set_ruleset", "NO_GI")
 	_assert(bool(no_gi.get("ok", false)), "Falha ao ativar No-Gi")
 	_assert(str(deck.call("get_ruleset_id")) == "NO_GI", "Deck não registrou No-Gi")
@@ -76,9 +90,9 @@ func _run() -> void:
 	_assert(no_gi_hand.size() == 1, "No-Gi não filtrou exatamente uma carta de tecido")
 	_assert(str(no_gi_hand[0].get("technique_id", "")) == "baiana", "Carta universal não permaneceu na mão No-Gi")
 	var blocked: Array = deck.call("get_blocked_equipped_cards")
-	_assert(blocked.size() == 1, "Carta de lapela não apareceu como bloqueada")
-	_assert(str(blocked[0].get("card_id", "")) == "card_lapela_test", "Carta bloqueada incorreta")
-	_assert(str(blocked[0].get("reason", "")).find("lapela") >= 0, "Carta bloqueada não explica o motivo")
+	_assert(blocked.size() == 1, "Carta de tecido não apareceu como bloqueada")
+	_assert(str(blocked[0].get("card_id", "")) == "card_tecido_test", "Carta bloqueada incorreta")
+	_assert(str(blocked[0].get("reason", "")).find("tecido") >= 0, "Carta bloqueada não explica o motivo")
 
 	var saved: Dictionary = deck.call("to_dict")
 	_assert(saved.get("cards", []).size() == 2, "Troca de ruleset apagou carta da coleção")
@@ -89,6 +103,7 @@ func _run() -> void:
 	_assert(bool(gi.get("ok", false)), "Falha ao retornar ao GI pelo alias")
 	_assert(deck.call("get_hand").size() == 2, "Carta de tecido não retornou ao GI")
 
+	registry.set("technique_rulesets", original_rulesets)
 	deck.call("configure_from_data", registry.get("combat_deck"))
 	_finish()
 

--- a/tests/ruleset_smoke.gd
+++ b/tests/ruleset_smoke.gd
@@ -1,0 +1,103 @@
+extends SceneTree
+
+var failures: Array[String] = []
+var checks := 0
+
+func _initialize() -> void:
+	call_deferred("_run")
+
+func _assert(condition: bool, message: String) -> void:
+	checks += 1
+	if condition:
+		return
+	failures.append(message)
+	push_error("[RulesetSmoke] " + message)
+
+func _run() -> void:
+	await process_frame
+	var registry := root.get_node_or_null("DataRegistry")
+	var deck := root.get_node_or_null("DeckManager")
+	_assert(registry != null, "DataRegistry ausente")
+	_assert(deck != null, "DeckManager ausente")
+	if registry == null or deck == null:
+		_finish()
+		return
+
+	_assert(str(registry.call("normalize_ruleset_id", "kimono")) == "GI", "Alias kimono não normalizou para GI")
+	_assert(str(registry.call("normalize_ruleset_id", "no-gi")) == "NO_GI", "Alias no-gi não normalizou para NO_GI")
+	_assert(str(registry.call("get_default_ruleset_id")) == "GI", "Ruleset padrão não é GI")
+	_assert(bool(registry.call("technique_allowed_in_ruleset", "baiana", "GI")), "Baiana deveria funcionar no GI")
+	_assert(bool(registry.call("technique_allowed_in_ruleset", "baiana", "NO_GI")), "Baiana deveria funcionar no No-Gi")
+	_assert(not bool(registry.call("technique_allowed_in_ruleset", "pegada_lapela_manga", "NO_GI")), "Pegada de lapela foi permitida no No-Gi")
+	_assert(str(registry.call("get_technique_ruleset_block_reason", "pegada_lapela_manga", "NO_GI")).find("lapela") >= 0, "Bloqueio No-Gi não possui explicação em português")
+	_assert(str(registry.call("get_technique_visual_variant", "grip_de_ferro", "NO_GI")) == "grip_de_ferro_punho_collar_tie", "Variante visual No-Gi do Grip de Ferro incorreta")
+
+	var fixture := {
+		"schema_version": "1.1.0",
+		"owner_id": "ruan_macacao",
+		"belt": "branca",
+		"current_ruleset": "GI",
+		"cards": [
+			{
+				"id": "card_baiana_test",
+				"name": "Baiana",
+				"kind": "active",
+				"technique_id": "baiana",
+				"level": 1,
+				"activation_cost": {},
+				"valid_states": ["PLAYER_STANDING_NEUTRAL"],
+				"unlocked": true
+			},
+			{
+				"id": "card_lapela_test",
+				"name": "Pegada Lapela e Manga",
+				"kind": "active",
+				"technique_id": "pegada_lapela_manga",
+				"level": 1,
+				"activation_cost": {},
+				"valid_states": ["PLAYER_STANDING_NEUTRAL"],
+				"unlocked": true
+			}
+		],
+		"equipped": {
+			"active": ["card_baiana_test", "card_lapela_test"],
+			"passive": []
+		}
+	}
+	var configured: Dictionary = deck.call("configure_from_data", fixture)
+	_assert(bool(configured.get("ok", false)), "Deck de teste não foi configurado")
+	_assert(str(deck.call("get_ruleset_id")) == "GI", "Deck não iniciou em GI")
+	_assert(deck.call("get_hand").size() == 2, "GI não carregou as duas cartas compatíveis")
+
+	var no_gi: Dictionary = deck.call("set_ruleset", "NO_GI")
+	_assert(bool(no_gi.get("ok", false)), "Falha ao ativar No-Gi")
+	_assert(str(deck.call("get_ruleset_id")) == "NO_GI", "Deck não registrou No-Gi")
+	var no_gi_hand: Array = deck.call("get_hand")
+	_assert(no_gi_hand.size() == 1, "No-Gi não filtrou exatamente uma carta de tecido")
+	_assert(str(no_gi_hand[0].get("technique_id", "")) == "baiana", "Carta universal não permaneceu na mão No-Gi")
+	var blocked: Array = deck.call("get_blocked_equipped_cards")
+	_assert(blocked.size() == 1, "Carta de lapela não apareceu como bloqueada")
+	_assert(str(blocked[0].get("card_id", "")) == "card_lapela_test", "Carta bloqueada incorreta")
+	_assert(str(blocked[0].get("reason", "")).find("lapela") >= 0, "Carta bloqueada não explica o motivo")
+
+	var saved: Dictionary = deck.call("to_dict")
+	_assert(saved.get("cards", []).size() == 2, "Troca de ruleset apagou carta da coleção")
+	_assert(saved.get("equipped", {}).get("active", []).size() == 2, "Troca de ruleset removeu carta equipada")
+	_assert(str(saved.get("current_ruleset", "")) == "NO_GI", "Save do deck não preservou o ruleset")
+
+	var gi: Dictionary = deck.call("set_ruleset", "kimono")
+	_assert(bool(gi.get("ok", false)), "Falha ao retornar ao GI pelo alias")
+	_assert(deck.call("get_hand").size() == 2, "Carta de tecido não retornou ao GI")
+
+	deck.call("configure_from_data", registry.get("combat_deck"))
+	_finish()
+
+func _finish() -> void:
+	if failures.is_empty():
+		print("[RulesetSmoke] OK - %d verificações" % checks)
+		quit(0)
+		return
+	print("[RulesetSmoke] FALHOU - %d de %d verificações" % [failures.size(), checks])
+	for failure in failures:
+		print(" - " + failure)
+	quit(1)

--- a/tests/test_rulesets_v4_3.py
+++ b/tests/test_rulesets_v4_3.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load(relative: str) -> dict:
+    return json.loads((ROOT / relative).read_text(encoding="utf-8"))
+
+
+def test_rulesets_define_distinct_grip_and_attire_models() -> None:
+    data = load("data/combat/rulesets_v01.json")
+    assert data["default_ruleset_id"] == "GI"
+    by_id = {item["id"]: item for item in data["rulesets"]}
+    assert set(by_id) == {"GI", "NO_GI"}
+    assert by_id["GI"]["grip_model"]["fabric_grips_allowed"] is True
+    assert by_id["NO_GI"]["grip_model"]["fabric_grips_allowed"] is False
+    assert by_id["GI"]["attire"]["visual_variant"] == "gi"
+    assert by_id["NO_GI"]["attire"]["visual_variant"] == "no_gi"
+    assert by_id["GI"]["audio_profile"] != by_id["NO_GI"]["audio_profile"]
+
+
+def test_lapel_is_blocked_but_initial_deck_survives_no_gi() -> None:
+    projection = load("data/combat/technique_rulesets_v01.json")
+    policies = projection["techniques"]
+    assert policies["pegada_lapela_manga"]["rulesets"] == ["GI"]
+    assert policies["pegada_lapela_manga"]["requires_fabric"] is True
+
+    deck = load("data/ruan_deck_inicial.json")
+    technique_ids = {
+        card["technique_id"] for card in deck["cards"] if card.get("technique_id")
+    }
+    assert technique_ids
+    assert technique_ids.issubset(policies)
+    for technique_id in technique_ids:
+        assert policies[technique_id]["rulesets"] == ["GI", "NO_GI"]
+        assert policies[technique_id]["requires_fabric"] is False
+
+
+def test_contract_does_not_claim_no_gi_playable_in_first_batch() -> None:
+    contract = load("data/production/ruleset_contract_v4_3.json")
+    batches = {item["id"]: item for item in contract["delivery_batches"]}
+    assert batches["v4_3a"]["playable_no_gi"] is False
+    assert batches["v4_3b"]["playable_no_gi"] is True
+    assert contract["vertical_slice"]["ruleset"] == "NO_GI"
+    assert "claiming_no_gi_playable_before_v4_3b" in contract["forbidden_in_v4_3a"]
+
+
+def test_validator_cli_passes() -> None:
+    result = subprocess.run(
+        [sys.executable, "tools/audit/validate_rulesets_v4_3.py"],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/test_rulesets_v4_3.py
+++ b/tests/test_rulesets_v4_3.py
@@ -24,11 +24,17 @@ def test_rulesets_define_distinct_grip_and_attire_models() -> None:
     assert by_id["GI"]["audio_profile"] != by_id["NO_GI"]["audio_profile"]
 
 
-def test_lapel_is_blocked_but_initial_deck_survives_no_gi() -> None:
+def test_fabric_template_is_gi_only_and_projection_uses_source_ids() -> None:
     projection = load("data/combat/technique_rulesets_v01.json")
+    fabric = projection["fabric_technique_template"]
+    assert fabric["rulesets"] == ["GI"]
+    assert fabric["requires_fabric"] is True
+    assert "tecido" in fabric["blocked_reason"].lower()
+
+    source = load("data/techniques.json")
+    source_ids = {item["id"] for item in source["techniques"]}
     policies = projection["techniques"]
-    assert policies["pegada_lapela_manga"]["rulesets"] == ["GI"]
-    assert policies["pegada_lapela_manga"]["requires_fabric"] is True
+    assert set(policies).issubset(source_ids)
 
     deck = load("data/ruan_deck_inicial.json")
     technique_ids = {
@@ -44,10 +50,23 @@ def test_lapel_is_blocked_but_initial_deck_survives_no_gi() -> None:
 def test_contract_does_not_claim_no_gi_playable_in_first_batch() -> None:
     contract = load("data/production/ruleset_contract_v4_3.json")
     batches = {item["id"]: item for item in contract["delivery_batches"]}
+    assert contract["master_tracking_issue"] == 46
+    assert contract["source_contract"] == "data/production/combat_master_contract_v2.json"
     assert batches["v4_3a"]["playable_no_gi"] is False
     assert batches["v4_3b"]["playable_no_gi"] is True
     assert contract["vertical_slice"]["ruleset"] == "NO_GI"
     assert "claiming_no_gi_playable_before_v4_3b" in contract["forbidden_in_v4_3a"]
+
+
+def test_master_contract_freezes_clamp_and_grapplemap_limits() -> None:
+    contract = load("data/production/combat_master_contract_v2.json")
+    invariants = contract["combat_invariants"]
+    assert invariants["technique_source"] == "data/techniques.json"
+    assert invariants["instant_finish"] is False
+    assert invariants["clash_modifier_min"] == -0.3
+    assert invariants["clash_modifier_max"] == 0.35
+    assert "authoritative_real_world_timing" in contract["grapplemap"]["forbidden_claims"]
+    assert "gi_specific_coverage" in contract["grapplemap"]["forbidden_claims"]
 
 
 def test_validator_cli_passes() -> None:

--- a/tools/audit/validate_rulesets_v4_3.py
+++ b/tools/audit/validate_rulesets_v4_3.py
@@ -67,7 +67,7 @@ def validate_technique_projection() -> None:
         assert techniques[technique_id]["requires_fabric"] is False, technique_id
 
 
-def validate_contract() -> None:
+def validate_ruleset_contract() -> None:
     contract = load_json("data/production/ruleset_contract_v4_3.json")
     assert contract["tracking_issue"] == 44
     assert contract["ruleset_ids"] == RULESET_IDS
@@ -82,6 +82,43 @@ def validate_contract() -> None:
     assert contract["vertical_slice"]["ruleset"] == "NO_GI"
     assert contract["vertical_slice"]["player"] == "ruan_macacao"
     assert contract["vertical_slice"]["opponent"] == "davi_relampago"
+
+
+def validate_master_contract_and_clash() -> None:
+    contract = load_json("data/production/combat_master_contract_v2.json")
+    invariants = contract["combat_invariants"]
+    assert contract["tracking_issue"] == 46
+    assert contract["runtime"]["generative_ai_allowed"] is False
+    assert contract["runtime"]["critical_loop_network_dependency_allowed"] is False
+    assert invariants["technique_source"] == "data/techniques.json"
+    assert invariants["position_before_submission"] is True
+    assert invariants["instant_finish"] is False
+    assert invariants["clash_modifier_min"] == -0.3
+    assert invariants["clash_modifier_max"] == 0.35
+    assert invariants["submission_end_states"] == [
+        "tap",
+        "escape",
+        "technical_intervention",
+    ]
+    assert contract["grapplemap"]["declared_license"] == "public_domain"
+    assert "authoritative_real_world_timing" in contract["grapplemap"]["forbidden_claims"]
+    assert "gi_specific_coverage" in contract["grapplemap"]["forbidden_claims"]
+    assert contract["delivery"]["golden_vertical_slice_before_scale"] is True
+
+    resolver = read_text("src/combat/TechniqueClashResolver.gd")
+    assert '"instant_finish": false' in resolver
+    assert "clampf(chance_modifier, -0.30, 0.35)" in resolver
+    assert 'chance_modifier = 0.25' in resolver
+    assert 'chance_modifier = 0.12' in resolver
+    assert 'chance_modifier = 0.03' in resolver
+    assert 'chance_modifier = -0.18' in resolver
+
+    project = read_text("project.godot")
+    assert 'CombatManager="*res://src/autoloads/CombatManager.gd"' in project
+    assert 'DeckManager="*res://src/autoloads/DeckManager.gd"' in project
+    assert 'DataRegistry="*res://src/autoloads/DataRegistry.gd"' in project
+    assert 'SaveManager="*res://src/autoloads/SaveManager.gd"' in project
+    assert 'AudioManager="*res://src/autoloads/AudioManager.gd"' in project
 
 
 def validate_registry_and_deck() -> None:
@@ -129,7 +166,8 @@ def main() -> int:
     checks = [
         validate_rulesets,
         validate_technique_projection,
-        validate_contract,
+        validate_ruleset_contract,
+        validate_master_contract_and_clash,
         validate_registry_and_deck,
         validate_tests_and_quality_gate,
     ]
@@ -144,7 +182,7 @@ def main() -> int:
         for error in errors:
             print(f" - {error}")
         return 1
-    print("[RulesetsV4.3] OK - GI e No-Gi, projeção e filtro de deck validados")
+    print("[RulesetsV4.3] OK - GI, No-Gi, contrato mestre, clamp e deck validados")
     return 0
 
 

--- a/tools/audit/validate_rulesets_v4_3.py
+++ b/tools/audit/validate_rulesets_v4_3.py
@@ -42,12 +42,17 @@ def validate_technique_projection() -> None:
     default = projection["default_policy"]
     assert default["rulesets"] == RULESET_IDS
     assert default["requires_fabric"] is False
+
+    fabric = projection["fabric_technique_template"]
+    assert fabric["rulesets"] == ["GI"]
+    assert fabric["requires_fabric"] is True
+    assert "tecido" in fabric["blocked_reason"].lower()
+
     techniques = projection["techniques"]
-    lapel = techniques["pegada_lapela_manga"]
-    assert lapel["rulesets"] == ["GI"]
-    assert lapel["requires_fabric"] is True
-    assert "lapela" in lapel["blocked_reason"].lower()
-    assert "NO_GI" not in lapel.get("visual_variants", {})
+    source = load_json("data/techniques.json")
+    source_ids = {item["id"] for item in source["techniques"]}
+    assert set(techniques).issubset(source_ids), sorted(set(techniques) - source_ids)
+    assert projection["policy"]["projection_ids_must_exist_in_source_catalog"] is True
 
     grip = techniques["grip_de_ferro"]
     assert grip["rulesets"] == RULESET_IDS
@@ -70,12 +75,16 @@ def validate_technique_projection() -> None:
 def validate_ruleset_contract() -> None:
     contract = load_json("data/production/ruleset_contract_v4_3.json")
     assert contract["tracking_issue"] == 44
+    assert contract["master_tracking_issue"] == 46
+    assert contract["source_contract"] == "data/production/combat_master_contract_v2.json"
     assert contract["ruleset_ids"] == RULESET_IDS
     assert contract["default_ruleset_id"] == "GI"
     assert contract["product_decisions"]["gi_and_no_gi_are_canonical"] is True
     assert contract["product_decisions"]["no_gi_is_not_cosmetic_only"] is True
     assert contract["compatibility_policy"]["equipped_cards_must_not_be_deleted"] is True
     assert contract["compatibility_policy"]["incompatible_cards_must_not_enter_combat_hand"] is True
+    assert "real_world_timing" in contract["reference_policy"]["grapplemap_not_authoritative_for"]
+    assert "gi_specific_grips" in contract["reference_policy"]["grapplemap_not_authoritative_for"]
     batches = {item["id"]: item for item in contract["delivery_batches"]}
     assert batches["v4_3a"]["playable_no_gi"] is False
     assert batches["v4_3b"]["playable_no_gi"] is True
@@ -108,10 +117,10 @@ def validate_master_contract_and_clash() -> None:
     resolver = read_text("src/combat/TechniqueClashResolver.gd")
     assert '"instant_finish": false' in resolver
     assert "clampf(chance_modifier, -0.30, 0.35)" in resolver
-    assert 'chance_modifier = 0.25' in resolver
-    assert 'chance_modifier = 0.12' in resolver
-    assert 'chance_modifier = 0.03' in resolver
-    assert 'chance_modifier = -0.18' in resolver
+    assert "chance_modifier = 0.25" in resolver
+    assert "chance_modifier = 0.12" in resolver
+    assert "chance_modifier = 0.03" in resolver
+    assert "chance_modifier = -0.18" in resolver
 
     project = read_text("project.godot")
     assert 'CombatManager="*res://src/autoloads/CombatManager.gd"' in project
@@ -133,6 +142,7 @@ def validate_registry_and_deck() -> None:
         "func technique_allowed_in_ruleset",
         "func get_technique_ruleset_block_reason",
         "func get_technique_visual_variant",
+        "projecao de ruleset referencia tecnica fora de data/techniques.json",
     ]:
         assert token in registry, token
 
@@ -143,7 +153,9 @@ def validate_registry_and_deck() -> None:
         "func get_card_ruleset_status",
         "func get_blocked_equipped_cards",
         "func _compatible_active_deck",
+        "func _normalize_ruleset(ruleset_id: String, allow_default: bool)",
         '"current_ruleset": current_ruleset',
+        '"error": "ruleset_invalid"',
     ]:
         assert token in deck, token
 
@@ -155,11 +167,13 @@ def validate_registry_and_deck() -> None:
 def validate_tests_and_quality_gate() -> None:
     smoke = read_text("tests/ruleset_smoke.gd")
     package = load_json("package.json")
-    assert "pegada_lapela_manga" in smoke
-    assert "set_ruleset" in smoke
+    workflow = read_text(".github/workflows/full-game-hardening.yml")
+    assert "test_fabric_grip" in smoke
+    assert "ruleset_invalid" in smoke
     assert "Troca de ruleset apagou carta da coleção" in smoke
     assert "validate:rulesets" in package["scripts"]
     assert "validate:rulesets" in package["scripts"]["quality"]
+    assert "res://tests/ruleset_smoke.gd" in workflow
 
 
 def main() -> int:
@@ -182,7 +196,7 @@ def main() -> int:
         for error in errors:
             print(f" - {error}")
         return 1
-    print("[RulesetsV4.3] OK - GI, No-Gi, contrato mestre, clamp e deck validados")
+    print("[RulesetsV4.3] OK - GI, No-Gi, fonte única, clamp e deck validados")
     return 0
 
 

--- a/tools/audit/validate_rulesets_v4_3.py
+++ b/tools/audit/validate_rulesets_v4_3.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+RULESET_IDS = ["GI", "NO_GI"]
+
+
+def read_text(relative: str) -> str:
+    path = ROOT / relative
+    if not path.is_file():
+        raise AssertionError(f"arquivo obrigatório ausente: {relative}")
+    return path.read_text(encoding="utf-8")
+
+
+def load_json(relative: str) -> dict:
+    return json.loads(read_text(relative))
+
+
+def validate_rulesets() -> None:
+    data = load_json("data/combat/rulesets_v01.json")
+    assert data["default_ruleset_id"] == "GI"
+    rulesets = data["rulesets"]
+    assert [item["id"] for item in rulesets] == RULESET_IDS
+    by_id = {item["id"]: item for item in rulesets}
+    assert by_id["GI"]["grip_model"]["fabric_grips_allowed"] is True
+    assert by_id["NO_GI"]["grip_model"]["fabric_grips_allowed"] is False
+    assert "kimono" in by_id["NO_GI"]["attire"]["forbidden"]
+    assert "rashguard" in by_id["NO_GI"]["attire"]["required"]
+    assert "body_lock" in by_id["NO_GI"]["grip_model"]["allowed_types"]
+    assert by_id["GI"]["runtime_policy"]["offline_required"] is True
+    assert by_id["NO_GI"]["runtime_policy"]["offline_required"] is True
+    assert by_id["GI"]["runtime_policy"]["automatic_submission_forbidden"] is True
+    assert by_id["NO_GI"]["runtime_policy"]["automatic_submission_forbidden"] is True
+
+
+def validate_technique_projection() -> None:
+    projection = load_json("data/combat/technique_rulesets_v01.json")
+    default = projection["default_policy"]
+    assert default["rulesets"] == RULESET_IDS
+    assert default["requires_fabric"] is False
+    techniques = projection["techniques"]
+    lapel = techniques["pegada_lapela_manga"]
+    assert lapel["rulesets"] == ["GI"]
+    assert lapel["requires_fabric"] is True
+    assert "lapela" in lapel["blocked_reason"].lower()
+    assert "NO_GI" not in lapel.get("visual_variants", {})
+
+    grip = techniques["grip_de_ferro"]
+    assert grip["rulesets"] == RULESET_IDS
+    assert grip["visual_variants"]["GI"] != grip["visual_variants"]["NO_GI"]
+    assert grip["contact_anchors"]["GI"] != grip["contact_anchors"]["NO_GI"]
+
+    initial_deck = load_json("data/ruan_deck_inicial.json")
+    card_techniques = {
+        card["technique_id"]
+        for card in initial_deck["cards"]
+        if card.get("technique_id")
+    }
+    missing = card_techniques - set(techniques)
+    assert not missing, f"cartas sem política explícita de ruleset: {sorted(missing)}"
+    for technique_id in card_techniques:
+        assert techniques[technique_id]["rulesets"] == RULESET_IDS, technique_id
+        assert techniques[technique_id]["requires_fabric"] is False, technique_id
+
+
+def validate_contract() -> None:
+    contract = load_json("data/production/ruleset_contract_v4_3.json")
+    assert contract["tracking_issue"] == 44
+    assert contract["ruleset_ids"] == RULESET_IDS
+    assert contract["default_ruleset_id"] == "GI"
+    assert contract["product_decisions"]["gi_and_no_gi_are_canonical"] is True
+    assert contract["product_decisions"]["no_gi_is_not_cosmetic_only"] is True
+    assert contract["compatibility_policy"]["equipped_cards_must_not_be_deleted"] is True
+    assert contract["compatibility_policy"]["incompatible_cards_must_not_enter_combat_hand"] is True
+    batches = {item["id"]: item for item in contract["delivery_batches"]}
+    assert batches["v4_3a"]["playable_no_gi"] is False
+    assert batches["v4_3b"]["playable_no_gi"] is True
+    assert contract["vertical_slice"]["ruleset"] == "NO_GI"
+    assert contract["vertical_slice"]["player"] == "ruan_macacao"
+    assert contract["vertical_slice"]["opponent"] == "davi_relampago"
+
+
+def validate_registry_and_deck() -> None:
+    registry = read_text("src/autoloads/DataRegistry.gd")
+    deck = read_text("src/autoloads/DeckManager.gd")
+    project = read_text("project.godot")
+
+    for token in [
+        '"combat_rulesets": "res://data/combat/rulesets_v01.json"',
+        '"technique_rulesets": "res://data/combat/technique_rulesets_v01.json"',
+        "func normalize_ruleset_id",
+        "func technique_allowed_in_ruleset",
+        "func get_technique_ruleset_block_reason",
+        "func get_technique_visual_variant",
+    ]:
+        assert token in registry, token
+
+    for token in [
+        'const DEFAULT_RULESET := "GI"',
+        "var current_ruleset",
+        "func set_ruleset",
+        "func get_card_ruleset_status",
+        "func get_blocked_equipped_cards",
+        "func _compatible_active_deck",
+        '"current_ruleset": current_ruleset',
+    ]:
+        assert token in deck, token
+
+    assert "RulesetManager=" not in project
+    assert project.count('DeckManager="*res://src/autoloads/DeckManager.gd"') == 1
+    assert project.count('CombatManager="*res://src/autoloads/CombatManager.gd"') == 1
+
+
+def validate_tests_and_quality_gate() -> None:
+    smoke = read_text("tests/ruleset_smoke.gd")
+    package = load_json("package.json")
+    assert "pegada_lapela_manga" in smoke
+    assert "set_ruleset" in smoke
+    assert "Troca de ruleset apagou carta da coleção" in smoke
+    assert "validate:rulesets" in package["scripts"]
+    assert "validate:rulesets" in package["scripts"]["quality"]
+
+
+def main() -> int:
+    checks = [
+        validate_rulesets,
+        validate_technique_projection,
+        validate_contract,
+        validate_registry_and_deck,
+        validate_tests_and_quality_gate,
+    ]
+    errors: list[str] = []
+    for check in checks:
+        try:
+            check()
+        except Exception as exc:  # noqa: BLE001 - CLI agrega todas as falhas
+            errors.append(f"{check.__name__}: {exc}")
+    if errors:
+        print("[RulesetsV4.3] FALHOU")
+        for error in errors:
+            print(f" - {error}")
+        return 1
+    print("[RulesetsV4.3] OK - GI e No-Gi, projeção e filtro de deck validados")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/audit/validate_rulesets_v4_3.py
+++ b/tools/audit/validate_rulesets_v4_3.py
@@ -119,7 +119,7 @@ def validate_master_contract_and_clash() -> None:
     assert "clampf(chance_modifier, -0.30, 0.35)" in resolver
     assert "chance_modifier = 0.25" in resolver
     assert "chance_modifier = 0.12" in resolver
-    assert "chance_modifier = 0.03" in resolver
+    assert "var chance_modifier := 0.03" in resolver
     assert "chance_modifier = -0.18" in resolver
 
     project = read_text("project.godot")


### PR DESCRIPTION
## Objetivo

Executar o lote **V4.3A** dos EPICs #44 e #46: estabelecer GI e No-Gi como rulesets canônicos, criar contratos executáveis, carregar as políticas no `DataRegistry` e filtrar cartas incompatíveis no `DeckManager` sem apagar coleção, equipamento ou save.

## Escopo entregue

- contrato mestre v2 para combate, progressão, arenas e pipeline visual;
- contrato de entrega V4.3 por lotes A/B/C;
- dados canônicos de `GI` e `NO_GI`;
- projeção de compatibilidade de técnicas baseada exclusivamente em `data/techniques.json`;
- aliases de ruleset (`kimono`, `no-gi`, `sem_kimono` etc.);
- variantes de pegada e visual por ruleset;
- filtro da mão de combate por ruleset;
- cartas incompatíveis permanecem na coleção e equipadas;
- motivo de bloqueio em português brasileiro;
- ruleset explícito inválido retorna `ruleset_invalid` em vez de cair silenciosamente em GI;
- smoke Godot dedicado integrado ao Full Game Hardening;
- validator Python integrado ao `npm run quality`;
- atualização de governança, índice e instruções para agentes.

## Integração e consumidores reais

- `DataRegistry` carrega `rulesets_v01.json` e `technique_rulesets_v01.json`;
- `DeckManager` usa essas políticas ao montar mão, selecionar carta, buscar ataque/defesa e aplicar passivos;
- `.github/workflows/full-game-hardening.yml` executa `tests/ruleset_smoke.gd` antes do full game smoke e do APK;
- `npm run quality` executa `validate:rulesets`.

## Fonte única de técnicas

`data/techniques.json` continua sendo a única fonte de técnicas. O validator falha se uma política de ruleset apontar para ID ausente nesse catálogo. A técnica de tecido usada no smoke é uma fixture temporária injetada somente durante o teste.

## GrappleMap — uso corrigido

O repositório `Eelis/GrappleMap` declara código e dados em domínio público. O próprio README, porém, informa que:

- não contém técnicas específicas de Gi;
- as animações são esquemáticas;
- timing real não é capturado com precisão.

Portanto, o contrato permite GrappleMap para grafo, taxonomia, poses, entanglements e sequência esquemática, mas proíbe tratá-lo como fonte autoritativa de timing, pegadas de tecido, biomecânica ou arte final.

## Garantias congeladas

- `instant_finish` permanece sempre falso;
- clash permanece limitado a `[-0.30, +0.35]`;
- IA generativa permanece fora do runtime;
- nenhum novo autoload ou manager paralelo;
- GI é o padrão de compatibilidade;
- No-Gi não pode ser apenas troca de roupa.

## Fora do escopo

Este PR **não**:

- altera `project.godot`;
- modifica `CombatManager`, `SaveManager`, HUD, missões ou arenas;
- torna o No-Gi selecionável no fluxo completo;
- adiciona sprites, animações ou áudio finais;
- implementa os cinco novos estados posicionais;
- adiciona as 29 técnicas restantes;
- declara o vertical slice Ruan × Davi pronto.

O No-Gi só será considerado jogável após o V4.3B integrar combate, save, missões e HUD. O V4.3C entregará arte, áudio e QA do vertical slice.

## Testes obrigatórios

```bash
python tools/audit/validate_rulesets_v4_3.py
python -m pytest -q tests/test_rulesets_v4_3.py
npm run quality
godot --headless --editor --path . --import
godot --headless --path . --script res://tests/ruleset_smoke.gd
godot --headless --path . --script res://tests/full_game_smoke.gd
```

A CI deve concluir também parser/import, runtime smoke, faction smoke, todos os testes Python e exportação/inspeção do APK Android ARM64.

## Riscos

- o ruleset ainda não é passado ao `CombatManager`; isso pertence ao V4.3B;
- variantes visuais são IDs contratuais, não assets finalizados;
- multiplicadores de ritmo e pegada ainda precisam de revisão biomecânica e balanceamento humano;
- GrappleMap não valida timing real nem Gi;
- teste físico Android continua obrigatório antes de release.

## Rollback

Reverter este PR remove os contratos e restaura o deck sem filtro de ruleset. Nenhuma carta ou save existente é destruído por este lote.

## Próximo lote

**V4.3B — integrar `ruleset_id` ao `CombatManager`, save, missões e HUD, tornando GI/No-Gi selecionáveis e jogáveis.**

Relaciona-se a #44 e #46. Sucede o PR #45.