### PR TITLE
feat(arena): Festival Maré Alta em Pratigi (apostas + heat)

### DIFF
--- a/data/arenas.json
+++ b/data/arenas.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.0",
+  "version": "0.2.0",
   "arenas": [
     {
       "id": "terreiro_da_luta",
@@ -44,6 +44,28 @@
       "type": "hype_arena",
       "visual_identity": "areia, sol, crowd regional, barracas e mar",
       "modifiers": {"hype_bonus": 4, "speed_penalty": 0.08}
+    },
+    {
+      "id": "praia_de_pratigi_festival",
+      "name": "Festival Maré Alta — Rota Paralela",
+      "region": "Praia de Pratigi, Ituberá - Bahia",
+      "type": "clandestine_parallel_event",
+      "parallel_variant_of": "praia_de_pratigi",
+      "fictional_event": true,
+      "officially_sanctioned": false,
+      "referee_role": "community_mediator",
+      "visual_identity": "praia noturna, palco de DJ ficcional, crowd de rave regional, maré animada e cantos azul/dourado",
+      "music_theme": "electronic_baixo_sul_original_candidate",
+      "modifiers": {
+        "hype_bonus": 6,
+        "speed_penalty": 0.1,
+        "gas_drain_multiplier": 1.08,
+        "crowd_pressure": 0.15,
+        "authority_heat": true,
+        "technical_stoppage": true
+      },
+      "narrative_tags": ["rota_paralela", "tentacao_hype", "consequencia", "cria_live", "16_plus"],
+      "asset_requirements": ["bg_far_ocean_night", "animated_water_line", "dj_stage", "rave_crowd", "community_referee", "blue_gold_corners"]
     },
     {
       "id": "colonia_nishimura",

--- a/data/arenas/arena_story_gameplay_v01.json
+++ b/data/arenas/arena_story_gameplay_v01.json
@@ -37,6 +37,14 @@
       "mission_links": ["ato3_comunicado_ou_silencio"],
       "visual_mood": "areia, mar, celulares, crowd leve"
     },
+    "praia_de_pratigi_festival": {
+      "role": "rota paralela de hype, aposta e consequencia",
+      "story_function": "Uma versão ficcional noturna de Pratigi onde o palco amplifica a tentação do público e a exposição chama atenção das autoridades.",
+      "gameplay_modifiers": {"explosion_penalty": -0.10, "hype_on_win": 4, "sombra_on_entry": 1, "authority_heat": true},
+      "mission_links": ["molho_pratigi_silencio"],
+      "visual_mood": "praia noturna, DJ ficcional, crowd dançando, maré viva, luz lenta ciano/magenta",
+      "safety": {"technical_stoppage": true, "authority_evasion": false, "real_money_betting": false}
+    },
     "colonia_nishimura": {
       "role": "disciplina fria",
       "story_function": "Lugar de silencio, precisao e custo do erro.",

--- a/data/arenas/pratigi_festival_v01.json
+++ b/data/arenas/pratigi_festival_v01.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "pratigi_festival_event_v1",
+  "version": "1.0.0",
+  "arena_id": "praia_de_pratigi_festival",
+  "base_arena_id": "praia_de_pratigi",
+  "display_name": "Festival Maré Alta — Rota Paralela",
+  "status": "fictional_parallel_variant",
+  "location": {
+    "municipality": "itubera",
+    "region": "Praia de Pratigi, Baixo Sul da Bahia",
+    "geo_policy": "fictional_event_inside_canonical_pratigi_anchor"
+  },
+  "content_policy": {
+    "age_rating": "16+",
+    "real_brand_references": false,
+    "drug_depiction": false,
+    "real_money_gambling": false,
+    "authority_evasion_gameplay": false,
+    "technical_stoppage_required": true
+  },
+  "presentation": {
+    "time": "night",
+    "crowd_style": "rave_regional_ficcional",
+    "dj_stage": true,
+    "community_referee": true,
+    "officially_sanctioned": false,
+    "corners": ["azul", "dourado"],
+    "sensory_safe_strobe_hz_max": 2.0,
+    "crowd_count_mobile": 40
+  },
+  "betting": {
+    "enabled": true,
+    "currency": "moeda_interna",
+    "real_money_allowed": false,
+    "minimum_stake": 0,
+    "maximum_stake": 150,
+    "stake_step": 25,
+    "payout_multiplier": 1.75,
+    "transparent_odds": true,
+    "purchase_with_real_money": false
+  },
+  "heat": {
+    "starting_value": 20.0,
+    "passive_per_second": 0.42,
+    "bet_exposure": 4.0,
+    "technique_exposure": 1.4,
+    "successful_technique_bonus": 1.6,
+    "technical_phase_bonus": 2.0,
+    "warning_threshold": 65.0,
+    "interdiction_threshold": 100.0
+  },
+  "tide": {
+    "visual_cycle_seconds": 124.2,
+    "low_threshold": 0.35,
+    "high_threshold": 0.65,
+    "animated_water_line": true
+  },
+  "consequences": {
+    "participation": {"hype": 1.0, "sombra": 1.0},
+    "clean_win": {"hype": 4.0, "honra": 1.0},
+    "interdiction": {"hype": 1.0, "sombra": 3.0, "honra": -2.0},
+    "cria_live_authority_attention": 18.0
+  }
+}

--- a/data/world/hubs_dense_v01.json
+++ b/data/world/hubs_dense_v01.json
@@ -53,7 +53,9 @@
       "npc_pool": ["leoa_quilombola", "pescadores", "tinker_bell", "moradores_raiz"],
       "activities": ["treino_base_lama", "corrida_mangue", "missao_raiz", "descanso_natureza"],
       "reactivity": {"raiz_high": "atalhos_abrem", "sombra_high": "moradores_fecham_portas", "legado_high": "leoa_ensina_raspagem"}
-    },
+    }
+  },
+  "event_destinations": {
     "pratigi_festival": {
       "name": "Pratigi — Festival Maré Alta",
       "role": "parallel_hype_event",
@@ -63,7 +65,7 @@
       "unlock_act": 2,
       "locations": ["praia_de_pratigi", "palco_mare_alta", "arena_areia", "ponto_cria_live"],
       "npc_pool": ["dj_veneno", "fans", "mediador_comunitario", "equipe_evento"],
-      "activities": ["luta_pratigi_paralela", "observar_mare", "cria_live_hype"],
+      "features": ["luta_pratigi_paralela", "mare_visual", "cria_live_hype"],
       "reactivity": {"hype_high": "crowd_grita_macacao", "honra_low": "mediador_desconfia", "sombra_high": "autoridades_observam"},
       "content_policy": {"fictional_event": true, "real_money_betting": false, "authority_evasion": false}
     }

--- a/data/world/hubs_dense_v01.json
+++ b/data/world/hubs_dense_v01.json
@@ -53,6 +53,19 @@
       "npc_pool": ["leoa_quilombola", "pescadores", "tinker_bell", "moradores_raiz"],
       "activities": ["treino_base_lama", "corrida_mangue", "missao_raiz", "descanso_natureza"],
       "reactivity": {"raiz_high": "atalhos_abrem", "sombra_high": "moradores_fecham_portas", "legado_high": "leoa_ensina_raspagem"}
+    },
+    "pratigi_festival": {
+      "name": "Pratigi — Festival Maré Alta",
+      "role": "parallel_hype_event",
+      "entry_scene": "res://scenes/combat/arenas/PratigiFestivalArena.tscn",
+      "travel_cost": 25,
+      "travel_hours": 2,
+      "unlock_act": 2,
+      "locations": ["praia_de_pratigi", "palco_mare_alta", "arena_areia", "ponto_cria_live"],
+      "npc_pool": ["dj_veneno", "fans", "mediador_comunitario", "equipe_evento"],
+      "activities": ["luta_pratigi_paralela", "observar_mare", "cria_live_hype"],
+      "reactivity": {"hype_high": "crowd_grita_macacao", "honra_low": "mediador_desconfia", "sombra_high": "autoridades_observam"},
+      "content_policy": {"fictional_event": true, "real_money_betting": false, "authority_evasion": false}
     }
   }
 }

--- a/docs/04_ARENA_BIBLE.md
+++ b/docs/04_ARENA_BIBLE.md
@@ -31,6 +31,12 @@ Cada arena deve ter identidade visual, trilha, mecânica e consequência narrati
 - Visual: areia, sol, barracas, crowd regional.
 - Modificadores: queda de velocidade, hype alto.
 
+#### Variante — Festival Maré Alta (Rota Paralela)
+- Status: evento noturno ficcional; não substitui a Praia de Pratigi canônica.
+- Visual: palco de DJ ficcional, crowd dançando ao redor, cantos azul/dourado e linha d'água animada.
+- Mecânica: aposta opcional apenas com moeda interna, heat visível, aviso e interdição segura.
+- Consequência: Cria Live, hype, sombra e atenção de autoridade; não existe gameplay de fuga.
+
 ### Zambiapunga
 - Função: cultura, ritmo e pressão coletiva.
 - Modificadores: moral e foco oscilam com o público.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -26,6 +26,7 @@ Este arquivo é a porta de entrada da documentação ativa. Antes de criar um do
 - [`gameplay/COMBAT_DECK_SYSTEM_V01.md`](gameplay/COMBAT_DECK_SYSTEM_V01.md) — deck atual integrado à `main`;
 - `canon/` — personagens, facções, mundo e narrativa aprovados;
 - `gameplay/` — combate, progressão, regras e economia.
+- [`implementation/PRATIGI_FESTIVAL_ARENA_V01.md`](implementation/PRATIGI_FESTIVAL_ARENA_V01.md) — arena paralela de Pratigi, aposta interna, heat, interdição e limites de escopo.
 
 ## Migrações ativas
 

--- a/docs/implementation/PRATIGI_FESTIVAL_ARENA_V01.md
+++ b/docs/implementation/PRATIGI_FESTIVAL_ARENA_V01.md
@@ -2,7 +2,7 @@
 
 **Status:** IMPLEMENTED — vertical slice de runtime; arte e áudio finais ainda pendentes de produção humana.
 **Versão:** 1.0.0
-**Escopo:** arena jogável de Pratigi, aposta interna opcional, heat, interdição, maré visual, Cria Live e acesso pelo mapa.
+**Escopo:** arena jogável de Pratigi, aposta interna opcional, heat, interdição, maré visual, Cria Live e acesso pelo mapa como destino de evento.
 
 ## Decisão de produto
 
@@ -38,7 +38,7 @@ Terreiro → Mapa do Baixo Sul → Pratigi (Ato 2)
 
 ## Rollback
 
-Remover o hub `pratigi_festival`, o botão do mapa, a variante em `arenas.json` e os arquivos listados acima. As alterações aditivas de `CombatArenaBase`, `CombatManager`, `AudioManager` e `CriaLiveManager` podem ser revertidas separadamente sem migração de save; os dados persistidos vivem em `story_flags` e são ignorados por versões anteriores.
+Remover o destino de evento `pratigi_festival`, o botão do mapa, a variante em `arenas.json` e os arquivos listados acima. As alterações aditivas de `CombatArenaBase`, `CombatManager`, `AudioManager` e `CriaLiveManager` podem ser revertidas separadamente sem migração de save; os dados persistidos vivem em `story_flags` e são ignorados por versões anteriores.
 
 ## Limitações reais
 

--- a/docs/implementation/PRATIGI_FESTIVAL_ARENA_V01.md
+++ b/docs/implementation/PRATIGI_FESTIVAL_ARENA_V01.md
@@ -1,0 +1,48 @@
+# Pratigi — Festival Maré Alta, Rota Paralela
+
+**Status:** IMPLEMENTED — vertical slice de runtime; arte e áudio finais ainda pendentes de produção humana.
+**Versão:** 1.0.0
+**Escopo:** arena jogável de Pratigi, aposta interna opcional, heat, interdição, maré visual, Cria Live e acesso pelo mapa.
+
+## Decisão de produto
+
+`praia_de_pratigi_festival` é uma variante ficcional e paralela de `praia_de_pratigi`. Não substitui a praia canônica diurna, não representa festival real e não altera a Arena do Dique, que permanece circuito oficial em Salvador.
+
+A variante testa a tese “violência com consequência”:
+
+- o público e o palco elevam hype e exposição;
+- a aposta usa apenas dinheiro já existente no save, com limite e retorno explícitos;
+- o heat cresce de forma legível;
+- no limite, o combate é encerrado com segurança;
+- não existe ação de fugir, esconder prova ou enfrentar autoridade;
+- tap e parada técnica permanecem obrigatórios.
+
+## Fluxo executável
+
+```text
+Terreiro → Mapa do Baixo Sul → Pratigi (Ato 2)
+→ pré-luta e aposta opcional → combate canônico Ruan × Davi
+→ heat/aviso/interdição ou resultado
+→ Cria Live + reputação + save → resultado/mapa
+```
+
+## Componentes
+
+- `PratigiFestivalArena.tscn`: cena completa, HUD, cantos, mediador, DJ, crowd e marcadores de produção;
+- `PratigiFestivalBackdrop.gd`: representação procedural temporária mobile-first;
+- `AnimatedWaterLine.gd`: frente do mar animada e modo de movimento reduzido;
+- `ClandestineEventDirector.gd`: estado, aposta, exposição, warning, interdição e liquidação;
+- `pratigi_festival_v01.json`: balanceamento e políticas de segurança;
+- `validate_pratigi_festival.py`: gate de dados, consumidor, cena e limites éticos;
+- `pratigi_festival_smoke.gd`: smoke headless do diretor e do parse da cena.
+
+## Rollback
+
+Remover o hub `pratigi_festival`, o botão do mapa, a variante em `arenas.json` e os arquivos listados acima. As alterações aditivas de `CombatArenaBase`, `CombatManager`, `AudioManager` e `CriaLiveManager` podem ser revertidas separadamente sem migração de save; os dados persistidos vivem em `story_flags` e são ignorados por versões anteriores.
+
+## Limitações reais
+
+- backdrop, crowd, mediador e DJ são arte procedural representativa, não asset final aprovado;
+- os tons do `AudioManager` são cues funcionais, não trilha final;
+- a maré desta cena é visual e comprimida para apresentação; navegação marítima regional continua em lote próprio;
+- teste em Android físico permanece obrigatório antes de promoção para shipping.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "validate:governance": "python tools/audit/validate_repository_governance.py",
     "validate:canon": "python tools/audit/validate_canon_contract_v4_1.py",
     "validate:factions-v4": "python tools/audit/validate_faction_migration_v4_2.py",
+    "validate:pratigi": "python tools/audit/validate_pratigi_festival.py",
     "validate:python": "python tools/validate_json.py",
     "validate:node": "node tools/node/validate_json.mjs",
     "validate:data": "node tools/node/validate_game_data.mjs",
@@ -20,7 +21,8 @@
     "assets:queue": "python tools/ai_asset_pipeline/build_production_queue_v02.py",
     "animations:generate": "python tools/animation/generate_character_animation_pack.py",
     "validate:animations": "python tools/animation/generate_character_animation_pack.py --validate-only",
-    "quality": "npm run validate:governance && npm run validate:canon && npm run validate:factions-v4 && npm run validate:python && npm run validate:node && npm run validate:data && npm run validate:animations && npm run validate:repository && npm run validate:runtime && npm run validate:release && npm run validate:supreme && npm run validate:deck",
+    "smoke:pratigi": "godot --headless --path . --script res://tests/pratigi_festival_smoke.gd",
+    "quality": "npm run validate:governance && npm run validate:canon && npm run validate:factions-v4 && npm run validate:pratigi && npm run validate:python && npm run validate:node && npm run validate:data && npm run validate:animations && npm run validate:repository && npm run validate:runtime && npm run validate:release && npm run validate:supreme && npm run validate:deck",
     "build:android:windows": "powershell -ExecutionPolicy Bypass -File tools/build/build_android_debug.ps1",
     "build:android:linux": "bash tools/build/build_android_debug.sh",
     "build:windows": "powershell -ExecutionPolicy Bypass -File tools/build/build_windows_debug.ps1"

--- a/scenes/combat/CombatArenaBase.gd
+++ b/scenes/combat/CombatArenaBase.gd
@@ -1,11 +1,19 @@
 extends Control
 
-const RESULT_SCENE: String = "res://scenes/result/ResultScreen.tscn"
+const DEFAULT_RESULT_SCENE: String = "res://scenes/result/ResultScreen.tscn"
 const FighterPlaceholderScript = preload("res://src/characters/FighterPlaceholder.gd")
 const GameFeelManagerScript = preload("res://src/gamefeel/GameFeelManager.gd")
 const DaviAIControllerScript = preload("res://src/combat/DaviAIController.gd")
 const VisualTheme = preload("res://src/ui/CriaVisualTheme.gd")
 const ArenaBackdropScript = preload("res://src/visual/ArenaBackdrop.gd")
+
+@export var configured_arena_id: String = "terreiro_da_luta"
+@export var configured_backdrop_id: String = "arena_do_dique"
+@export var configured_player_id: String = "ruan_macacao"
+@export var configured_opponent_id: String = "davi_relampago"
+@export var configured_music_cue: String = "terreiro"
+@export_file("*.tscn") var configured_result_scene: String = DEFAULT_RESULT_SCENE
+@export var start_combat_immediately: bool = true
 
 var gamefeel: Node
 var davi_ai: Node
@@ -49,19 +57,32 @@ func _ready() -> void:
 	_build_placeholder_fighters()
 	_connect_buttons()
 	_connect_runtime_signals()
-	CombatManager.start_combat("terreiro_da_luta", "ruan_macacao", "davi_relampago")
 	_ensure_ai_hint()
+	if start_combat_immediately:
+		_start_configured_combat()
+	else:
+		_set_actions_enabled(false)
+
+func _start_configured_combat() -> Dictionary:
+	var result: Dictionary = CombatManager.start_combat(
+		configured_arena_id,
+		configured_player_id,
+		configured_opponent_id
+	)
 	_update_state_label(CombatManager.get_current_state_name())
 	_refresh_action_buttons()
-	AudioManager.play_music_cue("terreiro")
+	_set_actions_enabled(true)
+	AudioManager.play_music_cue(configured_music_cue)
+	return result
 
 func _build_arena_visuals() -> void:
-	var backdrop := ArenaBackdropScript.new()
-	backdrop.name = "ArenaBackdrop"
-	backdrop.arena_id = "arena_do_dique"
-	backdrop.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
-	add_child(backdrop)
-	move_child(backdrop, 0)
+	if not has_node("ArenaBackdrop"):
+		var backdrop := ArenaBackdropScript.new()
+		backdrop.name = "ArenaBackdrop"
+		backdrop.arena_id = configured_backdrop_id
+		backdrop.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+		add_child(backdrop)
+		move_child(backdrop, 0)
 	var lower_panel := Panel.new()
 	lower_panel.name = "CombatPanelBackdrop"
 	lower_panel.anchor_left = 0.025
@@ -256,6 +277,7 @@ func _on_combat_finished(result) -> void:
 	WorldState.last_combat_result = result
 	SaveManager.save_game(1)
 	AudioManager.play_music_cue("vitoria" if result.get("winner", "") == "ruan_macacao" else "derrota")
-	var error: Error = get_tree().change_scene_to_file(RESULT_SCENE)
+	var target_scene := configured_result_scene if configured_result_scene != "" else DEFAULT_RESULT_SCENE
+	var error: Error = get_tree().change_scene_to_file(target_scene)
 	if error != OK:
 		push_error("[CombatArenaBase] Falha ao abrir resultado: %s" % error_string(error))

--- a/scenes/combat/arenas/PratigiFestivalArena.gd
+++ b/scenes/combat/arenas/PratigiFestivalArena.gd
@@ -1,0 +1,297 @@
+extends "res://scenes/combat/CombatArenaBase.gd"
+
+const CONFIG_PATH := "res://data/arenas/pratigi_festival_v01.json"
+const MAP_SCENE := "res://scenes/world/WorldMapScreen.tscn"
+
+@onready var event_director: ClandestineEventDirector = $EventDirector
+@onready var pratigi_backdrop: PratigiFestivalBackdrop = $ArenaBackdrop
+@onready var water_line: AnimatedWaterLine = $AnimatedWaterLine
+@onready var pre_fight_modal: Control = $PreFightModal
+@onready var bet_amount: SpinBox = $PreFightModal/Center/Card/VBox/BetRow/BetAmount
+@onready var potential_label: Label = $PreFightModal/Center/Card/VBox/Potential
+@onready var pre_fight_message: Label = $PreFightModal/Center/Card/VBox/Message
+@onready var heat_bar: ProgressBar = $EventHUD/VBox/HeatBar
+@onready var heat_label: Label = $EventHUD/VBox/HeatLabel
+@onready var bet_label: Label = $EventHUD/VBox/BetLabel
+@onready var tide_label: Label = $EventHUD/VBox/TideLabel
+@onready var warning_banner: Label = $WarningBanner
+@onready var crowd_chant: Label = $CrowdChant
+@onready var interdiction_overlay: Control = $InterdictionOverlay
+
+var event_config: Dictionary = {}
+var _interdiction_handled: bool = false
+var _combat_started: bool = false
+var _settled: bool = false
+var _reduced_motion: bool = false
+var _crowd_tween: Tween
+
+
+func _ready() -> void:
+	super._ready()
+	event_config = _load_event_config()
+	if event_config.is_empty():
+		_disable_event("Configuração do Festival Maré Alta indisponível.")
+		return
+	event_director.configure(event_config)
+	_connect_event_signals()
+	_configure_presentation()
+	_configure_betting_ui()
+	_update_bet_ui(event_director.get_bet_snapshot())
+	_on_heat_changed(event_director.heat, event_director.get_state_name())
+
+
+func _connect_event_signals() -> void:
+	event_director.bet_changed.connect(_update_bet_ui)
+	event_director.heat_changed.connect(_on_heat_changed)
+	event_director.warning_issued.connect(_on_warning_issued)
+	event_director.interdiction_triggered.connect(_on_interdiction_triggered)
+	event_director.event_settled.connect(_on_event_settled)
+	water_line.tide_level_changed.connect(_on_tide_level_changed)
+	$PreFightModal/Center/Card/VBox/PlaceBet.pressed.connect(_on_place_bet_pressed)
+	$PreFightModal/Center/Card/VBox/StartEvent.pressed.connect(_on_start_event_pressed)
+	$PreFightModal/Center/Card/VBox/Cancel.pressed.connect(_on_cancel_pressed)
+
+
+func _configure_presentation() -> void:
+	var presentation: Dictionary = event_config.get("presentation", {})
+	pratigi_backdrop.crowd_count = int(presentation.get("crowd_count_mobile", 40))
+	var accessibility: Dictionary = DataRegistry.settings.get("accessibility", {})
+	_reduced_motion = bool(accessibility.get("reduced_motion", false))
+	pratigi_backdrop.reduced_motion = _reduced_motion
+	water_line.reduced_motion = _reduced_motion
+	water_line.visual_cycle_seconds = float(event_config.get("tide", {}).get("visual_cycle_seconds", 124.2))
+	pratigi_backdrop.set_crowd_intensity(0.72)
+
+
+func _configure_betting_ui() -> void:
+	var betting: Dictionary = event_config.get("betting", {})
+	bet_amount.min_value = float(betting.get("minimum_stake", 0))
+	bet_amount.max_value = float(betting.get("maximum_stake", 150))
+	bet_amount.step = float(betting.get("stake_step", 25))
+	bet_amount.value = 0.0
+	bet_amount.allow_greater = false
+	bet_amount.allow_lesser = false
+	$PreFightModal/Center/Card/VBox/Wallet.text = "Carteira: R$ %d (somente moeda interna)" % WorldState.money
+	_update_potential_label()
+	if not bet_amount.value_changed.is_connected(_on_bet_amount_changed):
+		bet_amount.value_changed.connect(_on_bet_amount_changed)
+
+
+func _on_bet_amount_changed(_value: float) -> void:
+	_update_potential_label()
+
+
+func _update_potential_label() -> void:
+	var multiplier: float = float(event_config.get("betting", {}).get("payout_multiplier", 1.0))
+	var payout := int(round(bet_amount.value * multiplier))
+	potential_label.text = "Retorno transparente se vencer: R$ %d" % payout
+
+
+func _on_place_bet_pressed() -> void:
+	var result := event_director.place_bet(int(bet_amount.value), WorldState.money)
+	if not bool(result.get("ok", false)):
+		pre_fight_message.text = _bet_error_text(str(result.get("reason", "unknown")))
+		return
+	WorldState.money += int(result.get("wallet_delta", 0))
+	$PreFightModal/Center/Card/VBox/Wallet.text = "Carteira: R$ %d (somente moeda interna)" % WorldState.money
+	pre_fight_message.text = "Aposta registrada." if event_director.bet_placed else "Você escolheu lutar sem apostar."
+	SaveManager.save_game(1)
+
+
+func _on_start_event_pressed() -> void:
+	if _combat_started:
+		return
+	var start_result := event_director.start_event()
+	if not bool(start_result.get("ok", false)):
+		pre_fight_message.text = "O evento ainda não pode começar."
+		return
+	_combat_started = true
+	pre_fight_modal.visible = false
+	$EventHUD.visible = true
+	_start_configured_combat()
+	AudioManager.play_sfx("crowd_roar")
+	_show_crowd_shout("MACACÃO! MACACÃO!")
+	_apply_configured_consequence("participation")
+	WorldState.story_flags["pratigi_festival_entered"] = true
+	SaveManager.save_game(1)
+
+
+func _on_cancel_pressed() -> void:
+	if _combat_started:
+		return
+	var refund := event_director.cancel_bet()
+	WorldState.money += int(refund.get("wallet_delta", 0))
+	SaveManager.save_game(1)
+	get_tree().change_scene_to_file(MAP_SCENE)
+
+
+func _update_bet_ui(snapshot: Dictionary) -> void:
+	var stake := int(snapshot.get("stake", 0))
+	var potential := int(snapshot.get("potential_payout", 0))
+	bet_label.text = "Aposta: R$ %d • retorno R$ %d" % [stake, potential]
+	$PreFightModal/Center/Card/VBox/StartEvent.text = "ENTRAR NA ARENA" if stake == 0 else "ENTRAR NA ARENA COM APOSTA"
+
+
+func _on_heat_changed(value: float, state_name: String) -> void:
+	heat_bar.value = value
+	heat_label.text = "HEAT %d%% • %s" % [int(round(value)), _heat_state_text(state_name)]
+	pratigi_backdrop.set_heat_level(value)
+
+
+func _on_tide_level_changed(value: float) -> void:
+	pratigi_backdrop.set_tide_level(value)
+	tide_label.text = "Maré: %s • %d%%" % [water_line.get_state_name(), int(round(value * 100.0))]
+
+
+func _on_warning_issued(_snapshot: Dictionary) -> void:
+	warning_banner.visible = true
+	warning_banner.text = "ATENÇÃO: AUTORIDADES A CAMINHO — o evento pode ser interditado"
+	AudioManager.play_music_cue("authority_warning")
+	CriaLiveManager.create_post(
+		"O Festival Maré Alta entrou no radar. A praia ainda grita, mas o relógio agora pesa.",
+		"alerta_autoridade",
+		"cria_live",
+		{
+			"source_event": "pratigi_heat_warning",
+			"metrics": {"reach": 90, "polarization": 5, "authority_attention": 9}
+		}
+	)
+
+
+func _on_interdiction_triggered(snapshot: Dictionary) -> void:
+	if _interdiction_handled:
+		return
+	_interdiction_handled = true
+	_set_actions_enabled(false)
+	interdiction_overlay.visible = true
+	$InterdictionOverlay/Center/VBox/Details.text = "Heat %d%% • combate encerrado com segurança • sem minigame de fuga" % int(snapshot.get("heat", 100))
+	AudioManager.play_music_cue("authority_warning")
+	_complete_interdiction()
+
+
+func _complete_interdiction() -> void:
+	if CombatManager.is_running:
+		CombatManager.finish_combat({
+			"winner": "",
+			"loser": "",
+			"method": "evento_interditado",
+			"technical": false,
+			"interrupted": true,
+			"skip_career_result": true,
+			"arena_id": configured_arena_id,
+			"heat": event_director.heat
+		})
+
+
+func _on_technique_resolved(result) -> void:
+	super._on_technique_resolved(result)
+	if typeof(result) == TYPE_DICTIONARY:
+		event_director.register_technique(result)
+		if bool(result.get("success", false)) and event_director.get_state_name() in ["live", "warning"]:
+			var actor_id := str(result.get("actor_id", ""))
+			_show_crowd_shout("VAI, MACACÃO!" if actor_id == configured_player_id else "SEGURA A BASE!")
+
+
+func _show_crowd_shout(text: String) -> void:
+	if _crowd_tween != null and _crowd_tween.is_valid():
+		_crowd_tween.kill()
+	crowd_chant.text = text
+	crowd_chant.visible = true
+	crowd_chant.modulate.a = 1.0
+	crowd_chant.scale = Vector2.ONE
+	_crowd_tween = create_tween()
+	if not _reduced_motion:
+		crowd_chant.scale = Vector2(0.96, 0.96)
+		_crowd_tween.tween_property(crowd_chant, "scale", Vector2.ONE, 0.12)
+	_crowd_tween.tween_interval(0.45)
+	_crowd_tween.tween_property(crowd_chant, "modulate:a", 0.0, 0.55)
+	_crowd_tween.tween_callback(func(): crowd_chant.visible = false)
+
+
+func _on_combat_finished(result) -> void:
+	if typeof(result) != TYPE_DICTIONARY or _settled:
+		return
+	_settled = true
+	var settlement := event_director.settle(result, configured_player_id)
+	WorldState.money += int(settlement.get("wallet_delta", 0))
+	result["bet_settlement"] = settlement
+	result["heat"] = event_director.heat
+	WorldState.story_flags["pratigi_last_event"] = {
+		"week": WorldState.week,
+		"status": settlement.get("status", "unknown"),
+		"heat": event_director.heat,
+		"stake": settlement.get("stake", 0),
+		"payout": settlement.get("payout", 0)
+	}
+	if bool(result.get("interrupted", false)):
+		_apply_configured_consequence("interdiction")
+		WorldState.last_combat_result = result
+		SaveManager.save_game(1)
+		await get_tree().create_timer(1.0).timeout
+		get_tree().change_scene_to_file(MAP_SCENE)
+		return
+	if str(result.get("winner", "")) == configured_player_id:
+		_apply_configured_consequence("clean_win")
+	SaveManager.save_game(1)
+	super._on_combat_finished(result)
+
+
+func _on_event_settled(settlement: Dictionary) -> void:
+	match str(settlement.get("status", "")):
+		"won":
+			$Panel/Message.text = "Aposta liquidada: +R$ %d." % int(settlement.get("payout", 0))
+		"lost":
+			$Panel/Message.text = "A aposta ficou na areia. O resultado cobra."
+		"interdicted":
+			$Panel/Message.text = "Evento interditado: aposta sem pagamento."
+
+
+func _apply_configured_consequence(consequence_id: String) -> void:
+	var changes: Dictionary = event_config.get("consequences", {}).get(consequence_id, {})
+	for axis_value in changes.keys():
+		var axis := str(axis_value)
+		if axis in ["honra", "hype", "sombra", "legado", "moral", "raiz"]:
+			WorldState.modify_reputation(axis, float(changes[axis_value]))
+
+
+func _load_event_config() -> Dictionary:
+	if not FileAccess.file_exists(CONFIG_PATH):
+		return {}
+	var file := FileAccess.open(CONFIG_PATH, FileAccess.READ)
+	if file == null:
+		return {}
+	var parsed = JSON.parse_string(file.get_as_text())
+	file.close()
+	return parsed if typeof(parsed) == TYPE_DICTIONARY else {}
+
+
+func _disable_event(message: String) -> void:
+	pre_fight_message.text = message
+	$PreFightModal/Center/Card/VBox/PlaceBet.disabled = true
+	$PreFightModal/Center/Card/VBox/StartEvent.disabled = true
+
+
+func _bet_error_text(reason: String) -> String:
+	match reason:
+		"insufficient_funds": return "Dinheiro insuficiente. Entre sem apostar ou reduza o valor."
+		"invalid_stake": return "Valor fora dos limites transparentes do evento."
+		"unsafe_betting_config": return "A configuração de aposta foi bloqueada por segurança."
+		"betting_closed": return "As apostas já fecharam."
+	return "Não foi possível registrar a aposta."
+
+
+func _heat_state_text(state_name: String) -> String:
+	match state_name:
+		"setup": return "organização"
+		"ready": return "pronto"
+		"live": return "evento ativo"
+		"warning": return "autoridades a caminho"
+		"interdicted": return "interditado"
+		"resolved": return "encerrado"
+	return state_name
+
+
+func _exit_tree() -> void:
+	if not _combat_started and event_director != null and event_director.bet_placed and not event_director.bet_locked:
+		var refund := event_director.cancel_bet()
+		WorldState.money += int(refund.get("wallet_delta", 0))

--- a/scenes/combat/arenas/PratigiFestivalArena.tscn
+++ b/scenes/combat/arenas/PratigiFestivalArena.tscn
@@ -1,0 +1,399 @@
+[gd_scene load_steps=7 format=3]
+
+[ext_resource type="Script" path="res://scenes/combat/arenas/PratigiFestivalArena.gd" id="1_arena"]
+[ext_resource type="PackedScene" path="res://scenes/ui/CombatHUD.tscn" id="2_hud"]
+[ext_resource type="PackedScene" path="res://scenes/ui/CombatDeckHUD.tscn" id="3_deck"]
+[ext_resource type="Script" path="res://src/visual/PratigiFestivalBackdrop.gd" id="4_backdrop"]
+[ext_resource type="Script" path="res://src/visual/AnimatedWaterLine.gd" id="5_water"]
+[ext_resource type="Script" path="res://src/combat/arena/ClandestineEventDirector.gd" id="6_event"]
+
+[node name="PratigiFestivalArena" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_arena")
+configured_arena_id = "praia_de_pratigi_festival"
+configured_backdrop_id = "praia_de_pratigi"
+configured_player_id = "ruan_macacao"
+configured_opponent_id = "davi_relampago"
+configured_music_cue = "pratigi_festival"
+start_combat_immediately = false
+
+[node name="ArenaBackdrop" type="Control" parent="."]
+z_index = -20
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 2
+script = ExtResource("4_backdrop")
+
+[node name="AnimatedWaterLine" type="Control" parent="."]
+z_index = -19
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 2
+script = ExtResource("5_water")
+
+[node name="ArenaMarkers" type="Node2D" parent="."]
+
+[node name="BlueCorner" type="Marker2D" parent="ArenaMarkers"]
+position = Vector2(320, 554)
+
+[node name="GoldCorner" type="Marker2D" parent="ArenaMarkers"]
+position = Vector2(960, 554)
+
+[node name="CommunityReferee" type="Marker2D" parent="ArenaMarkers"]
+position = Vector2(640, 370)
+
+[node name="DJStage" type="Marker2D" parent="ArenaMarkers"]
+position = Vector2(205, 198)
+
+[node name="RaveCrowd" type="Marker2D" parent="ArenaMarkers"]
+position = Vector2(640, 430)
+
+[node name="WaterLineAnchor" type="Marker2D" parent="ArenaMarkers"]
+position = Vector2(640, 390)
+
+[node name="FestivalTitle" type="Label" parent="."]
+z_index = -5
+layout_mode = 1
+anchors_preset = 10
+anchor_right = 1.0
+offset_top = 12.0
+offset_bottom = 50.0
+grow_horizontal = 2
+theme_override_colors/font_color = Color(0.961, 0.773, 0.259, 1)
+theme_override_font_sizes/font_size = 24
+text = "FESTIVAL MARÉ ALTA — ROTA PARALELA"
+horizontal_alignment = 1
+
+[node name="StageCaption" type="Label" parent="."]
+z_index = -4
+layout_mode = 0
+offset_left = 92.0
+offset_top = 205.0
+offset_right = 290.0
+offset_bottom = 237.0
+theme_override_colors/font_color = Color(0.133, 0.827, 0.933, 1)
+theme_override_font_sizes/font_size = 14
+text = "DJ • GRAVE DA MARÉ"
+horizontal_alignment = 1
+
+[node name="RefereeCaption" type="Label" parent="."]
+z_index = -4
+layout_mode = 0
+offset_left = 579.0
+offset_top = 404.0
+offset_right = 701.0
+offset_bottom = 430.0
+theme_override_colors/font_color = Color(0.92, 0.92, 0.88, 1)
+theme_override_font_sizes/font_size = 11
+text = "MEDIADOR"
+horizontal_alignment = 1
+
+[node name="EventDirector" type="Node" parent="."]
+script = ExtResource("6_event")
+
+[node name="CombatHUD" parent="." instance=ExtResource("2_hud")]
+
+[node name="CombatDeckHUD" parent="." instance=ExtResource("3_deck")]
+
+[node name="Panel" type="VBoxContainer" parent="."]
+layout_mode = 2
+anchor_left = 0.04
+anchor_top = 0.68
+anchor_right = 0.96
+anchor_bottom = 0.98
+theme_override_constants/separation = 6
+
+[node name="Title" type="Label" parent="Panel"]
+layout_mode = 2
+horizontal_alignment = 1
+text = "RUAN MACACÃO vs DAVI RELÂMPAGO • AREIA DE PRATIGI"
+
+[node name="State" type="Label" parent="Panel"]
+layout_mode = 2
+text = "Estado: AGUARDANDO EVENTO"
+
+[node name="Resources" type="Label" parent="Panel"]
+layout_mode = 2
+text = "Recursos"
+
+[node name="Message" type="Label" parent="Panel"]
+layout_mode = 2
+autowrap_mode = 3
+text = "A areia pune pressa. O público testa caráter."
+
+[node name="AIHint" type="Label" parent="Panel"]
+layout_mode = 2
+autowrap_mode = 3
+text = "Davi usa o barulho para esconder o ritmo."
+
+[node name="Buttons" type="HBoxContainer" parent="Panel"]
+layout_mode = 2
+theme_override_constants/separation = 10
+
+[node name="Action1" type="Button" parent="Panel/Buttons"]
+custom_minimum_size = Vector2(0, 64)
+layout_mode = 2
+size_flags_horizontal = 3
+text = "—"
+
+[node name="Action2" type="Button" parent="Panel/Buttons"]
+custom_minimum_size = Vector2(0, 64)
+layout_mode = 2
+size_flags_horizontal = 3
+text = "—"
+
+[node name="Action3" type="Button" parent="Panel/Buttons"]
+custom_minimum_size = Vector2(0, 64)
+layout_mode = 2
+size_flags_horizontal = 3
+text = "—"
+
+[node name="Action4" type="Button" parent="Panel/Buttons"]
+custom_minimum_size = Vector2(0, 64)
+layout_mode = 2
+size_flags_horizontal = 3
+text = "—"
+
+[node name="Action5" type="Button" parent="Panel/Buttons"]
+custom_minimum_size = Vector2(0, 64)
+layout_mode = 2
+size_flags_horizontal = 3
+text = "—"
+
+[node name="EventHUD" type="PanelContainer" parent="."]
+visible = false
+z_index = 20
+layout_mode = 1
+anchor_left = 0.72
+anchor_top = 0.08
+anchor_right = 0.98
+anchor_bottom = 0.32
+offset_left = -8.0
+offset_top = -8.0
+offset_right = -8.0
+offset_bottom = -8.0
+
+[node name="VBox" type="VBoxContainer" parent="EventHUD"]
+layout_mode = 2
+theme_override_constants/separation = 6
+
+[node name="Title" type="Label" parent="EventHUD/VBox"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.961, 0.773, 0.259, 1)
+theme_override_font_sizes/font_size = 16
+text = "MARÉ ALTA • EVENTO PARALELO"
+
+[node name="HeatLabel" type="Label" parent="EventHUD/VBox"]
+layout_mode = 2
+text = "HEAT 20% • organização"
+
+[node name="HeatBar" type="ProgressBar" parent="EventHUD/VBox"]
+custom_minimum_size = Vector2(0, 20)
+layout_mode = 2
+max_value = 100.0
+value = 20.0
+show_percentage = false
+
+[node name="BetLabel" type="Label" parent="EventHUD/VBox"]
+layout_mode = 2
+text = "Aposta: R$ 0"
+
+[node name="TideLabel" type="Label" parent="EventHUD/VBox"]
+layout_mode = 2
+text = "Maré: subindo • 50%"
+
+[node name="Safety" type="Label" parent="EventHUD/VBox"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.65, 0.82, 0.88, 1)
+theme_override_font_sizes/font_size = 11
+text = "Tap e parada técnica permanecem obrigatórios."
+autowrap_mode = 3
+
+[node name="WarningBanner" type="Label" parent="."]
+visible = false
+z_index = 30
+layout_mode = 1
+anchors_preset = 10
+anchor_right = 1.0
+offset_top = 54.0
+offset_bottom = 94.0
+grow_horizontal = 2
+theme_override_colors/font_color = Color(1, 0.82, 0.34, 1)
+theme_override_colors/font_shadow_color = Color(0, 0, 0, 1)
+theme_override_constants/shadow_offset_x = 2
+theme_override_constants/shadow_offset_y = 2
+theme_override_font_sizes/font_size = 18
+text = "ATENÇÃO: AUTORIDADES A CAMINHO"
+horizontal_alignment = 1
+
+[node name="CrowdChant" type="Label" parent="."]
+visible = false
+z_index = 15
+layout_mode = 0
+offset_left = 420.0
+offset_top = 430.0
+offset_right = 860.0
+offset_bottom = 474.0
+pivot_offset = Vector2(220, 22)
+theme_override_colors/font_color = Color(0.961, 0.773, 0.259, 1)
+theme_override_colors/font_outline_color = Color(0.025, 0.035, 0.07, 1)
+theme_override_constants/outline_size = 6
+theme_override_font_sizes/font_size = 24
+text = "MACACÃO! MACACÃO!"
+horizontal_alignment = 1
+
+[node name="PreFightModal" type="ColorRect" parent="."]
+z_index = 50
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0.015, 0.025, 0.05, 0.88)
+
+[node name="Center" type="CenterContainer" parent="PreFightModal"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="Card" type="PanelContainer" parent="PreFightModal/Center"]
+custom_minimum_size = Vector2(620, 430)
+layout_mode = 2
+
+[node name="VBox" type="VBoxContainer" parent="PreFightModal/Center/Card"]
+layout_mode = 2
+theme_override_constants/separation = 12
+
+[node name="Title" type="Label" parent="PreFightModal/Center/Card/VBox"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.961, 0.773, 0.259, 1)
+theme_override_font_sizes/font_size = 26
+text = "FESTIVAL MARÉ ALTA"
+horizontal_alignment = 1
+
+[node name="Subtitle" type="Label" parent="PreFightModal/Center/Card/VBox"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.133, 0.827, 0.933, 1)
+theme_override_font_sizes/font_size = 16
+text = "PRATIGI • ROTA PARALELA FICCIONAL • 16+"
+horizontal_alignment = 1
+
+[node name="Description" type="Label" parent="PreFightModal/Center/Card/VBox"]
+layout_mode = 2
+text = "DJ no palco, crowd ao redor e areia sob os pés. Aqui o hype sobe junto com o heat. O mediador respeita o tap; se as autoridades chegarem, o combate para — sem fuga jogável."
+autowrap_mode = 3
+
+[node name="Policy" type="Label" parent="PreFightModal/Center/Card/VBox"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.72, 0.78, 0.84, 1)
+theme_override_font_sizes/font_size = 12
+text = "Aposta opcional com moeda interna. Sem dinheiro real, compra, loot box ou marca de festival real."
+autowrap_mode = 3
+
+[node name="Wallet" type="Label" parent="PreFightModal/Center/Card/VBox"]
+layout_mode = 2
+text = "Carteira: R$ 0 (somente moeda interna)"
+
+[node name="BetRow" type="HBoxContainer" parent="PreFightModal/Center/Card/VBox"]
+layout_mode = 2
+theme_override_constants/separation = 10
+
+[node name="BetCaption" type="Label" parent="PreFightModal/Center/Card/VBox/BetRow"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Valor da aposta opcional"
+
+[node name="BetAmount" type="SpinBox" parent="PreFightModal/Center/Card/VBox/BetRow"]
+custom_minimum_size = Vector2(170, 52)
+layout_mode = 2
+max_value = 150.0
+step = 25.0
+prefix = "R$ "
+
+[node name="Potential" type="Label" parent="PreFightModal/Center/Card/VBox"]
+layout_mode = 2
+text = "Retorno transparente se vencer: R$ 0"
+
+[node name="PlaceBet" type="Button" parent="PreFightModal/Center/Card/VBox"]
+custom_minimum_size = Vector2(0, 54)
+layout_mode = 2
+text = "REGISTRAR ESCOLHA"
+
+[node name="StartEvent" type="Button" parent="PreFightModal/Center/Card/VBox"]
+custom_minimum_size = Vector2(0, 60)
+layout_mode = 2
+theme_override_colors/font_color = Color(0.05, 0.07, 0.09, 1)
+text = "ENTRAR NA ARENA"
+
+[node name="Cancel" type="Button" parent="PreFightModal/Center/Card/VBox"]
+custom_minimum_size = Vector2(0, 50)
+layout_mode = 2
+text = "VOLTAR AO MAPA"
+
+[node name="Message" type="Label" parent="PreFightModal/Center/Card/VBox"]
+layout_mode = 2
+theme_override_colors/font_color = Color(1, 0.76, 0.22, 1)
+text = "Você pode entrar sem apostar."
+horizontal_alignment = 1
+autowrap_mode = 3
+
+[node name="InterdictionOverlay" type="ColorRect" parent="."]
+visible = false
+z_index = 100
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0.05, 0.06, 0.09, 0.94)
+
+[node name="Center" type="CenterContainer" parent="InterdictionOverlay"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="VBox" type="VBoxContainer" parent="InterdictionOverlay/Center"]
+custom_minimum_size = Vector2(680, 180)
+layout_mode = 2
+theme_override_constants/separation = 12
+
+[node name="Title" type="Label" parent="InterdictionOverlay/Center/VBox"]
+layout_mode = 2
+theme_override_colors/font_color = Color(1, 0.35, 0.32, 1)
+theme_override_font_sizes/font_size = 30
+text = "EVENTO INTERDITADO"
+horizontal_alignment = 1
+
+[node name="Details" type="Label" parent="InterdictionOverlay/Center/VBox"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 16
+text = "Combate encerrado com segurança."
+horizontal_alignment = 1
+autowrap_mode = 3
+
+[node name="Consequence" type="Label" parent="InterdictionOverlay/Center/VBox"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.72, 0.78, 0.84, 1)
+text = "O Cria Live registra. A sombra cresce. A aposta não é paga."
+horizontal_alignment = 1

--- a/scenes/hubs/TerreiroDaLuta.gd
+++ b/scenes/hubs/TerreiroDaLuta.gd
@@ -4,6 +4,7 @@ const COMBAT_SCENE := "res://scenes/combat/CombatArenaBase.tscn"
 const CRIA_LIVE_SCENE := "res://scenes/ui/CriaLiveUI.tscn"
 const MAIN_MENU_SCENE := "res://scenes/main_menu/MainMenu.tscn"
 const DECK_SCENE := "res://scenes/ui/DeckBuilder.tscn"
+const MAP_SCENE := "res://scenes/world/WorldMapScreen.tscn"
 
 var _transitioning := false
 
@@ -15,6 +16,7 @@ func _ready() -> void:
 	_connect_if_exists("Panel/SaveBtn", _on_save)
 	_connect_if_exists("Panel/AdvanceDayBtn", _on_advance_day)
 	_connect_if_exists("Panel/CriaLiveBtn", _on_cria_live)
+	_connect_if_exists("Panel/WorldMapBtn", _on_world_map)
 	_connect_if_exists("Panel/MainMenuBtn", _on_main_menu)
 	if not SignalBus.day_advanced.is_connected(_on_day_changed):
 		SignalBus.day_advanced.connect(_on_day_changed)
@@ -95,6 +97,11 @@ func _on_advance_day() -> void:
 
 func _on_cria_live() -> void:
 	_change_scene(CRIA_LIVE_SCENE)
+
+func _on_world_map() -> void:
+	WorldMapManager.current_hub = "itubera"
+	WorldState.current_hub = "itubera"
+	_change_scene(MAP_SCENE)
 
 func _on_main_menu() -> void:
 	SaveManager.save_game(1)

--- a/scenes/hubs/TerreiroDaLuta.tscn
+++ b/scenes/hubs/TerreiroDaLuta.tscn
@@ -96,6 +96,11 @@ custom_minimum_size = Vector2(0, 48)
 layout_mode = 2
 text = "ABRIR CRIA LIVE"
 
+[node name="WorldMapBtn" type="Button" parent="Panel"]
+custom_minimum_size = Vector2(0, 48)
+layout_mode = 2
+text = "MAPA DO BAIXO SUL"
+
 [node name="MainMenuBtn" type="Button" parent="Panel"]
 custom_minimum_size = Vector2(0, 48)
 layout_mode = 2

--- a/scenes/world/WorldMapScreen.gd
+++ b/scenes/world/WorldMapScreen.gd
@@ -7,6 +7,7 @@ func _ready() -> void:
 	_connect("Panel/Salvador", "salvador")
 	_connect("Panel/Zambiapunga", "zambiapunga")
 	_connect("Panel/Camamu", "camamu_manguezal")
+	_connect("Panel/Pratigi", "pratigi_festival")
 	if has_node("Panel/Back"):
 		$Panel/Back.pressed.connect(func(): get_tree().change_scene_to_file(HUB_SCENE))
 	_update_status()
@@ -27,3 +28,6 @@ func _on_travel_pressed(hub_id: String) -> void:
 func _update_status() -> void:
 	if has_node("Panel/Status"):
 		$Panel/Status.text = "Hub atual: %s • R$ %d • Semana %d" % [WorldMapManager.current_hub, WorldState.money, WorldState.week]
+	if has_node("Panel/Pratigi"):
+		$Panel/Pratigi.disabled = not WorldMapManager.can_travel_to("pratigi_festival")
+		$Panel/Pratigi.tooltip_text = WorldMapManager.get_travel_lock_reason("pratigi_festival")

--- a/scenes/world/WorldMapScreen.tscn
+++ b/scenes/world/WorldMapScreen.tscn
@@ -40,6 +40,11 @@ text = "ZAMBIAPUNGA"
 layout_mode = 2
 text = "CAMAMU E MANGUEZAL"
 
+[node name="Pratigi" type="Button" parent="Panel"]
+custom_minimum_size = Vector2(0, 56)
+layout_mode = 2
+text = "PRATIGI — FESTIVAL MARÉ ALTA (ATO 2)"
+
 [node name="Back" type="Button" parent="Panel"]
 layout_mode = 2
 text = "VOLTAR"

--- a/src/autoloads/AudioManager.gd
+++ b/src/autoloads/AudioManager.gd
@@ -23,11 +23,19 @@ func play_music_cue(cue_id: String) -> void:
 			_play_tone(330.0, 0.18)
 		"derrota":
 			_play_tone(98.0, 0.22)
+		"pratigi_festival":
+			_play_tone(82.0, 0.16)
+			_play_tone(164.0, 0.12)
+			_play_tone(246.0, 0.10)
+		"authority_warning":
+			_play_tone(196.0, 0.14)
+			_play_tone(147.0, 0.14)
 		_:
 			_play_tone(160.0, 0.12)
 
 func _pitch_for(event_id: String) -> float:
 	match event_id:
+		"crowd_roar": return 116.0
 		"grip_de_ferro": return 180.0
 		"baiana": return 120.0
 		"corte_joelho": return 210.0
@@ -39,6 +47,7 @@ func _pitch_for(event_id: String) -> float:
 
 func _duration_for(event_id: String) -> float:
 	match event_id:
+		"crowd_roar": return 0.38
 		"baiana": return 0.16
 		"encerramento_tecnico": return 0.22
 		"botao": return 0.05

--- a/src/autoloads/CombatManager.gd
+++ b/src/autoloads/CombatManager.gd
@@ -420,6 +420,8 @@ func finish_combat(result: Dictionary) -> void:
 	is_running = false
 	phase = CombatPhase.RESET
 	last_result = result.duplicate(true)
+	if not last_result.has("arena_id"):
+		last_result["arena_id"] = arena_id
 	last_result["fighters"] = fighters.duplicate(true)
 	last_result["final_state"] = get_current_state_name()
 	_apply_post_combat_effects(last_result)
@@ -434,6 +436,9 @@ func finalizar_combate(result: Dictionary) -> void:
 
 func _apply_post_combat_effects(result: Dictionary) -> void:
 	WorldState.last_combat_result = result
+	if bool(result.get("skip_career_result", false)):
+		WorldState._sync_aliases()
+		return
 	if result.get("winner", "") == player_id:
 		WorldState.fights_won += 1
 		WorldState.money += 200

--- a/src/autoloads/CriaLiveManager.gd
+++ b/src/autoloads/CriaLiveManager.gd
@@ -111,6 +111,23 @@ func _on_combat_finished(result: Dictionary) -> void:
 	if fingerprint == _last_combat_fingerprint:
 		return
 	_last_combat_fingerprint = fingerprint
+	var result_arena_id := str(result.get("arena_id", ""))
+	if bool(result.get("interrupted", false)) and result_arena_id == "praia_de_pratigi_festival":
+		create_post("O Festival Maré Alta foi interrompido. Em Pratigi, o hype passou do limite e a conta chegou antes do resultado.", "alerta_autoridade", "cria_live", {
+			"source_event": "pratigi_authority_interdiction",
+			"metrics": {"reach": 260, "polarization": 16, "hype": 8, "rejection": 10, "authority_attention": 22}
+		})
+		return
+	if bool(result.get("interrupted", false)):
+		return
+	if result_arena_id == "praia_de_pratigi_festival":
+		var player_won_pratigi := result.get("winner", "") in [WorldState.player_id, "ruan_macacao"]
+		var pratigi_text := "Macacão dominou a areia sob o grave do Festival Maré Alta. A praia gritou; agora ele terá de responder pelo alcance." if player_won_pratigi else "A areia cobrou a base de Macacão no Festival Maré Alta. O vídeo correu mais rápido que a desculpa."
+		create_post(pratigi_text, "pratigi_festival", "cria_live", {
+			"source_event": "pratigi_festival_combat",
+			"metrics": {"reach": 230 if player_won_pratigi else 170, "hype": 14 if player_won_pratigi else 7, "polarization": 8, "authority_attention": 6}
+		})
+		return
 	if result.get("winner", "") == WorldState.player_id or result.get("winner", "") == "ruan_macacao":
 		create_post(_text_for_context("vitoria", result), "vitoria", "cria_live", {
 			"source_event": "combat_finished",
@@ -123,12 +140,14 @@ func _on_combat_finished(result: Dictionary) -> void:
 		})
 
 func _combat_fingerprint(result: Dictionary) -> String:
-	return "%s|%s|%d|%d|%d" % [
+	return "%s|%s|%s|%d|%d|%d|%s" % [
+		str(result.get("arena_id", "")),
 		str(result.get("winner", "")),
 		str(result.get("method", "")),
 		WorldState.week,
 		WorldState.day_index,
-		WorldState.fights_won + WorldState.fights_lost
+		WorldState.fights_won + WorldState.fights_lost,
+		str(result.get("interrupted", false))
 	]
 
 func _on_reputation_changed(axis, _delta, new_value) -> void:

--- a/src/autoloads/CriaLiveManager.gd
+++ b/src/autoloads/CriaLiveManager.gd
@@ -121,7 +121,7 @@ func _on_combat_finished(result: Dictionary) -> void:
 	if bool(result.get("interrupted", false)):
 		return
 	if result_arena_id == "praia_de_pratigi_festival":
-		var player_won_pratigi := result.get("winner", "") in [WorldState.player_id, "ruan_macacao"]
+		var player_won_pratigi: bool = result.get("winner", "") in [WorldState.player_id, "ruan_macacao"]
 		var pratigi_text := "Macacão dominou a areia sob o grave do Festival Maré Alta. A praia gritou; agora ele terá de responder pelo alcance." if player_won_pratigi else "A areia cobrou a base de Macacão no Festival Maré Alta. O vídeo correu mais rápido que a desculpa."
 		create_post(pratigi_text, "pratigi_festival", "cria_live", {
 			"source_event": "pratigi_festival_combat",

--- a/src/autoloads/WorldMapManager.gd
+++ b/src/autoloads/WorldMapManager.gd
@@ -3,19 +3,33 @@ extends Node
 var current_hub := "itubera"
 var visited_hubs := ["itubera"]
 var travel_log := []
-var unlocked_hubs := ["itubera", "salvador", "zambiapunga", "camamu_manguezal"]
+var unlocked_hubs := ["itubera", "salvador", "zambiapunga", "camamu_manguezal", "pratigi_festival"]
 
 func reset() -> void:
 	current_hub = "itubera"
 	visited_hubs = ["itubera"]
 	travel_log = []
-	unlocked_hubs = ["itubera", "salvador", "zambiapunga", "camamu_manguezal"]
+	unlocked_hubs = ["itubera", "salvador", "zambiapunga", "camamu_manguezal", "pratigi_festival"]
 
 func get_hub_data(hub_id: String) -> Dictionary:
 	return DataRegistry.hubs_dense.get("hubs", {}).get(hub_id, {})
 
 func can_travel_to(hub_id: String) -> bool:
-	return unlocked_hubs.has(hub_id) and not get_hub_data(hub_id).is_empty()
+	var hub: Dictionary = get_hub_data(hub_id)
+	if hub.is_empty() or not unlocked_hubs.has(hub_id):
+		return false
+	return WorldState.act >= int(hub.get("unlock_act", 1))
+
+func get_travel_lock_reason(hub_id: String) -> String:
+	var hub: Dictionary = get_hub_data(hub_id)
+	if hub.is_empty():
+		return "Destino sem dados."
+	if not unlocked_hubs.has(hub_id):
+		return "Destino ainda não descoberto."
+	var required_act := int(hub.get("unlock_act", 1))
+	if WorldState.act < required_act:
+		return "Liberado no Ato %d." % required_act
+	return ""
 
 func travel_to(hub_id: String) -> Dictionary:
 	if not can_travel_to(hub_id):
@@ -50,3 +64,5 @@ func load_from_dict(data: Dictionary) -> void:
 	visited_hubs = data.get("visited_hubs", ["itubera"])
 	travel_log = data.get("travel_log", [])
 	unlocked_hubs = data.get("unlocked_hubs", unlocked_hubs)
+	if not unlocked_hubs.has("pratigi_festival"):
+		unlocked_hubs.append("pratigi_festival")

--- a/src/autoloads/WorldMapManager.gd
+++ b/src/autoloads/WorldMapManager.gd
@@ -12,7 +12,10 @@ func reset() -> void:
 	unlocked_hubs = ["itubera", "salvador", "zambiapunga", "camamu_manguezal", "pratigi_festival"]
 
 func get_hub_data(hub_id: String) -> Dictionary:
-	return DataRegistry.hubs_dense.get("hubs", {}).get(hub_id, {})
+	var canonical_hub: Dictionary = DataRegistry.hubs_dense.get("hubs", {}).get(hub_id, {})
+	if not canonical_hub.is_empty():
+		return canonical_hub
+	return DataRegistry.hubs_dense.get("event_destinations", {}).get(hub_id, {})
 
 func can_travel_to(hub_id: String) -> bool:
 	var hub: Dictionary = get_hub_data(hub_id)

--- a/src/combat/arena/ClandestineEventDirector.gd
+++ b/src/combat/arena/ClandestineEventDirector.gd
@@ -1,0 +1,212 @@
+class_name ClandestineEventDirector
+extends Node
+
+signal state_changed(state: String)
+signal bet_changed(snapshot: Dictionary)
+signal heat_changed(value: float, state: String)
+signal warning_issued(snapshot: Dictionary)
+signal interdiction_triggered(snapshot: Dictionary)
+signal event_settled(settlement: Dictionary)
+
+enum EventState { SETUP, READY, LIVE, WARNING, INTERDICTED, RESOLVED }
+
+var arena_id: String = ""
+var config: Dictionary = {}
+var state: EventState = EventState.SETUP
+var heat: float = 0.0
+var elapsed_seconds: float = 0.0
+var bet_stake: int = 0
+var potential_payout: int = 0
+var bet_placed: bool = false
+var bet_locked: bool = false
+
+
+func _ready() -> void:
+	set_process(false)
+
+
+func configure(event_config: Dictionary) -> void:
+	config = event_config.duplicate(true)
+	arena_id = str(config.get("arena_id", "praia_de_pratigi_festival"))
+	var heat_config: Dictionary = config.get("heat", {})
+	heat = clampf(float(heat_config.get("starting_value", 0.0)), 0.0, 100.0)
+	elapsed_seconds = 0.0
+	bet_stake = 0
+	potential_payout = 0
+	bet_placed = false
+	bet_locked = false
+	_set_state(EventState.SETUP)
+	heat_changed.emit(heat, get_state_name())
+	bet_changed.emit(get_bet_snapshot())
+
+
+func place_bet(stake: int, wallet_balance: int) -> Dictionary:
+	if state not in [EventState.SETUP, EventState.READY] or bet_locked:
+		return {"ok": false, "reason": "betting_closed", "wallet_delta": 0}
+	var betting: Dictionary = config.get("betting", {})
+	if bool(betting.get("real_money_allowed", false)):
+		return {"ok": false, "reason": "unsafe_betting_config", "wallet_delta": 0}
+	var minimum: int = int(betting.get("minimum_stake", 0))
+	var maximum: int = int(betting.get("maximum_stake", 0))
+	var step: int = maxi(1, int(betting.get("stake_step", 1)))
+	if stake < minimum or stake > maximum or stake % step != 0:
+		return {"ok": false, "reason": "invalid_stake", "wallet_delta": 0}
+	if stake > wallet_balance:
+		return {"ok": false, "reason": "insufficient_funds", "wallet_delta": 0}
+	var refund: int = bet_stake if bet_placed else 0
+	bet_stake = stake
+	bet_placed = stake > 0
+	potential_payout = int(round(float(stake) * float(betting.get("payout_multiplier", 1.0))))
+	_set_state(EventState.READY)
+	var snapshot := get_bet_snapshot()
+	bet_changed.emit(snapshot)
+	return {
+		"ok": true,
+		"reason": "bet_registered" if bet_placed else "no_bet_selected",
+		"wallet_delta": refund - stake,
+		"bet": snapshot
+	}
+
+
+func cancel_bet() -> Dictionary:
+	if bet_locked or state not in [EventState.SETUP, EventState.READY]:
+		return {"ok": false, "wallet_delta": 0, "reason": "bet_locked"}
+	var refund := bet_stake
+	bet_stake = 0
+	potential_payout = 0
+	bet_placed = false
+	_set_state(EventState.SETUP)
+	var snapshot := get_bet_snapshot()
+	bet_changed.emit(snapshot)
+	return {"ok": true, "wallet_delta": refund, "reason": "bet_cancelled", "bet": snapshot}
+
+
+func start_event() -> Dictionary:
+	if state not in [EventState.SETUP, EventState.READY]:
+		return {"ok": false, "reason": "event_not_ready"}
+	bet_locked = true
+	elapsed_seconds = 0.0
+	_set_state(EventState.LIVE)
+	set_process(true)
+	if bet_placed:
+		register_public_exposure(float(config.get("heat", {}).get("bet_exposure", 0.0)), "bet_registered")
+	return {"ok": true, "state": get_state_name(), "bet": get_bet_snapshot()}
+
+
+func _process(delta: float) -> void:
+	if state not in [EventState.LIVE, EventState.WARNING]:
+		return
+	elapsed_seconds += delta
+	var heat_config: Dictionary = config.get("heat", {})
+	var passive_rate: float = maxf(0.0, float(heat_config.get("passive_per_second", 0.0)))
+	_add_heat(passive_rate * delta, "passive_exposure")
+
+
+func register_technique(result: Dictionary) -> void:
+	if state not in [EventState.LIVE, EventState.WARNING]:
+		return
+	var heat_config: Dictionary = config.get("heat", {})
+	var amount: float = float(heat_config.get("technique_exposure", 0.0))
+	if bool(result.get("success", false)):
+		amount += float(heat_config.get("successful_technique_bonus", 0.0))
+	if str(result.get("phase", "")) == "TECHNICAL":
+		amount += float(heat_config.get("technical_phase_bonus", 0.0))
+	register_public_exposure(amount, "combat_technique")
+
+
+func register_public_exposure(amount: float, source: String = "public_exposure") -> void:
+	if state not in [EventState.LIVE, EventState.WARNING]:
+		return
+	_add_heat(maxf(0.0, amount), source)
+
+
+func force_interdiction(reason: String = "authority_arrival") -> void:
+	if state in [EventState.INTERDICTED, EventState.RESOLVED]:
+		return
+	heat = 100.0
+	_set_state(EventState.INTERDICTED)
+	set_process(false)
+	heat_changed.emit(heat, get_state_name())
+	var snapshot := get_snapshot()
+	snapshot["reason"] = reason
+	interdiction_triggered.emit(snapshot)
+
+
+func settle(combat_result: Dictionary, player_id: String) -> Dictionary:
+	if state == EventState.RESOLVED:
+		return {"ok": false, "reason": "already_settled", "wallet_delta": 0}
+	set_process(false)
+	var interrupted: bool = state == EventState.INTERDICTED or bool(combat_result.get("interrupted", false))
+	var player_won: bool = str(combat_result.get("winner", "")) == player_id
+	var payout: int = 0
+	var status := "no_bet"
+	if interrupted:
+		status = "interdicted"
+	elif bet_placed and player_won:
+		payout = potential_payout
+		status = "won"
+	elif bet_placed:
+		status = "lost"
+	_set_state(EventState.RESOLVED)
+	var settlement := {
+		"ok": true,
+		"arena_id": arena_id,
+		"status": status,
+		"stake": bet_stake,
+		"payout": payout,
+		"wallet_delta": payout,
+		"heat": heat,
+		"interrupted": interrupted,
+		"player_won": player_won
+	}
+	event_settled.emit(settlement)
+	return settlement
+
+
+func get_bet_snapshot() -> Dictionary:
+	return {
+		"stake": bet_stake,
+		"potential_payout": potential_payout,
+		"placed": bet_placed,
+		"locked": bet_locked,
+		"currency": str(config.get("betting", {}).get("currency", "moeda_interna"))
+	}
+
+
+func get_snapshot() -> Dictionary:
+	return {
+		"arena_id": arena_id,
+		"state": get_state_name(),
+		"heat": heat,
+		"elapsed_seconds": elapsed_seconds,
+		"bet": get_bet_snapshot()
+	}
+
+
+func get_state_name() -> String:
+	return str(EventState.keys()[state]).to_lower()
+
+
+func _add_heat(amount: float, source: String) -> void:
+	if amount <= 0.0:
+		return
+	heat = clampf(heat + amount, 0.0, 100.0)
+	var heat_config: Dictionary = config.get("heat", {})
+	var warning_threshold: float = float(heat_config.get("warning_threshold", 70.0))
+	var interdiction_threshold: float = float(heat_config.get("interdiction_threshold", 100.0))
+	if heat >= interdiction_threshold:
+		force_interdiction(source)
+		return
+	if heat >= warning_threshold and state == EventState.LIVE:
+		_set_state(EventState.WARNING)
+		var warning_snapshot := get_snapshot()
+		warning_snapshot["reason"] = source
+		warning_issued.emit(warning_snapshot)
+	heat_changed.emit(heat, get_state_name())
+
+
+func _set_state(new_state: EventState) -> void:
+	if state == new_state:
+		return
+	state = new_state
+	state_changed.emit(get_state_name())

--- a/src/visual/AnimatedWaterLine.gd
+++ b/src/visual/AnimatedWaterLine.gd
@@ -1,0 +1,52 @@
+class_name AnimatedWaterLine
+extends Control
+
+signal tide_level_changed(level: float)
+
+@export_range(30.0, 300.0, 0.1) var visual_cycle_seconds: float = 124.2
+@export var reduced_motion: bool = false
+
+var level: float = 0.5
+var _elapsed: float = 0.0
+var _last_emitted_level: float = -1.0
+
+
+func _ready() -> void:
+	mouse_filter = Control.MOUSE_FILTER_IGNORE
+	queue_redraw()
+
+
+func _process(delta: float) -> void:
+	var motion_scale := 0.2 if reduced_motion else 1.0
+	_elapsed += delta * motion_scale
+	level = 0.5 + 0.5 * sin((_elapsed / visual_cycle_seconds) * TAU)
+	if absf(level - _last_emitted_level) >= 0.01:
+		_last_emitted_level = level
+		tide_level_changed.emit(level)
+	queue_redraw()
+
+
+func _draw() -> void:
+	var w := size.x
+	var h := size.y
+	if w <= 0.0 or h <= 0.0:
+		return
+	var base_y := h * lerpf(0.505, 0.565, level)
+	for band in range(4):
+		var points := PackedVector2Array()
+		var amplitude := 3.0 + band * 1.2
+		var y_offset := band * 5.0
+		for x in range(0, int(w) + 17, 16):
+			var wave := sin(float(x) * 0.035 + _elapsed * (0.7 + band * 0.08)) * amplitude
+			points.append(Vector2(float(x), base_y + y_offset + wave))
+		if points.size() > 1:
+			draw_polyline(points, Color(0.55, 0.95, 1.0, 0.55 - band * 0.09), 2.0)
+
+
+func get_state_name() -> String:
+	if level < 0.35:
+		return "baixa"
+	if level > 0.65:
+		return "alta"
+	var derivative := cos((_elapsed / visual_cycle_seconds) * TAU)
+	return "subindo" if derivative > 0.0 else "descendo"

--- a/src/visual/PratigiFestivalBackdrop.gd
+++ b/src/visual/PratigiFestivalBackdrop.gd
@@ -1,0 +1,174 @@
+class_name PratigiFestivalBackdrop
+extends Control
+
+@export_range(12, 64, 1) var crowd_count: int = 40
+@export var reduced_motion: bool = false
+
+var _time: float = 0.0
+var _heat_level: float = 0.0
+var _crowd_intensity: float = 0.65
+var _tide_level: float = 0.5
+
+
+func _ready() -> void:
+	mouse_filter = Control.MOUSE_FILTER_IGNORE
+	queue_redraw()
+
+
+func _process(delta: float) -> void:
+	_time += delta * (0.25 if reduced_motion else 1.0)
+	queue_redraw()
+
+
+func set_heat_level(value: float) -> void:
+	_heat_level = clampf(value, 0.0, 100.0)
+	queue_redraw()
+
+
+func set_crowd_intensity(value: float) -> void:
+	_crowd_intensity = clampf(value, 0.0, 1.0)
+	queue_redraw()
+
+
+func set_tide_level(value: float) -> void:
+	_tide_level = clampf(value, 0.0, 1.0)
+	queue_redraw()
+
+
+func _draw() -> void:
+	var w := size.x
+	var h := size.y
+	if w <= 0.0 or h <= 0.0:
+		return
+	_draw_sky(w, h)
+	_draw_ocean(w, h)
+	_draw_beach(w, h)
+	_draw_stage(w, h)
+	_draw_slow_lights(w, h)
+	_draw_crowd_ring(w, h)
+	_draw_community_referee(w, h)
+	_draw_fight_area(w, h)
+	_draw_corners(w, h)
+	_draw_authority_glow(w, h)
+
+
+func _draw_sky(w: float, h: float) -> void:
+	draw_rect(Rect2(0.0, 0.0, w, h), Color("081124"))
+	for i in range(10):
+		var t := float(i) / 9.0
+		var color := Color(0.04 + t * 0.18, 0.07 + t * 0.08, 0.16 + t * 0.12, 1.0)
+		draw_rect(Rect2(0.0, h * 0.06 * i, w, h * 0.065 + 1.0), color)
+	var moon_pos := Vector2(w * 0.82, h * 0.15)
+	draw_circle(moon_pos, 42.0, Color(0.95, 0.86, 0.64, 0.82))
+	draw_circle(moon_pos + Vector2(13.0, -8.0), 38.0, Color("0d1830"))
+
+
+func _draw_ocean(w: float, h: float) -> void:
+	var ocean_top := h * lerpf(0.35, 0.40, _tide_level)
+	draw_rect(Rect2(0.0, ocean_top, w, h * 0.25), Color("0b4966"))
+	for i in range(9):
+		var y := ocean_top + 10.0 + i * 13.0
+		var drift := sin(_time * 0.55 + i * 0.8) * 18.0
+		draw_line(Vector2(drift, y), Vector2(w + drift, y), Color(0.22, 0.78, 0.84, 0.18), 2.0)
+
+
+func _draw_beach(w: float, h: float) -> void:
+	var sand_top := h * lerpf(0.50, 0.57, _tide_level)
+	var sand := PackedVector2Array([
+		Vector2(0.0, sand_top),
+		Vector2(w, sand_top - 18.0),
+		Vector2(w, h),
+		Vector2(0.0, h)
+	])
+	draw_colored_polygon(sand, Color("b88945"))
+	for i in range(26):
+		var x := fposmod(float(i * 97), w)
+		var y := sand_top + 18.0 + fposmod(float(i * 41), maxf(1.0, h - sand_top - 18.0))
+		draw_circle(Vector2(x, y), 1.4, Color(0.32, 0.20, 0.09, 0.38))
+
+
+func _draw_stage(w: float, h: float) -> void:
+	var stage_rect := Rect2(w * 0.04, h * 0.18, w * 0.24, h * 0.25)
+	draw_rect(stage_rect, Color("151320"))
+	draw_rect(Rect2(stage_rect.position + Vector2(10.0, 12.0), stage_rect.size - Vector2(20.0, 26.0)), Color("241b36"))
+	for x_ratio in [0.065, 0.245]:
+		draw_rect(Rect2(w * x_ratio, h * 0.20, 24.0, h * 0.19), Color("08080c"))
+		for i in range(3):
+			draw_circle(Vector2(w * x_ratio + 12.0, h * (0.235 + i * 0.052)), 7.0, Color("39264e"))
+	var booth := Rect2(w * 0.105, h * 0.31, w * 0.11, h * 0.075)
+	draw_rect(booth, Color("07090e"))
+	draw_line(booth.position + Vector2(8.0, 10.0), booth.end - Vector2(8.0, 12.0), Color("22d3ee"), 3.0)
+	var dj_center := Vector2(w * 0.16, h * 0.275)
+	draw_circle(dj_center, 10.0, Color("6f4d37"))
+	draw_rect(Rect2(dj_center + Vector2(-11.0, 9.0), Vector2(22.0, 30.0)), Color("191d2b"))
+
+
+func _draw_slow_lights(w: float, h: float) -> void:
+	var phase := sin(_time * 0.42) * 0.5 + 0.5
+	var colors := [Color(0.12, 0.83, 0.92, 0.10), Color(0.95, 0.35, 0.56, 0.08), Color(0.98, 0.72, 0.18, 0.08)]
+	for i in range(3):
+		var origin := Vector2(w * (0.09 + i * 0.075), h * 0.19)
+		var target_x := w * (0.38 + i * 0.20) + (phase - 0.5) * 80.0
+		var beam := PackedVector2Array([
+			origin,
+			Vector2(target_x - 58.0, h * 0.74),
+			Vector2(target_x + 58.0, h * 0.74)
+		])
+		draw_colored_polygon(beam, colors[i])
+
+
+func _draw_crowd_ring(w: float, h: float) -> void:
+	for i in range(crowd_count):
+		var left_side := i < crowd_count / 2
+		var local_index := i if left_side else i - crowd_count / 2
+		var side_count := maxi(1, crowd_count / 2)
+		var x_base := lerpf(w * 0.02, w * 0.31, float(local_index) / side_count) if left_side else lerpf(w * 0.69, w * 0.98, float(local_index) / side_count)
+		var row := i % 3
+		var bounce := sin(_time * (1.2 + (i % 5) * 0.08) + i) * (2.0 + 5.0 * _crowd_intensity)
+		var y := h * 0.57 + row * 32.0 + bounce
+		var skin := [Color("6f4d37"), Color("8e6248"), Color("4d352b"), Color("b27b57")][i % 4]
+		var shirt := [Color("202938"), Color("6f2338"), Color("164b58"), Color("8a5b19")][i % 4]
+		draw_circle(Vector2(x_base, y), 7.0, skin)
+		draw_rect(Rect2(x_base - 8.0, y + 7.0, 16.0, 20.0), shirt)
+		if i % 5 == 0:
+			draw_line(Vector2(x_base + 6.0, y + 13.0), Vector2(x_base + 13.0, y - 6.0 - bounce * 0.2), skin, 3.0)
+
+
+func _draw_community_referee(w: float, h: float) -> void:
+	var center := Vector2(w * 0.5, h * 0.515)
+	draw_circle(center, 8.5, Color("77503b"))
+	draw_rect(Rect2(center + Vector2(-8.0, 8.0), Vector2(16.0, 36.0)), Color("e5e7eb"))
+	draw_line(center + Vector2(-7.0, 19.0), center + Vector2(-23.0, 30.0), Color("77503b"), 4.0)
+	draw_line(center + Vector2(7.0, 19.0), center + Vector2(23.0, 30.0), Color("77503b"), 4.0)
+
+
+func _draw_fight_area(w: float, h: float) -> void:
+	var center := Vector2(w * 0.5, h * 0.77)
+	var rx := minf(w * 0.27, 345.0)
+	var ry := minf(h * 0.15, 102.0)
+	var ring := PackedVector2Array([
+		Vector2(center.x, center.y - ry),
+		Vector2(center.x + rx, center.y),
+		Vector2(center.x, center.y + ry),
+		Vector2(center.x - rx, center.y)
+	])
+	draw_colored_polygon(ring, Color(0.08, 0.10, 0.13, 0.62))
+	draw_polyline(ring, Color("f5c542"), 5.0, true)
+	draw_arc(center, 45.0, 0.0, TAU, 32, Color("22d3ee"), 3.0)
+
+
+func _draw_corners(w: float, h: float) -> void:
+	var y := h * 0.77
+	draw_rect(Rect2(w * 0.245, y - 30.0, 10.0, 60.0), Color("2f7df6"))
+	draw_circle(Vector2(w * 0.25, y - 36.0), 10.0, Color("2f7df6"))
+	draw_rect(Rect2(w * 0.747, y - 30.0, 10.0, 60.0), Color("f5c542"))
+	draw_circle(Vector2(w * 0.752, y - 36.0), 10.0, Color("f5c542"))
+
+
+func _draw_authority_glow(w: float, h: float) -> void:
+	if _heat_level < 65.0:
+		return
+	var alpha := clampf((_heat_level - 65.0) / 35.0, 0.0, 1.0) * 0.18
+	var pulse := 0.55 + sin(_time * 1.8) * 0.15
+	draw_rect(Rect2(0.0, 0.0, w * 0.13, h), Color(0.10, 0.32, 0.92, alpha * pulse))
+	draw_rect(Rect2(w * 0.87, 0.0, w * 0.13, h), Color(0.92, 0.12, 0.15, alpha * pulse))

--- a/src/visual/PratigiFestivalBackdrop.gd
+++ b/src/visual/PratigiFestivalBackdrop.gd
@@ -126,8 +126,8 @@ func _draw_crowd_ring(w: float, h: float) -> void:
 		var row := i % 3
 		var bounce := sin(_time * (1.2 + (i % 5) * 0.08) + i) * (2.0 + 5.0 * _crowd_intensity)
 		var y := h * 0.57 + row * 32.0 + bounce
-		var skin := [Color("6f4d37"), Color("8e6248"), Color("4d352b"), Color("b27b57")][i % 4]
-		var shirt := [Color("202938"), Color("6f2338"), Color("164b58"), Color("8a5b19")][i % 4]
+		var skin: Color = [Color("6f4d37"), Color("8e6248"), Color("4d352b"), Color("b27b57")][i % 4]
+		var shirt: Color = [Color("202938"), Color("6f2338"), Color("164b58"), Color("8a5b19")][i % 4]
 		draw_circle(Vector2(x_base, y), 7.0, skin)
 		draw_rect(Rect2(x_base - 8.0, y + 7.0, 16.0, 20.0), shirt)
 		if i % 5 == 0:

--- a/tests/pratigi_festival_smoke.gd
+++ b/tests/pratigi_festival_smoke.gd
@@ -1,0 +1,54 @@
+extends SceneTree
+
+var failures: Array[String] = []
+
+
+func _initialize() -> void:
+	call_deferred("_run")
+
+
+func _run() -> void:
+	var config_file := FileAccess.open("res://data/arenas/pratigi_festival_v01.json", FileAccess.READ)
+	_check(config_file != null, "festival config opens")
+	if config_file == null:
+		_finish()
+		return
+	var config = JSON.parse_string(config_file.get_as_text())
+	config_file.close()
+	_check(typeof(config) == TYPE_DICTIONARY, "festival config parses")
+
+	var director_script = load("res://src/combat/arena/ClandestineEventDirector.gd")
+	_check(director_script != null, "event director script loads")
+	var director: Node = director_script.new()
+	root.add_child(director)
+	director.call("configure", config)
+	var bet: Dictionary = director.call("place_bet", 50, 100)
+	_check(bool(bet.get("ok", false)), "internal-currency bet is accepted")
+	_check(int(bet.get("wallet_delta", 0)) == -50, "stake is debited once")
+	var started: Dictionary = director.call("start_event")
+	_check(bool(started.get("ok", false)), "event starts")
+	director.call("register_public_exposure", 50.0, "smoke_warning")
+	_check(str(director.call("get_state_name")) == "warning", "warning threshold is reached")
+	director.call("force_interdiction", "smoke_interdiction")
+	_check(str(director.call("get_state_name")) == "interdicted", "interdiction state is reached")
+	var settlement: Dictionary = director.call("settle", {"interrupted": true}, "ruan_macacao")
+	_check(str(settlement.get("status", "")) == "interdicted", "interdicted bet does not pay")
+	_check(int(settlement.get("wallet_delta", -1)) == 0, "interdicted event has zero payout")
+
+	var packed_scene = load("res://scenes/combat/arenas/PratigiFestivalArena.tscn")
+	_check(packed_scene != null, "Pratigi festival scene parses")
+	director.queue_free()
+	_finish()
+
+
+func _check(condition: bool, label: String) -> void:
+	if condition:
+		print("[OK] ", label)
+	else:
+		failures.append(label)
+		push_error("[FAIL] " + label)
+
+
+func _finish() -> void:
+	print("Pratigi festival smoke: %d failure(s)" % failures.size())
+	quit(0 if failures.is_empty() else 1)

--- a/tools/audit/validate_pratigi_festival.py
+++ b/tools/audit/validate_pratigi_festival.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Validate the Pratigi parallel festival vertical slice and its safety contracts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+ARENAS_PATH = ROOT / "data" / "arenas.json"
+CONFIG_PATH = ROOT / "data" / "arenas" / "pratigi_festival_v01.json"
+HUBS_PATH = ROOT / "data" / "world" / "hubs_dense_v01.json"
+SCENE_PATH = ROOT / "scenes" / "combat" / "arenas" / "PratigiFestivalArena.tscn"
+SCENE_SCRIPT_PATH = ROOT / "scenes" / "combat" / "arenas" / "PratigiFestivalArena.gd"
+DIRECTOR_PATH = ROOT / "src" / "combat" / "arena" / "ClandestineEventDirector.gd"
+PROJECT_PATH = ROOT / "project.godot"
+
+
+def load_json(path: Path) -> dict:
+    """Load one JSON object or fail with a useful path."""
+    with path.open("r", encoding="utf-8") as handle:
+        data = json.load(handle)
+    if not isinstance(data, dict):
+        raise AssertionError(f"{path.relative_to(ROOT)} must contain an object")
+    return data
+
+
+def require(condition: bool, message: str) -> None:
+    """Raise an assertion with a concise validation error."""
+    if not condition:
+        raise AssertionError(message)
+
+
+def main() -> int:
+    """Run the Pratigi arena contract validation."""
+    arenas = load_json(ARENAS_PATH).get("arenas", [])
+    by_id = {str(item.get("id", "")): item for item in arenas}
+    config = load_json(CONFIG_PATH)
+    hubs = load_json(HUBS_PATH).get("hubs", {})
+
+    require("praia_de_pratigi" in by_id, "canonical Pratigi base arena is missing")
+    require("praia_de_pratigi_festival" in by_id, "festival arena variant is missing")
+    festival = by_id["praia_de_pratigi_festival"]
+    require(
+        festival.get("parallel_variant_of") == "praia_de_pratigi",
+        "festival must remain a parallel variant of canonical Pratigi",
+    )
+    require(festival.get("fictional_event") is True, "festival must be explicitly fictional")
+    require(
+        festival.get("officially_sanctioned") is False,
+        "parallel festival cannot masquerade as an official circuit",
+    )
+    require(
+        festival.get("referee_role") == "community_mediator",
+        "clandestine event needs a tap-enforcing community mediator",
+    )
+
+    policy = config.get("content_policy", {})
+    betting = config.get("betting", {})
+    heat = config.get("heat", {})
+    require(policy.get("real_money_gambling") is False, "real-money gambling must stay disabled")
+    require(policy.get("authority_evasion_gameplay") is False, "authority evasion gameplay is forbidden")
+    require(policy.get("technical_stoppage_required") is True, "technical stoppage is mandatory")
+    require(betting.get("real_money_allowed") is False, "betting may use only internal currency")
+    require(betting.get("purchase_with_real_money") is False, "stakes cannot be bought with real money")
+    require(0 <= int(betting.get("maximum_stake", -1)) <= 150, "stake cap must remain bounded")
+    require(
+        0.0 < float(heat.get("warning_threshold", 0.0))
+        < float(heat.get("interdiction_threshold", 0.0))
+        <= 100.0,
+        "heat thresholds must be ordered inside 0..100",
+    )
+
+    hub = hubs.get("pratigi_festival", {})
+    require(hub.get("entry_scene") == "res://scenes/combat/arenas/PratigiFestivalArena.tscn", "Pratigi hub must consume the scene")
+    require(int(hub.get("unlock_act", 0)) == 2, "Pratigi parallel route must remain an Act 2 unlock")
+
+    for path in [SCENE_PATH, SCENE_SCRIPT_PATH, DIRECTOR_PATH]:
+        require(path.is_file(), f"missing runtime file: {path.relative_to(ROOT)}")
+    scene_text = SCENE_PATH.read_text(encoding="utf-8")
+    for node_name in [
+        "ArenaBackdrop",
+        "AnimatedWaterLine",
+        "BlueCorner",
+        "GoldCorner",
+        "CommunityReferee",
+        "DJStage",
+        "RaveCrowd",
+        "CrowdChant",
+        "EventDirector",
+        "EventHUD",
+        "InterdictionOverlay",
+    ]:
+        require(f'name="{node_name}"' in scene_text, f"scene is missing {node_name}")
+
+    project_text = PROJECT_PATH.read_text(encoding="utf-8")
+    require("ClandestineEventDirector=" not in project_text, "event director must stay scene-local")
+    require("PratigiFestivalArena=" not in project_text, "arena must not become an autoload")
+
+    print("[pratigi-festival] ok: data, scene, safety, map consumer and scope validated")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/audit/validate_pratigi_festival.py
+++ b/tools/audit/validate_pratigi_festival.py
@@ -37,7 +37,7 @@ def main() -> int:
     arenas = load_json(ARENAS_PATH).get("arenas", [])
     by_id = {str(item.get("id", "")): item for item in arenas}
     config = load_json(CONFIG_PATH)
-    hubs = load_json(HUBS_PATH).get("hubs", {})
+    event_destinations = load_json(HUBS_PATH).get("event_destinations", {})
 
     require("praia_de_pratigi" in by_id, "canonical Pratigi base arena is missing")
     require("praia_de_pratigi_festival" in by_id, "festival arena variant is missing")
@@ -72,9 +72,13 @@ def main() -> int:
         "heat thresholds must be ordered inside 0..100",
     )
 
-    hub = hubs.get("pratigi_festival", {})
-    require(hub.get("entry_scene") == "res://scenes/combat/arenas/PratigiFestivalArena.tscn", "Pratigi hub must consume the scene")
-    require(int(hub.get("unlock_act", 0)) == 2, "Pratigi parallel route must remain an Act 2 unlock")
+    destination = event_destinations.get("pratigi_festival", {})
+    require(
+        destination.get("entry_scene") == "res://scenes/combat/arenas/PratigiFestivalArena.tscn",
+        "Pratigi event destination must consume the scene",
+    )
+    require(int(destination.get("unlock_act", 0)) == 2, "Pratigi parallel route must remain an Act 2 unlock")
+    require("activities" not in destination, "event destination cannot advertise unimplemented hub activities")
 
     for path in [SCENE_PATH, SCENE_SCRIPT_PATH, DIRECTOR_PATH]:
         require(path.is_file(), f"missing runtime file: {path.relative_to(ROOT)}")


### PR DESCRIPTION
## Objetivo

Entregar uma vertical slice jogável do **Festival Maré Alta — Rota Paralela**, em Pratigi: arena de praia noturna com DJ ficcional, crowd ao redor, cantos azul/dourado, juiz/mediador comunitário, linha d'água animada, aposta opcional em moeda interna e heat com aviso/interdição segura.

A implementação preserva a Praia de Pratigi canônica e não altera a Arena do Dique, que continua sendo o circuito oficial em Salvador.

## Tipo de mudança

- [ ] Correção de bug
- [x] Feature jogável
- [x] Dados/cânone
- [x] Visual/animação/áudio
- [x] Build/CI/release
- [x] Documentação/governança

## Escopo

### Incluído

- cena completa `PratigiFestivalArena.tscn` integrada ao combate canônico Ruan × Davi;
- backdrop procedural mobile-first com praia, DJ, crowd reativo, gritos visuais, mediador, cantos e iluminação lenta;
- linha d'água animada com opção de movimento reduzido;
- aposta opcional limitada a moeda já existente no save, odds/retorno explícitos e cap de R$ 150;
- state machine local de heat: setup → live → warning → interdicted/resolved;
- interdição no mesmo frame lógico, encerrando o combate sem vitória/derrota de carreira e sem gameplay de fuga;
- consequências em hype/honra/sombra, Cria Live e save;
- acesso pelo Terreiro → Mapa do Baixo Sul → Pratigi, liberado no Ato 2;
- validador estático, smoke headless e documentação de implementação/rollback.

### Fora do escopo

- arte final aprovada, música eletrônica final e vozes reais de crowd;
- navegação marítima/maré global;
- dinheiro real, compra de moeda, loot box ou aposta externa;
- fuga, confronto ou ocultação diante de autoridade;
- nova facção, novo autoload ou segundo runtime;
- teste Android físico.

## Integração no jogo

- Cena ou fluxo consumidor: `TerreiroDaLuta.tscn → WorldMapScreen.tscn → PratigiFestivalArena.tscn`.
- Managers/autoloads afetados: extensões cirúrgicas em `CombatManager`, `WorldMapManager`, `CriaLiveManager` e `AudioManager`; nenhum autoload novo.
- Dados persistidos ou migração de save: usa `WorldState.money`, reputação e `story_flags`; saves antigos recebem o hub de Pratigi de forma aditiva, sem bump de schema.
- Compatibilidade com `main`: baseada em `912e515722931519aadf103f4d7674057e922772`; alterações aditivas e fallback padrão preservado em `CombatArenaBase`.

## Evidências

- [x] `npm run quality`
- [ ] Godot import/parser
- [ ] Smoke test do fluxo alterado
- [x] Save/load ou migração validada, quando aplicável
- [ ] Screenshots/GIF/vídeo, quando visual
- [ ] Teste Android físico, quando exigido
- [x] Licenças e origem dos assets registradas

### Resultados dos testes

```text
PASS  npm run quality
      governance, canon, factions-v4, pratigi, JSON, data,
      animations, repository, runtime, release, supreme e deck

PASS  git diff --cached --check

PASS  python tools/audit/validate_pratigi_festival.py
      [pratigi-festival] ok: data, scene, safety, map consumer and scope validated

BLOCKED  npm run smoke:pratigi
         sh: godot: not found

BLOCKED  apt-get install -y godot4
         Unable to locate package godot4
```

## Cânone e segurança

- [x] Mantém Ruan “Macacão” Silva como protagonista canônico
- [x] Não cria uma quarta facção ativa
- [x] Não introduz segundo runtime, manager concorrente ou backend obrigatório
- [x] Não inclui segredos, chaves, keystore ou credenciais
- [x] Não usa marca, pessoa, frame ou asset de terceiro sem licença
- [x] Combate continua determinístico e funcional offline

O festival é explicitamente ficcional. Apostas usam apenas moeda interna não comprável. Tap e parada técnica são obrigatórios. No heat máximo, a arena encerra a luta; não há minigame de evasão.

## Riscos e rollback

- Riscos conhecidos: parser/smoke Godot e leitura visual em Android ainda precisam de runner 4.3+ e aparelho físico.
- Dívida técnica: backdrop, crowd e áudio são placeholders procedurais/funcionais; assets finais seguem pendentes.
- Como reverter: remover o hub/botão/variante e os arquivos da vertical slice; extensões dos managers são aditivas e podem ser revertidas separadamente. Dados residuais ficam apenas em `story_flags` e são ignorados por versões anteriores.

## Checklist de merge

- [x] PR focado em uma vertical slice
- [x] Sem conflitos com a branch-alvo no momento da publicação
- [x] Checks estáticos obrigatórios verdes
- [ ] Revisão humana concluída
- [x] Documentação atualizada
- [x] Justificativa registrada: solicitação direta de atualização jogável da arena de Pratigi
