### PR TITLE
feat(visual): add governed sprite forge compatibility layer

### DIFF
--- a/docs/production/M4_SPRITE_FORGE_COMPAT_V01.md
+++ b/docs/production/M4_SPRITE_FORGE_COMPAT_V01.md
@@ -1,0 +1,132 @@
+# M4 — Compatibilidade do Sprite Forge
+
+**Status:** DRAFT operacional  
+**Branch de trabalho:** `feat/m4-sprite-forge-compat`  
+**Objetivo:** desbloquear a preparação determinística de candidatos do M4 sem alterar o runtime Godot, sem promover assets e sem depender de um projeto externo não verificado.
+
+## Decisão
+
+O bloqueio não deve ser resolvido procurando um binário mágico chamado `agent-sprite-forge`. A `main` já possui `tools/cria_forge/cria_forge.py`, o pipeline de fila `tools/ai_asset_pipeline/build_production_queue_v02.py` e dependências suficientes para operações locais de imagem, mas não possui `tools/sprite_forge/`, `generate2dsprite`, `map`, um builder de props/VFX ou um gate visual integrado ao quality gate.[1] [2]
+
+A solução adotada nesta branch é uma **camada fina de compatibilidade determinística**:
+
+| Camada | Responsabilidade | Pode promover asset? |
+|---|---|---:|
+| Geração de conceito/candidato | Ambiente de geração autorizado ou produção manual; saída bruta imutável | Não |
+| `tools/sprite_forge/cli.py` | Chroma key/despill conservador, fatiamento, contact sheet, metadata, licença-templated e validação estrutural | Não |
+| `tools/sprite_forge/generate2dsprite` | Launcher compatível para empacotamento de uma folha PNG | Não |
+| `tools/sprite_forge/map` | Launcher compatível para gerar mapa de regiões, pivôs e SHA-256 | Não |
+| `tools/sprite_forge/build_m4_queue.py` | Subfila segura para ícones, arenas e UI usando IDs existentes | Não |
+| QA humano e integração Godot | Aprovação de cânone, licença, biomecânica, legibilidade e consumidor real | Sim, manualmente |
+
+Essa camada não tenta substituir o `Visual QA V2` proposto no PR [#65](https://github.com/ringuemkt-rgb/cria-do-tatame/pull/65), nem o gerador de fila visual proposto no PR [#38](https://github.com/ringuemkt-rgb/cria-do-tatame/pull/38). O plano correto é portar ou rebasear esses PRs depois da revisão da base, usando este compatibilizador apenas para fechar a lacuna de comandos e empacotamento.
+
+## Por que não vendorizar imediatamente um forge externo
+
+O contrato do projeto exige que ferramentas externas sejam opcionais, licenciadas, reproduzíveis e separadas do runtime. Também exige que fontes, revisões imutáveis, datasets, adapters e cadeia de licença sejam registrados antes da adoção.[3] A busca no GitHub encontrou projetos de pixel-art pipeline, porém a maioria dos resultados relevantes tem poucos sinais de maturidade ou não declara compatibilidade com este contrato; o repositório do projeto já lista Pixelorama e Material Maker como ferramentas de pesquisa/aprovação, mas não como um CLI `generate2dsprite/map` pronto para esta base.[4]
+
+Consequentemente, a regra é: **reaproveitar a arquitetura existente e fixar uma interface local estável; somente depois avaliar um backend externo atrás dessa interface**. Um backend futuro poderá produzir ou normalizar imagens, mas deverá continuar entregando o mesmo pacote e passar pelos mesmos gates. O M4 não deve ficar bloqueado por uma dependência cujo código, licença, versão ou comportamento não foram verificados.
+
+## Contrato dos comandos
+
+### Empacotamento de um spritesheet
+
+```bash
+python tools/sprite_forge/generate2dsprite \
+  --input /path/to/candidate.png \
+  --output-dir /path/to/candidate-package \
+  --asset-id m4_item_id \
+  --frame-width 256 \
+  --frame-height 256 \
+  --fps 12 \
+  --grid-px 16 \
+  --chroma-key '#FF00FF' \
+  --key-threshold 24
+```
+
+O comando preserva `raw_sheet.png`, produz `clean_sheet.png` e `spritesheet.png`, fatia `frames/frame_###.png`, cria `preview.gif` e `contact_sheet.png`, grava `metadata.json`, `import_notes.md`, `qa_report.md` e um `license.json` inicial com estado `pending_human_review`. O `license.json` é um formulário de proveniência, não uma licença concedida.
+
+O cleanup é deliberadamente limitado. Ele remove a chave magenta próxima da cor declarada, reduz fringe em pixels de borda e não faz redimensionamento, inferência de anatomia, geração de poses, pintura de textura ou promoção de resultado. A ausência de redimensionamento evita transformar uma auditoria em uma alteração silenciosa do asset.
+
+### Mapa de regiões
+
+```bash
+python tools/sprite_forge/map \
+  --input /path/to/clean_sheet.png \
+  --output /path/to/regions.json \
+  --frame-width 256 \
+  --frame-height 256 \
+  --labels anticipation,entry,contact,stabilize,response,recovery
+```
+
+O `map` calcula regiões retangulares, pivô `bottom_center`, quantidade de frames e SHA-256 da folha de entrada. Ele **não** é um `sync_map.json` biomecânico de atacante e defensor. Técnicas pareadas continuam exigindo atacante, defensor, estados de entrada/saída, contato, timing, interrupção, custos e aprovação BJJ conforme o contrato de produção.[5]
+
+### Subfila M4
+
+```bash
+python tools/sprite_forge/build_m4_queue.py \
+  --output /tmp/m4_queue_v01.jsonl
+```
+
+A subfila atual é conservadora e emite 14 linhas:
+
+| Tipo | Quantidade | Estado inicial |
+|---|---:|---|
+| Ícones/cards de técnica | 6 | `queued` |
+| Ícones de UI | 4 | `queued` |
+| Props do Terreiro/Dique | 2 | `needs_item_specification` |
+| Partículas do Terreiro/Dique | 2 | `needs_item_specification` |
+
+Os seis IDs de técnica são `grip_de_ferro`, `baiana`, `knee_cut`, `cem_quilos`, `montada` e `mata_leao`, todos presentes no catálogo gráfico atual. Os quatro alvos de UI são `combat_hud_mobile`, `submission_hud`, `result_screen` e `cria_live_feed`, todos presentes no manifesto audiovisual v02. Os pacotes de arena ficam em nível de variante: `terreiro_da_luta/afternoon` e `arena_do_dique/event_day`. O builder não inventa IDs de props, partículas ou materiais; exige uma especificação de item antes de gerar.
+
+## Pacote e armazenamento
+
+Os candidatos grandes devem ir para a árvore privada `CriaDoTatame/assets/candidatos/<BATCH_ID>/`. Git deve receber somente o código do compatibilizador, subfila, metadata, relatórios, hashes e documentação permitidos pelo contrato vigente. O fluxo privado recomendado é candidato → revisão humana de arte, biomecânica, licença e cânone → aprovado → cache local → integração explícita em cena Godot.[6]
+
+O pacote de cada item deve manter, quando aplicável, `raw_sheet.png`, `clean_sheet.png`, `spritesheet.png`, `frames/`, `preview.gif`, `contact_sheet.png`, `metadata.json`, `import_notes.md`, `qa_report.md` e sidecar de licença. O `metadata.json` deve declarar fonte, SHA, frame size, FPS, pivot, grid, estado e parâmetros de cleanup. Nenhum arquivo recebe o estado `approved` por este CLI.
+
+## Critérios de desbloqueio
+
+O M4 pode sair de `BLOCKED` para `READY_FOR_CANDIDATE_GENERATION` quando os seguintes itens estiverem verdes:
+
+1. `tools/sprite_forge/` existe na branch e possui licença/documentação próprias;
+2. `generate2dsprite`, `map` e `validate` executam de forma reproduzível;
+3. a subfila M4 é gerada somente a partir de manifests versionados;
+4. os testes cobrem cleanup, fatiamento, regiões, contagem e estado de promoção;
+5. `license.json` é obrigatório e começa como pendente de revisão humana;
+6. o PR não toca `project.godot`, autoloads, `CombatManager`, `DeckManager`, `AudioManager`, save migration ou segundo runtime;
+7. o Visual QA V2, quando portado/rebaseado, é usado como gate adicional e não como aprovação humana;
+8. cada item gerado tem consumidor real planejado ou permanece apenas especificado.
+
+## Validação local
+
+```bash
+python -m unittest discover -s tests/sprite_forge -p 'test_*.py'
+python tools/sprite_forge/build_m4_queue.py --output /tmp/m4_queue_v01.jsonl
+python tools/cria_forge/cria_forge.py validate
+npm run quality
+```
+
+A execução completa de `npm run quality` continua sendo obrigatória para a branch, mas o resultado deve ser atribuído aos arquivos realmente modificados. Um teste verde do compatibilizador não prova licença, cânone, biomecânica, legibilidade mobile ou integração Godot.
+
+## Rollback
+
+Se a camada não for aceita, fechar o PR sem merge, remover a branch temporária e manter o M4 como intake bloqueado. O rollback não exige alterar o runtime, apagar dados canônicos ou remover candidatos privados; basta descartar a camada compatível e preservar o ledger de decisão.
+
+## Próximo passo após este PR
+
+O próximo PR deve ser separado e pequeno: adicionar o comando do builder ao CI, integrar o Visual QA V2 portado/rebaseado e validar um único item de ícone ou partícula em candidato privado. Só depois deve-se criar uma ficha de prop individual e permitir que M4 avance de `needs_item_specification` para `queued`.
+
+## Referências
+
+[1]: https://github.com/ringuemkt-rgb/cria-do-tatame/blob/main/tools/cria_forge/cria_forge.py "Cria Forge local — comandos atuais"
+
+[2]: https://github.com/ringuemkt-rgb/cria-do-tatame/blob/main/tools/ai_asset_pipeline/build_production_queue_v02.py "Fila de produção audiovisual v02"
+
+[3]: https://github.com/ringuemkt-rgb/cria-do-tatame/blob/main/data/production/canon_contract_v4_1.json "Contrato canônico v4.1 — proibições e autoridades"
+
+[4]: https://github.com/Orama-Interactive/Pixelorama "Pixelorama — ferramenta aprovada no catálogo do projeto"
+
+[5]: https://github.com/ringuemkt-rgb/cria-do-tatame/blob/main/data/visual/production_manifest_v02.json "Manifesto visual v02 — técnicas pareadas e quality gate"
+
+[6]: https://github.com/ringuemkt-rgb/cria-do-tatame/blob/main/docs/production/DRIVE_CLOUD_V1.md "Drive Cloud v1 — proveniência e promoção manual"

--- a/tests/sprite_forge/test_cli.py
+++ b/tests/sprite_forge/test_cli.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from PIL import Image
+
+from tools.sprite_forge.cli import build_parser
+
+
+class SpriteForgeCliTests(unittest.TestCase):
+    def _run(self, argv: list[str]) -> int:
+        args = build_parser().parse_args(argv)
+        return int(args.handler(args))
+
+    def test_generate2dsprite_creates_clean_package(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "candidate.png"
+            output = root / "package"
+            image = Image.new("RGBA", (8, 4), (255, 0, 255, 255))
+            image.putpixel((2, 3), (255, 255, 255, 255))
+            image.putpixel((6, 3), (255, 255, 255, 255))
+            image.save(source)
+
+            result = self._run(
+                [
+                    "generate2dsprite",
+                    "--input",
+                    str(source),
+                    "--output-dir",
+                    str(output),
+                    "--asset-id",
+                    "m4_test_prop",
+                    "--frame-width",
+                    "4",
+                    "--frame-height",
+                    "4",
+                ]
+            )
+
+            self.assertEqual(result, 0)
+            for filename in [
+                "raw_sheet.png",
+                "clean_sheet.png",
+                "spritesheet.png",
+                "preview.gif",
+                "contact_sheet.png",
+                "metadata.json",
+                "license.json",
+                "import_notes.md",
+                "qa_report.md",
+            ]:
+                self.assertTrue((output / filename).exists(), filename)
+            self.assertEqual(len(list((output / "frames").glob("frame_*.png"))), 2)
+            metadata = json.loads((output / "metadata.json").read_text(encoding="utf-8"))
+            self.assertEqual(metadata["frame_count"], 2)
+            self.assertEqual(metadata["state"], "automated_qa_pass_pending_human")
+            with Image.open(output / "clean_sheet.png") as clean:
+                self.assertEqual(clean.getpixel((0, 0))[3], 0)
+                self.assertEqual(clean.getpixel((2, 3))[3], 255)
+
+            self.assertEqual(self._run(["validate", "--package-dir", str(output)]), 0)
+
+    def test_map_writes_labeled_regions_and_hash(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "sheet.png"
+            destination = root / "sync_map.json"
+            Image.new("RGBA", (8, 4), (0, 0, 0, 0)).save(source)
+
+            result = self._run(
+                [
+                    "map",
+                    "--input",
+                    str(source),
+                    "--output",
+                    str(destination),
+                    "--frame-width",
+                    "4",
+                    "--frame-height",
+                    "4",
+                    "--labels",
+                    "anticipation,contact",
+                ]
+            )
+
+            self.assertEqual(result, 0)
+            mapping = json.loads(destination.read_text(encoding="utf-8"))
+            self.assertEqual([item["name"] for item in mapping["regions"]], ["anticipation", "contact"])
+            self.assertEqual(mapping["regions"][1]["rect"]["x"], 4)
+            self.assertEqual(len(mapping["source"]["sha256"]), 64)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/sprite_forge/test_m4_queue.py
+++ b/tests/sprite_forge/test_m4_queue.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from tools.sprite_forge.build_m4_queue import build, main
+
+
+class M4QueueTests(unittest.TestCase):
+    def test_queue_contains_canonical_icons_and_guarded_arena_packs(self) -> None:
+        root = Path(__file__).resolve().parents[2]
+        manifest = json.loads((root / "data/visual/production_manifest_v02.json").read_text(encoding="utf-8"))
+        catalog = json.loads((root / "data/visual/graphic_asset_catalog_v01.json").read_text(encoding="utf-8"))
+        rows = build(manifest, catalog)
+
+        self.assertEqual(len(rows), 14)
+        self.assertTrue(any(row["task_id"] == "m4::technique_icon::baiana" for row in rows))
+        self.assertTrue(any(row["task_id"] == "m4::ui_icons::combat_hud_mobile" for row in rows))
+        arena_rows = [row for row in rows if row["kind"].startswith("arena_")]
+        self.assertEqual(len(arena_rows), 4)
+        self.assertTrue(all(row["status"] == "needs_item_specification" for row in arena_rows))
+        self.assertTrue(all(row["promotion"] == "forbidden_without_human_review" for row in rows))
+        self.assertTrue(all("item_id" in row.get("required_before_generation", []) for row in arena_rows))
+
+    def test_cli_writes_jsonl(self) -> None:
+        root = Path(__file__).resolve().parents[2]
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / "m4.jsonl"
+            argv = [
+                "build_m4_queue.py",
+                "--manifest",
+                str(root / "data/visual/production_manifest_v02.json"),
+                "--catalog",
+                str(root / "data/visual/graphic_asset_catalog_v01.json"),
+                "--output",
+                str(output),
+            ]
+            import sys
+
+            previous = sys.argv
+            try:
+                sys.argv = argv
+                self.assertEqual(main(), 0)
+            finally:
+                sys.argv = previous
+            self.assertEqual(len(output.read_text(encoding="utf-8").splitlines()), 14)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/sprite_forge/build_m4_queue.py
+++ b/tools/sprite_forge/build_m4_queue.py
@@ -1,0 +1,154 @@
+"""Build a conservative M4 intake queue from canonical repository manifests.
+
+The queue intentionally describes candidate work; it never promotes files and
+never adds a new runtime consumer. Arena props remain pack-level requests until
+an item-level spec exists.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+MANIFEST = ROOT / "data" / "visual" / "production_manifest_v02.json"
+CATALOG = ROOT / "data" / "visual" / "graphic_asset_catalog_v01.json"
+DEFAULT_OUTPUT = ROOT / "tools" / "sprite_forge" / "generated_queue" / "m4_queue_v01.jsonl"
+
+TECHNIQUE_ICON_TARGETS = {
+    "grip_de_ferro",
+    "baiana",
+    "knee_cut",
+    "cem_quilos",
+    "montada",
+    "mata_leao",
+}
+UI_ICON_TARGETS = {
+    "combat_hud_mobile",
+    "submission_hud",
+    "result_screen",
+    "cria_live_feed",
+}
+ARENA_TARGETS = {
+    ("terreiro_da_luta", "afternoon"),
+    ("arena_do_dique", "event_day"),
+}
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def queue_row(
+    task_id: str,
+    kind: str,
+    target: str,
+    output_dir: str,
+    *,
+    status: str = "needs_specification",
+    **extra: Any,
+) -> dict[str, Any]:
+    return {
+        "task_id": task_id,
+        "kind": kind,
+        "target": target,
+        "output_dir": output_dir,
+        "status": status,
+        "promotion": "forbidden_without_human_review",
+        **extra,
+    }
+
+
+def build(manifest: dict[str, Any], catalog: dict[str, Any]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    catalog_techniques = {item["id"]: item for item in catalog.get("techniques", [])}
+    for target in sorted(TECHNIQUE_ICON_TARGETS):
+        if target not in catalog_techniques:
+            continue
+        rows.append(
+            queue_row(
+                f"m4::technique_icon::{target}",
+                "technique_icon_pack",
+                target,
+                f"assets/graphics/techniques/{target}",
+                status="queued",
+                outputs=["icon", "card_art", "thumbnail", "ui_metadata.json", "qa_report.md"],
+                canonical_assets=catalog_techniques[target].get("assets", []),
+                consumer="technique_catalog_and_code_native_ui",
+            )
+        )
+
+    for screen in sorted(UI_ICON_TARGETS):
+        if screen not in manifest.get("ui_screens", []):
+            continue
+        rows.append(
+            queue_row(
+                f"m4::ui_icons::{screen}",
+                "ui_icon_pack",
+                screen,
+                f"assets/graphics/ui/{screen}/icons",
+                status="queued",
+                outputs=["icons", "ui_metadata.json", "qa_report.md"],
+                consumer=screen,
+                text_policy="text_rendered_in_godot",
+            )
+        )
+
+    manifest_arenas = {item["id"]: item for item in manifest.get("arenas", [])}
+    for arena_id, variant in sorted(ARENA_TARGETS):
+        arena = manifest_arenas.get(arena_id)
+        if not arena or variant not in arena.get("variants", []):
+            continue
+        base = f"assets/graphics/arenas/{arena_id}/{variant}"
+        for kind, subdir, layer in [
+            ("arena_props_pack", "props", "props"),
+            ("arena_particles_pack", "particles", "particles"),
+        ]:
+            rows.append(
+                queue_row(
+                    f"m4::{kind}::{arena_id}::{variant}",
+                    kind,
+                    f"{arena_id}/{variant}",
+                    f"{base}/{subdir}",
+                    status="needs_item_specification",
+                    layers=[layer],
+                    arena_type=arena["type"],
+                    consumer=f"arena::{arena_id}::{variant}",
+                    required_before_generation=[
+                        "item_id",
+                        "dimensions",
+                        "palette",
+                        "collision_or_none",
+                        "mobile_fallback",
+                        "license_chain",
+                    ],
+                )
+            )
+    return sorted(rows, key=lambda row: row["task_id"])
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Build a governed M4 candidate intake queue")
+    parser.add_argument("--manifest", type=Path, default=MANIFEST)
+    parser.add_argument("--catalog", type=Path, default=CATALOG)
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    args = parser.parse_args()
+
+    rows = build(read_json(args.manifest), read_json(args.catalog))
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with args.output.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row, ensure_ascii=False, sort_keys=True) + "\n")
+    summary = {
+        "ok": True,
+        "count": len(rows),
+        "by_kind": {kind: sum(row["kind"] == kind for row in rows) for kind in sorted({row["kind"] for row in rows})},
+        "output": str(args.output),
+    }
+    print(json.dumps(summary, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/sprite_forge/cli.py
+++ b/tools/sprite_forge/cli.py
@@ -1,0 +1,330 @@
+"""Deterministic candidate packer for Cria do Tatame M4.
+
+This is deliberately not an AI generator and never promotes assets. It turns a
+PNG candidate into a traceable package, removes an optional magenta chroma key,
+creates frame/contact-sheet metadata, and emits a structural validation report.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+from pathlib import Path
+from typing import Any, Iterable
+
+from PIL import Image
+
+VERSION = "0.1.0"
+DEFAULT_KEY = (255, 0, 255)
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def parse_hex(value: str) -> tuple[int, int, int]:
+    value = value.strip().lstrip("#")
+    if len(value) != 6:
+        raise ValueError("cor da chave deve estar no formato RRGGBB")
+    try:
+        rgb = tuple(int(value[index : index + 2], 16) for index in (0, 2, 4))
+    except ValueError as exc:
+        raise ValueError("cor da chave invalida") from exc
+    return rgb  # type: ignore[return-value]
+
+
+def split_frames(image: Image.Image, frame_width: int | None, frame_height: int | None) -> list[Image.Image]:
+    if frame_width is None and frame_height is None:
+        return [image.copy()]
+    if frame_width is None or frame_height is None:
+        raise ValueError("frame-width e frame-height devem ser usados juntos")
+    if frame_width <= 0 or frame_height <= 0:
+        raise ValueError("dimensoes de frame devem ser positivas")
+    if image.width % frame_width or image.height % frame_height:
+        raise ValueError("a imagem nao fecha uma grade inteira de frames")
+    frames: list[Image.Image] = []
+    for top in range(0, image.height, frame_height):
+        for left in range(0, image.width, frame_width):
+            frames.append(image.crop((left, top, left + frame_width, top + frame_height)))
+    return frames
+
+
+def cleanup_chroma(image: Image.Image, key: tuple[int, int, int], threshold: int) -> tuple[Image.Image, int, int]:
+    """Remove a chave de cor e reduz fringe magenta de forma deterministica."""
+    if threshold < 0:
+        raise ValueError("threshold nao pode ser negativo")
+    rgba = image.convert("RGBA")
+    cleaned: list[tuple[int, int, int, int]] = []
+    removed = 0
+    softened = 0
+    kr, kg, kb = key
+    for r, g, b, alpha in rgba.getdata():
+        if alpha == 0 or threshold == 0:
+            cleaned.append((r, g, b, alpha))
+            continue
+        distance = math.sqrt((r - kr) ** 2 + (g - kg) ** 2 + (b - kb) ** 2)
+        if distance <= threshold:
+            if distance <= threshold * 0.45:
+                cleaned.append((r, g, b, 0))
+                removed += 1
+                continue
+            ratio = (distance - threshold * 0.45) / (threshold * 0.55)
+            new_alpha = max(0, min(alpha, int(alpha * ratio)))
+            spill = max(0, min(r, b) - g)
+            new_green = min(255, g + int(spill * 0.8))
+            cleaned.append((r, new_green, b, new_alpha))
+            softened += 1
+            continue
+        cleaned.append((r, g, b, alpha))
+    output = Image.new("RGBA", rgba.size)
+    output.putdata(cleaned)
+    return output, removed, softened
+
+
+def make_contact_sheet(frames: list[Image.Image], columns: int = 8) -> Image.Image:
+    if not frames:
+        raise ValueError("nenhum frame para contact sheet")
+    columns = max(1, min(columns, len(frames)))
+    frame_width = max(frame.width for frame in frames)
+    frame_height = max(frame.height for frame in frames)
+    rows = math.ceil(len(frames) / columns)
+    sheet = Image.new("RGBA", (columns * frame_width, rows * frame_height), (0, 0, 0, 0))
+    for index, frame in enumerate(frames):
+        x = (index % columns) * frame_width
+        y = (index // columns) * frame_height
+        sheet.alpha_composite(frame, (x, y))
+    return sheet
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def write_license_template(path: Path, asset_id: str, source: Path) -> None:
+    write_json(
+        path,
+        {
+            "schema_version": 1,
+            "asset_id": asset_id,
+            "status": "pending_human_review",
+            "source": {"path": str(source), "sha256": sha256(source)},
+            "model": None,
+            "resolved_revision": None,
+            "dataset": None,
+            "adapters": [],
+            "license_chain": [],
+            "human_signoff": None,
+            "notes": "Preencher e revisar antes de qualquer promocao; este arquivo nao e uma aprovacao.",
+        },
+    )
+
+
+def generate2dsprite(args: argparse.Namespace) -> int:
+    source = Path(args.input).resolve()
+    if not source.is_file():
+        raise FileNotFoundError(f"input nao encontrado: {source}")
+    output = Path(args.output_dir).resolve()
+    output.mkdir(parents=True, exist_ok=True)
+    image = Image.open(source).convert("RGBA")
+    key = parse_hex(args.chroma_key)
+    clean, removed, softened = cleanup_chroma(image, key, args.key_threshold)
+    frames = split_frames(clean, args.frame_width, args.frame_height)
+
+    image.save(output / "raw_sheet.png")
+    clean.save(output / "clean_sheet.png")
+    clean.save(output / "spritesheet.png")
+    frames_dir = output / "frames"
+    frames_dir.mkdir(exist_ok=True)
+    for index, frame in enumerate(frames):
+        frame.save(frames_dir / f"frame_{index:03d}.png")
+
+    contact = make_contact_sheet(frames, args.columns)
+    contact.save(output / "contact_sheet.png")
+    frames[0].save(
+        output / "preview.gif",
+        save_all=True,
+        append_images=frames[1:],
+        duration=max(1, int(1000 / args.fps)),
+        loop=0,
+        disposal=2,
+        transparency=0,
+    )
+
+    frame_width, frame_height = frames[0].size
+    metadata = {
+        "schema_version": 1,
+        "tool": "cria_sprite_forge_compat",
+        "tool_version": VERSION,
+        "asset_id": args.asset_id,
+        "source": {"path": str(source), "sha256": sha256(source)},
+        "image": {"width": clean.width, "height": clean.height, "mode": "RGBA"},
+        "frame_size": [frame_width, frame_height],
+        "frame_count": len(frames),
+        "fps": args.fps,
+        "loop": True,
+        "pivot": {"x": frame_width // 2, "y": frame_height - 1, "anchor": "bottom_center"},
+        "grid_px": args.grid_px,
+        "chroma_key": {"color": args.chroma_key, "threshold": args.key_threshold},
+        "cleanup": {"key_pixels_removed": removed, "edge_pixels_softened": softened},
+        "state": "automated_qa_pass_pending_human",
+    }
+    write_json(output / "metadata.json", metadata)
+    write_license_template(output / "license.json", args.asset_id, source)
+    (output / "import_notes.md").write_text(
+        "# Import notes\n\n"
+        "- Importar como RGBA.\n"
+        "- Usar filtro nearest-neighbor.\n"
+        "- Preservar o pivot `bottom_center` registrado no metadata.\n"
+        "- Nao integrar automaticamente em uma cena Godot.\n",
+        encoding="utf-8",
+    )
+    (output / "qa_report.md").write_text(
+        "# QA report\n\n"
+        "- Structural package: PASS\n"
+        f"- Frames: {len(frames)} at {args.fps} FPS\n"
+        f"- Chroma pixels removed: {removed}\n"
+        f"- Edge pixels softened: {softened}\n"
+        "- License/canon/human visual review: PENDING\n"
+        "- Promotion: FORBIDDEN\n",
+        encoding="utf-8",
+    )
+    print(json.dumps({"ok": True, "output_dir": str(output), "frame_count": len(frames), "state": metadata["state"]}, ensure_ascii=False, indent=2))
+    return 0
+
+
+def map_sheet(args: argparse.Namespace) -> int:
+    source = Path(args.input).resolve()
+    if not source.is_file():
+        raise FileNotFoundError(f"input nao encontrado: {source}")
+    image = Image.open(source).convert("RGBA")
+    if args.frame_width <= 0 or args.frame_height <= 0:
+        raise ValueError("dimensoes de frame devem ser positivas")
+    if image.width % args.frame_width or image.height % args.frame_height:
+        raise ValueError("a imagem nao fecha uma grade inteira de frames")
+    labels = [item.strip() for item in args.labels.split(",") if item.strip()]
+    regions: list[dict[str, Any]] = []
+    index = 0
+    for top in range(0, image.height, args.frame_height):
+        for left in range(0, image.width, args.frame_width):
+            name = labels[index] if index < len(labels) else f"frame_{index:03d}"
+            regions.append(
+                {
+                    "name": name,
+                    "index": index,
+                    "rect": {"x": left, "y": top, "w": args.frame_width, "h": args.frame_height},
+                    "pivot": {"x": args.frame_width // 2, "y": args.frame_height - 1, "anchor": "bottom_center"},
+                }
+            )
+            index += 1
+    destination = Path(args.output).resolve()
+    write_json(
+        destination,
+        {
+            "schema_version": 1,
+            "tool": "cria_sprite_forge_compat",
+            "tool_version": VERSION,
+            "source": {"path": str(source), "sha256": sha256(source)},
+            "sheet_size": [image.width, image.height],
+            "frame_size": [args.frame_width, args.frame_height],
+            "regions": regions,
+            "state": "automated_qa_pass_pending_human",
+        },
+    )
+    print(json.dumps({"ok": True, "output": str(destination), "regions": len(regions)}, ensure_ascii=False, indent=2))
+    return 0
+
+
+def validate_package(args: argparse.Namespace) -> int:
+    root = Path(args.package_dir).resolve()
+    required = [
+        "raw_sheet.png",
+        "clean_sheet.png",
+        "spritesheet.png",
+        "frames",
+        "preview.gif",
+        "contact_sheet.png",
+        "metadata.json",
+        "import_notes.md",
+        "qa_report.md",
+        "license.json",
+    ]
+    errors: list[str] = [item for item in required if not (root / item).exists()]
+    metadata: dict[str, Any] = {}
+    license_data: dict[str, Any] = {}
+    if not errors:
+        try:
+            metadata = json.loads((root / "metadata.json").read_text(encoding="utf-8"))
+            license_data = json.loads((root / "license.json").read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            errors.append(f"metadata/licence invalido: {exc}")
+    frame_files = sorted((root / "frames").glob("frame_*.png")) if (root / "frames").exists() else []
+    if not frame_files:
+        errors.append("frames sem PNGs")
+    expected_count = metadata.get("frame_count")
+    if expected_count is not None and expected_count != len(frame_files):
+        errors.append(f"frame_count={expected_count} mas encontrados={len(frame_files)}")
+    for filename in ("raw_sheet.png", "clean_sheet.png", "spritesheet.png", "contact_sheet.png"):
+        path = root / filename
+        if path.exists():
+            try:
+                with Image.open(path) as image:
+                    if image.mode not in {"RGBA", "LA", "P"}:
+                        errors.append(f"{filename} sem canal de transparencia: {image.mode}")
+            except OSError as exc:
+                errors.append(f"{filename} invalido: {exc}")
+    if license_data and license_data.get("status") not in {"pending_human_review", "approved_by_human"}:
+        errors.append("license.json sem estado reconhecido")
+    result = {
+        "ok": not errors,
+        "package": str(root),
+        "errors": errors,
+        "state": "automated_qa_pass_pending_human" if not errors else "blocked",
+        "license_status": license_data.get("status", "missing"),
+    }
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    return 0 if not errors else 1
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Compatibilizador deterministico do M4")
+    sub = parser.add_subparsers(dest="command", required=True)
+    generate = sub.add_parser("generate2dsprite", help="empacota e limpa um PNG candidato")
+    generate.add_argument("--input", required=True)
+    generate.add_argument("--output-dir", required=True)
+    generate.add_argument("--asset-id", required=True)
+    generate.add_argument("--frame-width", type=int)
+    generate.add_argument("--frame-height", type=int)
+    generate.add_argument("--fps", type=int, default=12)
+    generate.add_argument("--grid-px", type=int, default=16)
+    generate.add_argument("--columns", type=int, default=8)
+    generate.add_argument("--chroma-key", default="#FF00FF")
+    generate.add_argument("--key-threshold", type=int, default=24)
+    generate.set_defaults(handler=generate2dsprite)
+
+    mapping = sub.add_parser("map", help="gera mapa deterministico de regioes do spritesheet")
+    mapping.add_argument("--input", required=True)
+    mapping.add_argument("--output", required=True)
+    mapping.add_argument("--frame-width", type=int, required=True)
+    mapping.add_argument("--frame-height", type=int, required=True)
+    mapping.add_argument("--labels", default="")
+    mapping.set_defaults(handler=map_sheet)
+
+    validate = sub.add_parser("validate", help="valida a estrutura de um pacote candidato")
+    validate.add_argument("--package-dir", required=True)
+    validate.set_defaults(handler=validate_package)
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    return int(args.handler(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/sprite_forge/generate2dsprite
+++ b/tools/sprite_forge/generate2dsprite
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from cli import main  # noqa: E402
+
+if __name__ == "__main__":
+    sys.argv.insert(1, "generate2dsprite")
+    raise SystemExit(main())

--- a/tools/sprite_forge/map
+++ b/tools/sprite_forge/map
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from cli import main  # noqa: E402
+
+if __name__ == "__main__":
+    sys.argv.insert(1, "map")
+    raise SystemExit(main())

--- a/tools/sprite_forge/validate
+++ b/tools/sprite_forge/validate
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from cli import main  # noqa: E402
+
+if __name__ == "__main__":
+    sys.argv.insert(1, "validate")
+    raise SystemExit(main())


### PR DESCRIPTION
## Objetivo

Desbloquear o intake M4 com uma camada determinística e isolada que fornece os comandos compatíveis `generate2dsprite`, `map` e `validate`, além de uma subfila conservadora para ícones, props e partículas.

## O que foi incluído

- `tools/sprite_forge/cli.py` com cleanup de chroma, fatiamento, contact sheet, metadata, SHA-256 e validação estrutural;
- launchers diretos `tools/sprite_forge/generate2dsprite`, `tools/sprite_forge/map` e `tools/sprite_forge/validate`;
- `tools/sprite_forge/build_m4_queue.py`, usando os manifestos canônicos e mantendo props/partículas em `needs_item_specification`;
- testes unitários para pacote, fatiamento, mapa, contagem e bloqueio de promoção;
- documentação `docs/production/M4_SPRITE_FORGE_COMPAT_V01.md`.

## Governança preservada

- não altera `project.godot`, autoloads, managers, save migration ou runtime;
- não gera ou promove assets automaticamente;
- não versiona binários candidatos;
- `license.json` começa em `pending_human_review`;
- estado de saída permanece `automated_qa_pass_pending_human`;
- nenhum material ou prop recebe ID inventado; itens de arena exigem spec antes de geração;
- `map` não substitui `sync_map.json` biomecânico de técnica pareada.

## Relações

- Rastreia o bloqueio documentado no M4 e o issue #64 (Visual QA V2).
- Compatível para revisão/port posterior do PR #38 (Visual Forge) e do PR #65 (Visual QA V2), sem depender deles para o smoke local.

## Validação executada

```text
python3 -m unittest discover -s tests/sprite_forge -p 'test_*.py'  -> 4/4 OK
python3 tools/sprite_forge/build_m4_queue.py --output /tmp/m4_queue_v01.jsonl -> 14 rows OK
python3 tools/sprite_forge/generate2dsprite ... -> 8 frames OK
python3 tools/sprite_forge/map ... -> 8 regions OK
python3 tools/sprite_forge/validate ... -> package OK
npm run quality -> OK
```

## Riscos e limites

A camada não comprova licença, cânone, biomecânica, legibilidade mobile ou integração Godot. Esses gates continuam humanos ou pertencem ao pipeline de QA posterior. A normalização de nomes entre `production_manifest_v02.json` e `supreme_build_contract_v01.json` ainda precisa de revisão antes de promoção.

## Rollback

Fechar este PR sem merge e remover a branch. Como não há alterações de runtime nem binários no Git, a `main` permanece intacta.
