### PR TITLE
MCP WORK v1: doctrine + data contracts + mobile/rollback docs

### DIFF
--- a/data/combat_deck_schema_v2.json
+++ b/data/combat_deck_schema_v2.json
@@ -1,0 +1,18 @@
+{
+  "$schema":"https://json-schema.org/draft/2020-12/schema",
+  "$id":"https://cria-do-tatame.local/schema/combat_deck_schema_v2.json",
+  "title":"Combat Deck v2",
+  "type":"object",
+  "required":["schema_version","deck_id","ruleset","slots"],
+  "properties":{
+    "schema_version":{"const":"2.0.0"},
+    "deck_id":{"type":"string","minLength":1},
+    "ruleset":{"enum":["gi","nogi"]},
+    "style_id":{"type":"string"},
+    "gameplan_id":{"type":"string"},
+    "slots":{"type":"array","minItems":1,"maxItems":12,"items":{"type":"object","required":["slot","technique_id","tags"],"properties":{"slot":{"type":"integer","minimum":1,"maximum":12},"technique_id":{"type":"string","minLength":1},"tags":{"type":"array","items":{"enum":["gi","nogi"]},"minItems":1,"uniqueItems":true},"position_allow":{"type":"array","items":{"type":"string"}},"faixa_min":{"enum":["branca","azul","roxa","marrom","preta"]},"resource_cost":{"type":"object","additionalProperties":{"type":"number","minimum":0}}},"additionalProperties":false}},
+    "filters":{"type":"object","properties":{"position":{"type":"array","items":{"type":"string"}},"ruleset":{"type":"array","items":{"enum":["gi","nogi"]}},"faixa":{"type":"array","items":{"enum":["branca","azul","roxa","marrom","preta"]}}},"additionalProperties":false}
+  },
+  "additionalProperties":false,
+  "decision_refs":["D5","D6","D48","D49","D57"]
+}

--- a/data/positional_graph_v2.json
+++ b/data/positional_graph_v2.json
@@ -1,0 +1,43 @@
+{
+  "schema_version": "2.0.0",
+  "decision_refs": ["D49", "D50", "D82", "D84"],
+  "positions": [
+    {"id":"em_pe_neutro","label":"Em pé neutro","layer":"standing"},
+    {"id":"clinch","label":"Clinch","layer":"standing"},
+    {"id":"guarda_fechada_bottom","label":"Guarda fechada — baixo","layer":"ground"},
+    {"id":"guarda_fechada_top","label":"Guarda fechada — cima","layer":"ground"},
+    {"id":"guarda_aberta_bottom","label":"Guarda aberta — baixo","layer":"ground"},
+    {"id":"guarda_aberta_top","label":"Guarda aberta — cima","layer":"ground"},
+    {"id":"meia_guarda_bottom","label":"Meia-guarda — baixo","layer":"ground"},
+    {"id":"meia_guarda_top","label":"Meia-guarda — cima","layer":"ground"},
+    {"id":"cem_quilos_bottom","label":"Controle lateral — baixo","layer":"ground"},
+    {"id":"cem_quilos_top","label":"Controle lateral — cima","layer":"ground"},
+    {"id":"montada_bottom","label":"Montada — baixo","layer":"ground"},
+    {"id":"montada_top","label":"Montada — cima","layer":"ground"},
+    {"id":"costas_defensor","label":"Costas — defensor","layer":"ground"},
+    {"id":"costas_atacante","label":"Costas — atacante","layer":"ground"},
+    {"id":"tartaruga_bottom","label":"Tartaruga — baixo","layer":"ground"},
+    {"id":"tartaruga_top","label":"Tartaruga — cima","layer":"ground"},
+    {"id":"norte_sul_bottom","label":"Norte-sul — baixo","layer":"ground"},
+    {"id":"norte_sul_top","label":"Norte-sul — cima","layer":"ground"},
+    {"id":"sprawl_top","label":"Sprawl — cima","layer":"transition"}
+  ],
+  "transitions": [
+    {"id":"t01","from":"em_pe_neutro","to":"clinch","technique_id":"entrada_clinch","pos_req":["em_pe_neutro"],"grip_req":[],"ruleset":["gi","nogi"],"faixa_min":"branca"},
+    {"id":"t02","from":"clinch","to":"guarda_fechada_top","technique_id":"queda_controle","pos_req":["clinch"],"grip_req":["controle_superior"],"ruleset":["gi","nogi"],"faixa_min":"branca"},
+    {"id":"t03","from":"clinch","to":"sprawl_top","technique_id":"defesa_queda_sprawl","pos_req":["clinch"],"grip_req":[],"ruleset":["gi","nogi"],"faixa_min":"branca"},
+    {"id":"t04","from":"sprawl_top","to":"tartaruga_top","technique_id":"controle_sprawl","pos_req":["sprawl_top"],"grip_req":["controle_tronco"],"ruleset":["gi","nogi"],"faixa_min":"branca"},
+    {"id":"t05","from":"guarda_fechada_top","to":"guarda_aberta_top","technique_id":"abrir_guarda","pos_req":["guarda_fechada_top"],"grip_req":["base_estavel"],"ruleset":["gi","nogi"],"faixa_min":"branca"},
+    {"id":"t06","from":"guarda_aberta_top","to":"meia_guarda_top","technique_id":"passagem_meia_guarda","pos_req":["guarda_aberta_top"],"grip_req":["controle_perna"],"ruleset":["gi","nogi"],"faixa_min":"branca"},
+    {"id":"t07","from":"meia_guarda_top","to":"cem_quilos_top","technique_id":"passagem_meia_guarda","pos_req":["meia_guarda_top"],"grip_req":["underhook_ou_controle_quadril"],"ruleset":["gi","nogi"],"faixa_min":"branca"},
+    {"id":"t08","from":"cem_quilos_top","to":"montada_top","technique_id":"transicao_montada","pos_req":["cem_quilos_top"],"grip_req":["controle_tronco"],"ruleset":["gi","nogi"],"faixa_min":"branca"},
+    {"id":"t09","from":"cem_quilos_top","to":"norte_sul_top","technique_id":"transicao_norte_sul","pos_req":["cem_quilos_top"],"grip_req":["controle_tronco"],"ruleset":["gi","nogi"],"faixa_min":"branca"},
+    {"id":"t10","from":"tartaruga_top","to":"costas_atacante","technique_id":"pegar_costas","pos_req":["tartaruga_top"],"grip_req":["controle_cintura"],"ruleset":["gi","nogi"],"faixa_min":"branca"},
+    {"id":"t11","from":"montada_bottom","to":"guarda_fechada_bottom","technique_id":"reposicao_guarda","pos_req":["montada_bottom"],"grip_req":["frame"],"ruleset":["gi","nogi"],"faixa_min":"branca"},
+    {"id":"t12","from":"cem_quilos_bottom","to":"meia_guarda_bottom","technique_id":"recuperar_meia_guarda","pos_req":["cem_quilos_bottom"],"grip_req":["frame"],"ruleset":["gi","nogi"],"faixa_min":"branca"},
+    {"id":"t13","from":"meia_guarda_bottom","to":"guarda_aberta_bottom","technique_id":"recuperar_guarda_aberta","pos_req":["meia_guarda_bottom"],"grip_req":["frame"],"ruleset":["gi","nogi"],"faixa_min":"branca"},
+    {"id":"t14","from":"guarda_aberta_bottom","to":"em_pe_neutro","technique_id":"technical_standup","pos_req":["guarda_aberta_bottom"],"grip_req":[],"ruleset":["gi","nogi"],"faixa_min":"branca"},
+    {"id":"t15","from":"costas_defensor","to":"tartaruga_bottom","technique_id":"escape_costas_tartaruga","pos_req":["costas_defensor"],"grip_req":["hand_fight"],"ruleset":["gi","nogi"],"faixa_min":"branca"},
+    {"id":"t16","from":"norte_sul_bottom","to":"cem_quilos_bottom","technique_id":"escape_norte_sul","pos_req":["norte_sul_bottom"],"grip_req":["frame"],"ruleset":["gi","nogi"],"faixa_min":"azul"}
+  ]
+}

--- a/data/skill_tree_v2.json
+++ b/data/skill_tree_v2.json
@@ -1,0 +1,36 @@
+{
+  "schema_version":"2.0.0",
+  "decision_refs":["D45","D51","D53","D58"],
+  "rules":{"branches":4,"tiers_per_branch":5,"legado_gameplay_bonus":false},
+  "branches":[
+    {"id":"controle","tiers":[
+      {"tier":1,"modifier":{"window_bonus_ms":20}},
+      {"tier":2,"modifier":{"resource_cost_mult":0.97}},
+      {"tier":3,"modifier":{"recovery_ms_delta":-20}},
+      {"tier":4,"modifier":{"window_bonus_ms":35}},
+      {"tier":5,"modifier":{"resource_cost_mult":0.94}}
+    ]},
+    {"id":"mobilidade","tiers":[
+      {"tier":1,"modifier":{"buffer_ms_bonus":15}},
+      {"tier":2,"modifier":{"recovery_ms_delta":-15}},
+      {"tier":3,"modifier":{"resource_cost_mult":0.97}},
+      {"tier":4,"modifier":{"buffer_ms_bonus":25}},
+      {"tier":5,"modifier":{"recovery_ms_delta":-30}}
+    ]},
+    {"id":"defesa","tiers":[
+      {"tier":1,"modifier":{"escape_window_bonus_ms":20}},
+      {"tier":2,"modifier":{"resource_cost_mult":0.98}},
+      {"tier":3,"modifier":{"escape_window_bonus_ms":30}},
+      {"tier":4,"modifier":{"recovery_ms_delta":-20}},
+      {"tier":5,"modifier":{"escape_window_bonus_ms":45}}
+    ]},
+    {"id":"ritmo","tiers":[
+      {"tier":1,"modifier":{"resource_regen_mult":1.02}},
+      {"tier":2,"modifier":{"window_bonus_ms":15}},
+      {"tier":3,"modifier":{"resource_regen_mult":1.04}},
+      {"tier":4,"modifier":{"resource_cost_mult":0.96}},
+      {"tier":5,"modifier":{"window_bonus_ms":30}}
+    ]}
+  ],
+  "legado":{"kind":"narrative_only","gameplay_modifier":null}
+}

--- a/data/stages_catalog_v1.json
+++ b/data/stages_catalog_v1.json
@@ -1,0 +1,16 @@
+{
+  "schema_version":"1.0.0",
+  "decision_refs":["D36","D41","D42","D47","D75"],
+  "budget":{"atlas_2048_max":2,"draw_calls_max":24,"particles_max":64,"animated_crowd_max":4},
+  "stages":[
+    {"id":"terreiro_vivo","label":"Terreiro Vivo","bioma":"terreiro_costeiro","paleta":["#D5A84B","#7A4F2A","#3D6B3D","#E8DFC8"],"luz":["dia","por_do_sol"],"props":["tatame","madeira","plantas","bancos"],"crowd":{"mode":"baked","animated_max":4},"ato_rota":{"ato":1,"rota":"terreiro"}},
+    {"id":"terreiro_noite_fogo","label":"Terreiro Noite-do-Fogo","bioma":"terreiro_memoria","paleta":["#17171B","#6A2E24","#D06A2B","#B7A487"],"luz":["noite","fogo_cenografico"],"props":["tatame","madeira_escura","cinzas_cenograficas"],"crowd":{"mode":"baked","animated_max":2},"ato_rota":{"ato":3,"rota":"memoria"}},
+    {"id":"dique","label":"Dique","bioma":"agua_urbana","paleta":["#2B5968","#7C8B78","#C7A55A","#20262A"],"luz":["fim_de_tarde"],"props":["mureta","agua","vegetacao","postes"],"crowd":{"mode":"baked","animated_max":3},"ato_rota":{"ato":1,"rota":"dique"}},
+    {"id":"nishimura","label":"Nishimura","bioma":"colonia_rural","paleta":["#52633C","#A88D62","#D7D0B7","#37424A"],"luz":["manha_difusa"],"props":["galpao","caminho","vegetacao","caixas"],"crowd":{"mode":"baked","animated_max":3},"ato_rota":{"ato":2,"rota":"nishimura"}},
+    {"id":"ponte_do_saci","label":"Ponte do Saci","bioma":"ponte_mata","paleta":["#284C3A","#6E5A43","#A98A55","#1B2621"],"luz":["nublado"],"props":["ponte","mata","rio","placas_ficcionais"],"crowd":{"mode":"baked","animated_max":2},"ato_rota":{"ato":2,"rota":"ponte"}},
+    {"id":"pratigi","label":"Pratigi","bioma":"litoral_mata","paleta":["#1E6C74","#6D8A4C","#D8C08A","#F1E6CF"],"luz":["dia_aberto"],"props":["areia","vegetacao","madeira","agua"],"crowd":{"mode":"baked","animated_max":2},"ato_rota":{"ato":2,"rota":"pratigi"}},
+    {"id":"ferro_velho","label":"Ferro Velho","bioma":"industrial_reciclado","paleta":["#4C4B47","#8B5A3C","#B88943","#232326"],"luz":["lateral_dura"],"props":["sucata_cenografica","chapas","pneus","grades"],"crowd":{"mode":"baked","animated_max":3},"ato_rota":{"ato":2,"rota":"ntm"}},
+    {"id":"manguezal","label":"Manguezal","bioma":"mangue","paleta":["#324E42","#657052","#8E7654","#9AB0A0"],"luz":["difusa_umida"],"props":["raizes","passarela","lama_cenografica","agua"],"crowd":{"mode":"baked","animated_max":2},"ato_rota":{"ato":2,"rota":"ntm"}},
+    {"id":"budokan","label":"Budokan","bioma":"arena_ficcional","paleta":["#1B1C20","#C5A45C","#E8E4DB","#6A2525"],"luz":["arena_controlada"],"props":["tatame","placar_ficcional","grades","banners_originais"],"crowd":{"mode":"baked","animated_max":4},"ato_rota":{"ato":3,"rota":"final"}}
+  ]
+}

--- a/data/style_wheel_v2.json
+++ b/data/style_wheel_v2.json
@@ -1,0 +1,28 @@
+{
+  "schema_version":"2.0.0",
+  "decision_refs":["D52","D60","D63","D64","D67"],
+  "styles":[
+    {"id":"pressao","label":"Pressão","axes":{"pace":0.8,"control":0.8,"mobility":0.4,"risk":0.6}},
+    {"id":"contragolpe","label":"Contra-jogo","axes":{"pace":0.4,"control":0.6,"mobility":0.7,"risk":0.4}},
+    {"id":"guarda","label":"Guarda","axes":{"pace":0.5,"control":0.7,"mobility":0.6,"risk":0.5}},
+    {"id":"passador","label":"Passador","axes":{"pace":0.7,"control":0.8,"mobility":0.5,"risk":0.5}},
+    {"id":"raspador","label":"Raspador","axes":{"pace":0.6,"control":0.6,"mobility":0.8,"risk":0.6}},
+    {"id":"finalizador","label":"Finalizador","axes":{"pace":0.7,"control":0.6,"mobility":0.5,"risk":0.8}},
+    {"id":"scrambler","label":"Scrambler","axes":{"pace":0.9,"control":0.3,"mobility":0.9,"risk":0.8}},
+    {"id":"estrategista","label":"Estrategista","axes":{"pace":0.4,"control":0.8,"mobility":0.6,"risk":0.3}}
+  ],
+  "matchup":{
+    "scale":{"min":-2,"max":2,"meaning":"pressao relativa, nunca hard-counter"},
+    "matrix":{
+      "pressao":{"pressao":0,"contragolpe":-1,"guarda":0,"passador":0,"raspador":-1,"finalizador":0,"scrambler":1,"estrategista":-1},
+      "contragolpe":{"pressao":1,"contragolpe":0,"guarda":0,"passador":-1,"raspador":0,"finalizador":0,"scrambler":1,"estrategista":0},
+      "guarda":{"pressao":0,"contragolpe":0,"guarda":0,"passador":-1,"raspador":1,"finalizador":0,"scrambler":0,"estrategista":0},
+      "passador":{"pressao":0,"contragolpe":1,"guarda":1,"passador":0,"raspador":0,"finalizador":0,"scrambler":-1,"estrategista":0},
+      "raspador":{"pressao":1,"contragolpe":0,"guarda":-1,"passador":0,"raspador":0,"finalizador":0,"scrambler":0,"estrategista":0},
+      "finalizador":{"pressao":0,"contragolpe":0,"guarda":0,"passador":0,"raspador":0,"finalizador":0,"scrambler":-1,"estrategista":1},
+      "scrambler":{"pressao":-1,"contragolpe":-1,"guarda":0,"passador":1,"raspador":0,"finalizador":1,"scrambler":0,"estrategista":-1},
+      "estrategista":{"pressao":1,"contragolpe":0,"guarda":0,"passador":0,"raspador":0,"finalizador":-1,"scrambler":1,"estrategista":0}
+    }
+  },
+  "rule":"position+ruleset+belt+resources+execution override style pressure"
+}

--- a/docs/ADR/online-rollback.md
+++ b/docs/ADR/online-rollback.md
@@ -1,0 +1,25 @@
+# ADR — Online Rollback
+
+Status: DEFERRED / RESEARCH_ONLY
+CTX: CRIA-WORK-v2@cfbc572
+Decision refs: D72, D75, D79
+
+## Context
+The vertical slice does not require online rollback netcode. Any rollback architecture would add determinism, synchronization, device-budget, test and operational complexity before the local combat loop is proven.
+
+## Decision
+Rollback remains outside the slice. `dsnopek`, `Klotho` and equivalent approaches are research candidates only; none is adopted, vendored or permitted as a runtime dependency by this ADR.
+
+## Entry criteria for a future ADR
+A later proposal must include:
+1. deterministic-state feasibility evidence for the active CombatManager;
+2. isolated prototype with no save/runtime regression;
+3. Android CPU/memory/network budget measurements;
+4. latency/jitter test matrix;
+5. desync detection and recovery plan;
+6. dependency pin + license/provenance record;
+7. rollback/removal plan;
+8. CI and human gameplay gate.
+
+## Consequence
+Current shipping code remains local/offline. No placeholder networking API may become a second combat source of truth.

--- a/docs/ANDROID_DOCTRINE.md
+++ b/docs/ANDROID_DOCTRINE.md
@@ -1,0 +1,33 @@
+# Android Doctrine — Mobile Baseline
+
+Status: canonical operating doctrine under D75
+CTX: CRIA-WORK-v2@cfbc572
+Decision refs: D36, D43, D47, D55, D75, D85
+
+## Baseline
+- Android ARM64 is the required device target for the vertical slice.
+- Touch targets: minimum 48 dp.
+- Critical combat/UI text and silhouettes must remain readable at the 72 px review scale used by visual QA.
+- Target presentation: 60 fps when device permits; acceptance floor for low-end profile: stable 30 fps without gameplay timing divergence.
+- Input buffering must follow D85 and may not bypass invalid state locks.
+
+## Per-stage hard budgets
+Inherited from D47:
+- atlases 2048²: max 2;
+- draw calls: max 24;
+- simultaneous particles: max 64;
+- animated crowd actors: max 4; baked crowd is default.
+
+## Runtime working budgets
+These are engineering ceilings for profiling, not promises of hardware support:
+- gameplay frame CPU budget at 60 fps: <= 16.67 ms total frame;
+- low-end 30 fps ceiling: <= 33.33 ms total frame;
+- avoid frame-time spikes > 50 ms during normal combat flow;
+- texture/audio assets must be imported in mobile-appropriate compressed forms before device promotion;
+- no synchronous large-file load inside an active combat exchange.
+
+## Device gate
+A build cannot become `device_validated` without: install, launch, 10-minute checklist, crash-free combat loop, save/load, result→hub, 48 dp touch check, 72 px readability check, and human GATE05.
+
+## Fail-closed
+If profiling evidence is absent, the state remains `device_candidate`. Desktop/web success never substitutes the Android gate.

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -264,3 +264,173 @@ A lista explícita contém dez variantes, mas oito locais-base. A D41 resolve o 
 ### R00-04 — Trama PF real
 
 Nenhum arquivo versionado na `main` atual contém Polícia Federal/PF. Referências externas desse rascunho são pesquisa não canônica e ficam governadas por `docs/research/INSTITUTIONAL_REFERENCE_BOUNDARY.md`; a história ativa usa DIE e A Maré.
+
+## D48 — Deck como filtro
+
+O deck não cria técnica nem altera cânone: ele filtra o catálogo ativo por contexto, posição, ruleset, faixa e recursos. A fonte mestre continua sendo o catálogo de técnicas conforme D6.
+
+## D49 — Tags Gi/No-Gi
+
+Técnicas e modificadores usam tags explícitas `gi`, `nogi` ou ambas. O runtime não infere ruleset por nome, roupa ou stage.
+
+## D50 — Clash por frame em dados
+
+Janelas de clash, prioridade, contato e resolução são data-driven por frame/evento. Arte e animação não codificam regra de combate.
+
+## D51 — Árvore modifica janelas
+
+A árvore de progressão modifica apenas janelas, custos, recuperação ou recursos já definidos. Ela não cria técnica implícita e não altera o grafo posicional canônico.
+
+## D52 — Afinidades
+
+Afinidades são modificadores transparentes e limitados, definidos em dados por estilo/personagem. Não substituem skill, faixa, posição, ruleset ou matchup.
+
+## D53 — Maestria
+
+Maestria é progressão por uso válido de técnicas e famílias, com tetos e thresholds em dados. Não concede vitória automática nem ignora requisitos posicionais.
+
+## D54 — Clandestino cobra Sombra
+
+A participação no circuito clandestino pode cobrar recurso narrativo `SOMBRA` conforme dados ativos. O custo é consequência ficcional, não instrução operacional.
+
+## D55 — Feedback
+
+Feedback de combate deve ser imediato, multimodal e proporcional: visual, sonoro e háptico quando disponível, sempre com fallback não sensorial e sem depender só de cor.
+
+## D56 — Dendê tutor
+
+`Dendê` é tutor ficcional diegético. Explica controles, leitura de posição e segurança; não adiciona regra, técnica ou cânone fora dos dados aprovados.
+
+## D57 — Gameplans
+
+Gameplans são presets de intenção tática construídos sobre técnicas e posições existentes. O jogador pode inspecionar seus filtros e custos; nenhum preset contorna requisitos.
+
+## D58 — Legado narrativo
+
+`Legado` é eixo exclusivamente narrativo/reputacional no slice. Não concede bônus direto de dano, hitbox, prioridade ou probabilidade de finalização.
+
+## D59 — Repetição punida
+
+Repetição imediata e previsível da mesma ação pode receber penalidade data-driven de eficiência, leitura adversária ou recurso. A regra deve ser limitada, inspecionável e reversível.
+
+## D60 — Assinatura por uso
+
+A assinatura de estilo emerge de uso consistente registrado em telemetria/save e não de escolha cosmética isolada. Ela não bloqueia mudança futura de gameplan.
+
+## D61 — Ledger de cinco assinaturas
+
+Cada promoção relevante registra cinco assinaturas independentes quando aplicáveis: técnica/BJJ, arte/animação, gameplay, acessibilidade e direitos/proveniência. Automação coleta evidência; somente humano autorizado assina gate humano.
+
+## D62 — Fidelity diff
+
+Assets derivados devem registrar comparação de fidelidade contra o candidato aprovado: identidade, paleta, escala, baseline, contatos e leitura. Divergência fora do orçamento reprova promoção sem apagar o candidato fonte.
+
+## D63 — Roda de oito estilos
+
+A taxonomia de combate usa oito estilos parametrizados em `style_wheel_v2.json`. A roda é ferramenta de leitura e balanceamento, não classe rígida de personagem.
+
+## D64 — Matchup
+
+Matchup é matriz explícita de pressões e respostas entre estilos, sempre subordinada a posição, faixa, ruleset, recursos e execução. Não há hard-counter absoluto.
+
+## D65 — Source notes
+
+Pesquisa externa que informa design técnico, histórico ou cultural usa `source_notes` separado do produto shipping. O produto não expõe nomes de pesquisadores, atletas ou marcas por padrão.
+
+## D66 — Legalidade e direitos
+
+Nenhum asset, áudio, texto, regra proprietária, marca, pessoa real ou material de terceiro entra em shipping sem licença/proveniência compatível. Inspiração deve permanecer abstrata e transformativa.
+
+## D67 — Counter-pick
+
+Counter-pick é recomendação transparente baseada em estado do jogo e matchup; nunca altera secretamente atributos do adversário nem cria vantagem paga.
+
+## D68 — Identidade narrativa
+
+Identidade narrativa deriva de escolhas, relações e consequências registradas em dados. Aparência cosmética sozinha não redefine facção, Legado, SOMBRA ou final.
+
+## D69 — OpenCap/OpenSim
+
+OpenCap e OpenSim são ferramentas opcionais de pesquisa/validação biomecânica offline. Resultados não aprovam técnica, hitbox ou segurança automaticamente e não são dependências de runtime.
+
+## D70 — Rigify
+
+Rigify pode auxiliar rigging/prototipagem offline quando licença e pipeline forem compatíveis. O rig final deve obedecer aos contratos de pivô, escala, exportação e QA do projeto.
+
+## D71 — GUT
+
+GUT é o framework preferencial para testes unitários de GDScript quando aplicável. Adoção é incremental e não substitui smokes, parser/import ou gates de dispositivo.
+
+## D72 — Rollback exige ADR
+
+Netcode rollback permanece fora do vertical slice. Qualquer adoção futura exige ADR própria, protótipo isolado, orçamento mobile, determinismo medido e rollback claro.
+
+## D73 — DVC
+
+DVC pode versionar binários/datasets fora do Git somente quando o remote e a política de hashes estiverem definidos. Git conserva manifests/pointers; binário grande não é duplicado no repositório.
+
+## D74 — Hugging Face pinado
+
+Modelo ou dataset Hugging Face usado na produção deve ser fixado por revisão/commit/hash verificável, com licença registrada. `latest`, remote code não auditado e download mutável são proibidos.
+
+## D75 — Doutrina mobile
+
+Mobile é baseline de produto: budgets de CPU/GPU/memória, atlas, draw calls, partículas, input e legibilidade são definidos antes da expansão. Low-end nasce no primeiro commit conforme D47.
+
+## D76 — Ledger de release
+
+Todo candidato de release registra commit, artefatos, hashes, gates, origem, licenças, CI, device baseline, estado e decisão humana. Release sem ledger completo é inválido.
+
+## D77 — Manus bloqueado
+
+Manus não possui autoridade de escrita, promoção, gate ou execução no pipeline canônico. Qualquer uso futuro depende de decisão explícita nova e ambiente de capacidade auditável.
+
+## D78 — CTX versionado
+
+Todo lote delegado referencia `CTX=<doutrina>@<commit>`. IDs de decisão são interpretados na revisão fixada, evitando drift semântico entre lotes e réplicas.
+
+## D79 — Gates por fase
+
+Gates são vinculados à fase e ao teto de estado: geração, clean candidate, human approved, runtime ready, integrated, device validated e release candidate não podem ser colapsados por automação.
+
+## D80 — Higiene de fallback
+
+Fallback deve ser explícito, simples, reversível e menos ambicioso que o caminho principal. Nunca pode introduzir novo cânone, segunda fonte de verdade ou dependência oculta.
+
+## D81 — ComfyUI
+
+ComfyUI é ferramenta opcional de geração/edição offline, com workflows pinados quando usados. Saída permanece candidata até proveniência, rights gate, QA visual e aprovação humana aplicáveis.
+
+## D82 — Grafo posicional de 19 nós
+
+O grafo canônico v2 contém 19 posições identificadas e transições data-driven. Toda transição declara requisitos posicionais, de pegada, ruleset e faixa mínima quando aplicáveis.
+
+## D83 — GEEvo
+
+GEEvo ou otimização evolutiva equivalente pode explorar parâmetros somente em sandbox/dados derivados. Não altera cânone, dificuldade shipping ou balanceamento sem benchmark e revisão humana.
+
+## D84 — Hitbox adaptada ao estado
+
+Hitbox/hurtbox pode variar por frame e estado corporal mediante dados versionados, limites visuais e teste de regressão. Nunca é inferida silenciosamente da transparência do sprite.
+
+## D85 — Input buffer
+
+Input buffer mobile é explícito e limitado por ação/estado. Deve melhorar responsividade sem executar comandos inválidos, atravessar locks, antecipar posições inexistentes ou esconder latência crítica.
+
+## Addendum de toolchain
+
+- Runtime canônico: Godot único, versão governada por D19.
+- Teste: CI + GUT quando aplicável; smokes e device gates continuam obrigatórios.
+- Arte offline permitida sob gates: Sprite Forge, Pixelorama/scripts, Rigify e ComfyUI.
+- Biomecânica offline opcional: OpenCap/OpenSim; evidência auxilia, não assina gate.
+- Dados/binários grandes: DVC/Drive/Releases por pointer + SHA; Git/MCP recebe somente texto e binários dentro do limite autorizado.
+- Dependências/modelos externos: pin por revisão/hash + licença; remote code não auditado é fail-closed.
+
+## Quarentena
+
+- `Manus`: BLOCKED conforme D77.
+- Netcode rollback (`dsnopek`, Klotho ou equivalente): RESEARCH_ONLY até ADR D72.
+- GEEvo/otimizadores: SANDBOX_ONLY conforme D83.
+- Modelos HF sem pin/licença: QUARANTINE conforme D74.
+- Conteúdo/asset sem proveniência ou rights gate: QUARANTINE conforme D66.
+- Saída generativa sem fidelity diff/QA/assinatura aplicável: CANDIDATE_ONLY conforme D61/D62/D79.

--- a/docs/research/source_notes.md
+++ b/docs/research/source_notes.md
@@ -1,0 +1,33 @@
+# Source Notes — Research Template
+
+Status: TEMPLATE
+CTX: CRIA-WORK-v2@cfbc572
+Decision refs: D40, D65, D66, D69, D74
+
+Use one block per external source. Research names and citations stay here or in evidence ledgers; shipping product text remains name-free unless separately approved.
+
+## SN-000
+- claim_id:
+- topic:
+- source_type:
+- title:
+- author_or_org:
+- publication_date:
+- url_or_identifier:
+- accessed_at:
+- license_or_terms:
+- exact_revision_or_hash:
+- evidence_summary:
+- supports:
+- contradicts:
+- confidence:
+- product_implication:
+- allowed_use: RESEARCH_ONLY
+- rights_gate:
+- reviewer:
+- notes:
+
+## Product boundary
+- Do not copy names, logos, frames, branded rules text, athlete likenesses or protected assets into product shipping data from this note.
+- Convert research into abstract, original design claims only after rights/provenance review.
+- Missing license, revision pin or provenance => QUARANTINE.

--- a/reports/ledger_mcp.md
+++ b/reports/ledger_mcp.md
@@ -1,0 +1,12 @@
+# MCP WORK v1 — Ledger
+
+CTX: CRIA-WORK-v2@cfbc572
+Repo: ringuemkt-rgb/cria-do-tatame
+Branch: lead-mcp/doctrine-v1
+
+## M01 handshake
+- base_sha: cfbc5723f2f2f2c03fb9c7ef82cfd7dde65d58a9
+- docs/DECISIONS.md: readable at base; D47 present
+- production_state.json: NOT_FOUND at repository root on base
+- state: handshake_partial
+- pending: resolve production_state path or create canonical root file only if later card authorizes it


### PR DESCRIPTION
CTX=CRIA-WORK-v2@cfbc572

Stacked on `lead/calibracao-v1` / PR #70.

Scope:
- M01 MCP delegated handshake + ledger init
- M02 append D48-D85, toolchain addendum and quarantine policy
- M03 add positional/deck/skill/style/stage data contracts
- M04 add Android doctrine, rollback ADR and source-notes template

Not included:
- M05 visual candidates: no input images available through this MCP session
- V01/V02/V03
- merge, release or publication

Human gates remain authoritative. CI is evidence only, never approval.