### PR TITLE
EPIC 71 — skill-tree visual bible + progression graph

### DIFF
--- a/.github/workflows/repository-quality.yml
+++ b/.github/workflows/repository-quality.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Validate Phase 1 data backbone and canon diff
         run: python tools/data/validate_phase1_data.py
 
+      - name: Validate skill-tree visual bible authority boundaries
+        run: python tools/data/validate_skill_tree_visual_bible.py
+
       - name: Validate JSON syntax with Python
         run: python tools/validate_json.py
 

--- a/assets/ref/skill_tree/README.md
+++ b/assets/ref/skill_tree/README.md
@@ -1,0 +1,28 @@
+# Skill Tree Reference Assets
+
+This directory is the repository-side index for the approved ten-page CRIA DO TATAME skill-tree visual bible.
+
+The original PNG boards are archived persistently in ChatGPT Library at:
+
+`/CRIA DO TATAME/Visual Bible/Skill Tree v1/`
+
+They are **not yet repository binaries**. Phase 2 asset ingestion must copy the exact archived images into this directory (or its final canonical replacement), generate per-binary provenance/license/QA sidecars, register them in `assets/manifest_v2.json`, and keep `shipping=false` until human QA.
+
+Expected canonical filenames:
+
+1. `01_skill_tree_overview.png`
+2. `02_pressure_silverback.png`
+3. `03_technique_zanshin.png`
+4. `04_mobility_scramble.png`
+5. `05_finalization.png`
+6. `06_resilience.png`
+7. `07_arena_perks.png`
+8. `08_factions_reputation.png`
+9. `09_meta_progression.png`
+10. `10_jiujitsu_skill_tree.png`
+
+Exact hashes and Library IDs live in `data/visual/skill_tree_visual_manifest_v1.json`.
+
+## Non-negotiable rule
+
+The boards are art/layout authority only. Baked text and numbers are never imported as gameplay authority. Runtime UI must recreate the design with Godot controls populated from canonical data.

--- a/data/progression/skill_graph_v1.json
+++ b/data/progression/skill_graph_v1.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "skill_graph_v1",
+  "version": "1.0.0",
+  "status": "design_locked_data_pending_balance",
+  "runtime_authority_target": "combat_reducer_epic55",
+  "numeric_balance_status": "pending_epic55_epic56",
+  "belt_order": ["white", "blue", "purple", "brown", "black"],
+  "paths": [
+    {
+      "id": "pressure",
+      "display_name": "Pressão",
+      "color": "#C62828",
+      "theme": "avancar_dominar_cansar",
+      "capstone": "silverback_pressure",
+      "nodes": [
+        "postura_pesada", "controle_de_base", "quebra_de_postura", "pressao_de_ombro",
+        "controle_de_quadril", "passagem_forte", "amassar_espaco", "cadeia_de_ataques",
+        "knee_cut_brutal", "meia_guarda_de_peso", "silverback_pressure"
+      ]
+    },
+    {
+      "id": "technique",
+      "display_name": "Técnica",
+      "color": "#29A8FF",
+      "theme": "controle_leitura_timing",
+      "capstone": "zanshin_counter",
+      "nodes": [
+        "base_limpa", "ajuste_de_pegada", "kuzushi_fino", "timing_de_entrada",
+        "transicoes", "leitura_de_base", "defesa_e_contra", "fluxo_de_guarda",
+        "passagem_sistematica", "zanshin_counter"
+      ]
+    },
+    {
+      "id": "mobility",
+      "display_name": "Mobilidade",
+      "color": "#39FF14",
+      "theme": "fluxo_escape_scramble",
+      "capstone": "fantasma_do_mangue",
+      "nodes": [
+        "passo_curto", "deslocamento_lateral", "base_leve", "shrimp_rapido", "ponte_e_giro",
+        "sprawl_e_retorno", "esquiva_curta", "recuperacao_de_guarda", "scramble_reativo",
+        "fantasma_do_mangue"
+      ]
+    },
+    {
+      "id": "finalization",
+      "display_name": "Finalização",
+      "color": "#B84DFF",
+      "theme": "caca_oportunidade_controle",
+      "capstone": "cacador_de_finalizacoes",
+      "nodes": [
+        "controle_isolado", "quebra_de_postura_finalizacao", "caca_ao_pescoco", "ataque_de_braco",
+        "kimura_de_cria", "triangulo_vivo", "estrangulamentos", "alavancas_em_cadeia",
+        "armadilha_de_guarda", "cacador_de_finalizacoes"
+      ]
+    },
+    {
+      "id": "resilience",
+      "display_name": "Resiliência",
+      "color": "#C9971C",
+      "theme": "corpo_mente_recuperacao",
+      "capstone": "coracao_do_tatame",
+      "nodes": [
+        "condicionamento_fisico", "casca_dura", "controle_da_respiracao", "mente_fria",
+        "recuperacao_ativa", "gas_de_rua", "superacao", "ritmo_constante", "disciplina_de_aco",
+        "coracao_do_tatame"
+      ]
+    }
+  ],
+  "cross_systems": {
+    "arena_perks": {
+      "status": "visual_reference_only_until_epic66",
+      "known_ids": ["passo_de_lama", "ginga_de_ponte", "carga_pesada", "mare_viva", "cerco", "sucata_blindada"]
+    },
+    "faction_reputation": {
+      "status": "data_driven",
+      "factions": ["ALE", "LEM", "NTM"]
+    },
+    "meta_progression": {
+      "belts": ["white", "blue", "purple", "brown", "black"],
+      "meters": ["honra", "hype", "heat", "truth_fragments"]
+    }
+  },
+  "guardrails": {
+    "ui_decides_rules": false,
+    "visual_costs_are_authority": false,
+    "visual_belt_labels_are_authority": false,
+    "generated_text_is_authority": false,
+    "seeded_random_only": true
+  }
+}

--- a/data/visual/skill_tree_ui_contract_v1.json
+++ b/data/visual/skill_tree_ui_contract_v1.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "skill_tree_ui_contract_v1",
+  "version": "1.0.0",
+  "design_system": "CRIA_DO_TATAME_MAP_UI_PREMIUM",
+  "canvas": {"aspect_ratio":"16:9","reference_resolution":[1672,941]},
+  "palette": {
+    "background":"#0B0B0D",
+    "gold":"#C9971C",
+    "off_white":"#EDE6D6",
+    "pressure":"#C62828",
+    "technique":"#29A8FF",
+    "mobility":"#39FF14",
+    "finalization":"#B84DFF",
+    "resilience":"#C9971C"
+  },
+  "layout": {
+    "top_nav":"global navigation + currency + level",
+    "left_rail":"player card + path selector",
+    "center":"node graph and dependency connections",
+    "right_panel":"selected node preview + effects + requirements",
+    "bottom":"legend + belt requirements + page/status information"
+  },
+  "node_states": ["locked","available","owned","selected","capstone"],
+  "node_types": ["fundamental","advanced","hybrid","signature","arena_perk","faction_reward"],
+  "interaction": {
+    "hover_or_focus":"show tooltip generated from data",
+    "select":"populate right panel",
+    "unlock":"request rules service; UI cannot mutate progression directly",
+    "preview":"play short character animation or technique clip when available"
+  },
+  "accessibility": {
+    "color_only_signaling": false,
+    "text_scale": true,
+    "reduced_motion": true,
+    "focus_outline": true,
+    "colorblind_symbols_required": true
+  },
+  "runtime_rules": {
+    "no_baked_text_for_interactive_ui": true,
+    "no_reference_image_as_runtime_screen": true,
+    "labels_from_data": true,
+    "costs_from_reducer_owned_rules": true,
+    "belt_requirements_from_data": true,
+    "animations_are_presentation_only": true
+  }
+}

--- a/data/visual/skill_tree_visual_manifest_v1.json
+++ b/data/visual/skill_tree_visual_manifest_v1.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "skill_tree_visual_manifest_v1",
+  "version": "1.0.0",
+  "status": "reference_candidate",
+  "shipping": false,
+  "visual_authority": true,
+  "text_authority": false,
+  "numeric_balance_authority": false,
+  "repo_binary_status": "pending_phase2_ingestion",
+  "source_archive": {
+    "surface": "chatgpt_library",
+    "folder": "/CRIA DO TATAME/Visual Bible/Skill Tree v1"
+  },
+  "rules": [
+    "Use these images as layout, art-direction, hierarchy and presentation ground truth.",
+    "Never promote baked text, costs, levels, belt labels or generated faction spellings into gameplay authority.",
+    "canon_lock.json, factions_v2.json, roster_v3.json and reducer-owned rules override visual text.",
+    "Runtime UI must reconstruct labels and values from data; reference images are never loaded as interactive screens.",
+    "All binary assets remain shipping=false until Phase 2 ingestion, provenance and human QA."
+  ],
+  "pages": [
+    {
+      "order": 1,
+      "id": "skill_tree_overview",
+      "role": "overview",
+      "library_path": "/CRIA DO TATAME/Visual Bible/Skill Tree v1/01_skill_tree_overview.png",
+      "library_file_id": "libfile_3e9d4cda205c8191959915c5b51fd8b6",
+      "source_sha256": "2e2989732fca0cf8b4b27cf003d571d051105faaea2cd6632d95277a4b891b20",
+      "dimensions": [1672, 941]
+    },
+    {
+      "order": 2,
+      "id": "pressure_silverback",
+      "role": "path_pressure",
+      "library_path": "/CRIA DO TATAME/Visual Bible/Skill Tree v1/02_pressure_silverback.png",
+      "library_file_id": "libfile_4b794ea22e0c8191ab5ec05f346ede98",
+      "source_sha256": "1ce37b164daf29d36b5432a3eaf4763d541c9bccc5b4637c60d3fd6b34853359",
+      "dimensions": [1672, 941]
+    },
+    {
+      "order": 3,
+      "id": "technique_zanshin",
+      "role": "path_technique",
+      "library_path": "/CRIA DO TATAME/Visual Bible/Skill Tree v1/03_technique_zanshin.png",
+      "library_file_id": "libfile_f63e2d9c571481918a2a55eaddc62754",
+      "source_sha256": "5c07d2f57cb650564c759baf50d97ec664cc05e370b6df0047f54c88d3b0ff11",
+      "dimensions": [1672, 941]
+    },
+    {
+      "order": 4,
+      "id": "mobility_scramble",
+      "role": "path_mobility",
+      "library_path": "/CRIA DO TATAME/Visual Bible/Skill Tree v1/04_mobility_scramble.png",
+      "library_file_id": "libfile_8fe967a1321881919982ec30fbc8ee42",
+      "source_sha256": "fce1ea20e35d54118f6775a724a182dd0e2800d4d33a699cffc62189fc2eb423",
+      "dimensions": [1672, 941]
+    },
+    {
+      "order": 5,
+      "id": "finalization",
+      "role": "path_finalization",
+      "library_path": "/CRIA DO TATAME/Visual Bible/Skill Tree v1/05_finalization.png",
+      "library_file_id": "libfile_f094421051b0819183d163ecaa5eed62",
+      "source_sha256": "3809b2cf75eada90b40b41e0a1f0fb35da29a5367f8509dfa3faf507cd1d753a",
+      "dimensions": [1672, 941]
+    },
+    {
+      "order": 6,
+      "id": "resilience",
+      "role": "path_resilience",
+      "library_path": "/CRIA DO TATAME/Visual Bible/Skill Tree v1/06_resilience.png",
+      "library_file_id": "libfile_71a224f9ad6481919bf7b4f061960d85",
+      "source_sha256": "77c4232d8ff12db531fa8f1954d7a8fec1cf5ee4f0bba11e575a1603759e4632",
+      "dimensions": [1672, 941]
+    },
+    {
+      "order": 7,
+      "id": "arena_perks",
+      "role": "cross_system_arena_perks",
+      "library_path": "/CRIA DO TATAME/Visual Bible/Skill Tree v1/07_arena_perks.png",
+      "library_file_id": "libfile_bab4a43b76188191bc310da2177dc44b",
+      "source_sha256": "819b9e6d14a263f24bdcfea7856a780c290a9a007f2872300055f412136fbdc0",
+      "dimensions": [1672, 941]
+    },
+    {
+      "order": 8,
+      "id": "factions_reputation",
+      "role": "cross_system_faction_reputation",
+      "library_path": "/CRIA DO TATAME/Visual Bible/Skill Tree v1/08_factions_reputation.png",
+      "library_file_id": "libfile_a5084c6ca774819198aa29cdf9154b1c",
+      "source_sha256": "7e8fdec411e3d79d6726eb66221d18da8d3f30146b3cbb94548abdc47c9d2832",
+      "dimensions": [1672, 941]
+    },
+    {
+      "order": 9,
+      "id": "meta_progression",
+      "role": "cross_system_meta_progression",
+      "library_path": "/CRIA DO TATAME/Visual Bible/Skill Tree v1/09_meta_progression.png",
+      "library_file_id": "libfile_8d8e072f46688191bd91347767d576d4",
+      "source_sha256": "ef32f6477ef1450928194aaa03f8630837920929743100dfed6fd51e1789c0d9",
+      "dimensions": [1672, 941]
+    },
+    {
+      "order": 10,
+      "id": "jiujitsu_skill_tree",
+      "role": "system_summary",
+      "library_path": "/CRIA DO TATAME/Visual Bible/Skill Tree v1/10_jiujitsu_skill_tree.png",
+      "library_file_id": "libfile_f601649643b081919b87636a063a95b8",
+      "source_sha256": "4ef146ed4d8849dc486c2a46d8e3404d4c3a6a3ca9bdbd3823bce4536be51ffc",
+      "dimensions": [1672, 941]
+    }
+  ]
+}

--- a/docs/art/SKILL_TREE_VISUAL_BIBLE_v1.md
+++ b/docs/art/SKILL_TREE_VISUAL_BIBLE_v1.md
@@ -1,0 +1,125 @@
+# SKILL TREE VISUAL BIBLE v1 — CRIA DO TATAME
+
+Status: **VISUAL GROUND TRUTH / REFERENCE_CANDIDATE**  
+Shipping: **false**  
+Runtime authority: **none**  
+Gameplay authority target: **data + reducer**
+
+## 1. Purpose
+
+The ten approved skill-tree boards define the official visual language for progression screens in CRIA DO TATAME. They are the art-direction reference for composition, hierarchy, icon density, typography scale, graph readability, path colors, preview panels and the relationship between progression, factions, arena perks and meta-progression.
+
+They are **not screenshots to be loaded directly as interactive UI**. Runtime screens must be reconstructed in Godot from data, theme resources and UI components.
+
+## 2. Visual language
+
+- Premium pixel-art / illustrated game UI aligned with the official world-map quality bar.
+- Dark charcoal/black chrome with gold borders and off-white text.
+- Dense but clearly segmented information architecture.
+- 16:9 wide layout.
+- Strong contextual environment behind the UI, without reducing readability.
+- Ruan remains the central visual anchor for the skill system.
+- Path colors are stable: Pressão red, Técnica blue, Mobilidade green, Finalização purple, Resiliência gold.
+
+## 3. Canonical screen anatomy
+
+1. Top global navigation.
+2. Player card with portrait and current progression state.
+3. Path selector on the left.
+4. Central graph with connected nodes and visible dependency direction.
+5. Right contextual panel with selected technique preview, effects and requirements.
+6. Bottom legend / belt requirements / page marker.
+
+## 4. The five canonical paths
+
+### Pressão
+Identity: advance, dominate, exhaust, positional control.  
+Signature visual capstone: **Silverback Pressure**.
+
+### Técnica
+Identity: clean mechanics, grip adjustment, kuzushi, timing, reading and countering.  
+Signature visual capstone: **Zanshin Counter**.
+
+### Mobilidade
+Identity: movement, escapes, guard recovery, scramble and re-composition.  
+Signature visual capstone: **Fantasma do Mangue**.
+
+### Finalização
+Identity: isolate, hunt, chain attacks and finish under control.  
+Signature visual capstone: **Caçador de Finalizações**.
+
+### Resiliência
+Identity: conditioning, breath control, recovery, mental stability and consistency.  
+Signature visual capstone: **Coração do Tatame**.
+
+## 5. Cross-progression screens
+
+The visual system also includes three cross-system families:
+
+- Arena perks: environmental/territorial rewards linked to clandestine arenas.
+- Faction reputation: ALE, LEM and NTM progression, with exclusive rewards and consequences.
+- Meta progression: belt journey, Honra, Hype, Heat and Truth Fragments.
+
+These screens must reuse the same chrome, typography and graph language instead of creating unrelated UI styles.
+
+## 6. Authority boundary — mandatory
+
+Generated text inside reference boards is **not canon by itself**. Examples of possible generation drift include faction spelling, player level, prices, percentage bonuses, belt labels or captions.
+
+The authority order is:
+
+1. `data/brand/canon_lock.json`
+2. canonical gameplay/narrative data (`factions_v2`, `roster_v3`, progression contracts)
+3. reducer/rules services
+4. runtime UI presentation
+5. visual reference boards
+
+Therefore:
+
+- Official faction names remain **Os Aleluiados**, **Lá Ele Mil Vezes**, **Nós Tem o Molho**.
+- The canonical belt sequence remains white → blue → purple → brown → black unless a future explicit data migration changes it.
+- Numbers printed into generated artwork do not establish balance.
+- A visual node is not automatically unlocked or implemented because it exists in a board.
+
+## 7. Runtime implementation rules
+
+```text
+DATA / REDUCER
+      ↓
+SkillTreeRules
+      ↓
+SkillTreeViewModel
+      ↓
+Godot Control Nodes
+      ↓
+Animation / Audio / VFX
+```
+
+The UI must never calculate unlock rules, costs, rewards or combat effects. It requests a decision and presents the result.
+
+Interactive labels must be actual UI text, not baked into a PNG. Player-focused accessibility requires text scaling, reduced-motion mode, focus outlines and non-color-only node state signaling.
+
+## 8. Asset lifecycle
+
+```text
+visual board
+→ reference_candidate
+→ human art QA
+→ component extraction / recreation
+→ runtime UI implementation
+→ gameplay QA
+→ shipping candidate
+→ shipping
+```
+
+No reference board is shipping-ready merely because it looks final.
+
+## 9. Source archive
+
+The exact ten boards are preserved in the persistent ChatGPT Library folder:
+
+`/CRIA DO TATAME/Visual Bible/Skill Tree v1/`
+
+Hashes and stable Library file IDs are recorded in `data/visual/skill_tree_visual_manifest_v1.json`.
+
+Binary copy into the repository is intentionally deferred to Phase 2 asset ingestion so the repository never claims a binary that was not actually ingested and sidecar-validated.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "validate:canon": "python tools/audit/validate_canon_contract_v4_1.py",
     "validate:factions-v4": "python tools/audit/validate_faction_migration_v4_2.py",
     "validate:phase1-data": "python tools/data/validate_phase1_data.py",
+    "validate:skill-tree-visual": "python tools/data/validate_skill_tree_visual_bible.py",
     "validate:python": "python tools/validate_json.py",
     "validate:node": "node tools/node/validate_json.mjs",
     "validate:data": "node tools/node/validate_game_data.mjs",
@@ -26,7 +27,7 @@
     "cloud:batch": "python tools/ai_asset_pipeline/cloud/prepare_batch.py --output-dir tools/ai_asset_pipeline/generated_outputs/candidate_batches",
     "animations:generate": "python tools/animation/generate_character_animation_pack.py",
     "validate:animations": "python tools/animation/generate_character_animation_pack.py --validate-only",
-    "quality": "npm run validate:governance && npm run validate:canon && npm run validate:factions-v4 && npm run validate:phase1-data && npm run validate:python && npm run validate:node && npm run validate:data && npm run validate:cloud && npm run test:cloud && npm run validate:animations && npm run validate:asset-protocol && npm run validate:repository && npm run validate:runtime && npm run validate:release && npm run validate:supreme && npm run validate:deck",
+    "quality": "npm run validate:governance && npm run validate:canon && npm run validate:factions-v4 && npm run validate:phase1-data && npm run validate:skill-tree-visual && npm run validate:python && npm run validate:node && npm run validate:data && npm run validate:cloud && npm run test:cloud && npm run validate:animations && npm run validate:asset-protocol && npm run validate:repository && npm run validate:runtime && npm run validate:release && npm run validate:supreme && npm run validate:deck",
     "build:android:windows": "powershell -ExecutionPolicy Bypass -File tools/build/build_android_debug.ps1",
     "build:android:linux": "bash tools/build/build_android_debug.sh",
     "build:windows": "powershell -ExecutionPolicy Bypass -File tools/build/build_windows_debug.ps1"

--- a/reports/epic71_skill_tree_visual_bible.json
+++ b/reports/epic71_skill_tree_visual_bible.json
@@ -1,0 +1,30 @@
+{
+  "schema": "epic71_skill_tree_visual_bible_report_v1",
+  "epic": 71,
+  "branch": "cmd/epic71-skill-tree-visual-bible",
+  "source_main": "b4c97e928e170867b6fa9bf510696d2d3ef06267",
+  "visual_pages": 10,
+  "source_archive": "/CRIA DO TATAME/Visual Bible/Skill Tree v1",
+  "source_archive_status": "persistent_library_saved",
+  "repo_binary_ingestion": "pending_phase2",
+  "visual_ground_truth": true,
+  "runtime_screen_ready": false,
+  "shipping": false,
+  "gameplay_authority": "data_and_reducer",
+  "files_added": [
+    "data/visual/skill_tree_visual_manifest_v1.json",
+    "data/progression/skill_graph_v1.json",
+    "data/visual/skill_tree_ui_contract_v1.json",
+    "docs/art/SKILL_TREE_VISUAL_BIBLE_v1.md",
+    "assets/ref/skill_tree/README.md",
+    "tools/data/validate_skill_tree_visual_bible.py"
+  ],
+  "package_quality_gate": "validate:skill-tree-visual",
+  "blocked": [
+    "Copy exact PNG binaries from persistent Library into repository during Phase 2 asset ingestion.",
+    "Generate per-binary license/provenance/qa sidecars after repository ingestion.",
+    "Register ingested binaries in assets/manifest_v2.json.",
+    "Implement runtime Godot UI from data instead of loading reference boards."
+  ],
+  "rollback": "Revert the eventual squash-merge commit for EPIC 71; Library archive remains intentionally preserved as source evidence."
+}

--- a/tools/data/validate_skill_tree_visual_bible.py
+++ b/tools/data/validate_skill_tree_visual_bible.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Validate the CRIA DO TATAME skill-tree visual bible contracts.
+
+Fail-closed rules:
+- exactly 10 visual reference pages;
+- reference images are non-runtime and shipping=false;
+- five canonical skill paths exist exactly once;
+- generated visual text/numbers are not gameplay authority;
+- canonical faction names and five-belt order remain untouched;
+- numeric balance stays pending until the declared gameplay EPICs.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def load(path: str) -> dict:
+    return json.loads((ROOT / path).read_text(encoding="utf-8"))
+
+
+def fail(msg: str) -> None:
+    raise AssertionError(msg)
+
+
+def main() -> int:
+    visual = load("data/visual/skill_tree_visual_manifest_v1.json")
+    graph = load("data/progression/skill_graph_v1.json")
+    ui = load("data/visual/skill_tree_ui_contract_v1.json")
+    canon = load("data/brand/canon_lock.json")
+    factions = load("data/factions/factions_v2.json")
+
+    pages = visual.get("pages", [])
+    if len(pages) != 10:
+        fail(f"visual pages != 10: {len(pages)}")
+    if [p.get("order") for p in pages] != list(range(1, 11)):
+        fail("visual page order must be exactly 1..10")
+    if len({p.get("id") for p in pages}) != 10:
+        fail("visual page ids must be unique")
+    if visual.get("shipping") is not False:
+        fail("visual bible must remain shipping=false")
+    if visual.get("text_authority") is not False:
+        fail("generated text must not be authority")
+    if visual.get("numeric_balance_authority") is not False:
+        fail("generated numeric balance must not be authority")
+    if visual.get("repo_binary_status") != "pending_phase2_ingestion":
+        fail("reference binaries must remain pending Phase 2 ingestion")
+    for page in pages:
+        if page.get("dimensions") != [1672, 941]:
+            fail(f"unexpected dimensions for {page.get('id')}")
+        sha = page.get("source_sha256", "")
+        if len(sha) != 64:
+            fail(f"invalid sha256 for {page.get('id')}")
+        if not page.get("library_file_id", "").startswith("libfile_"):
+            fail(f"missing persistent Library id for {page.get('id')}")
+
+    paths = graph.get("paths", [])
+    ids = [p.get("id") for p in paths]
+    expected_paths = ["pressure", "technique", "mobility", "finalization", "resilience"]
+    if ids != expected_paths:
+        fail(f"canonical paths mismatch: {ids}")
+    if graph.get("belt_order") != ["white", "blue", "purple", "brown", "black"]:
+        fail("canonical belt order drift")
+    if graph.get("numeric_balance_status") != "pending_epic55_epic56":
+        fail("numeric balance must remain pending")
+    if graph.get("guardrails", {}).get("ui_decides_rules") is not False:
+        fail("UI must not decide progression rules")
+
+    if ui.get("runtime_rules", {}).get("no_baked_text_for_interactive_ui") is not True:
+        fail("runtime UI must forbid baked interactive text")
+    if ui.get("runtime_rules", {}).get("no_reference_image_as_runtime_screen") is not True:
+        fail("reference boards must not be runtime screens")
+    if ui.get("accessibility", {}).get("color_only_signaling") is not False:
+        fail("color-only node signaling is forbidden")
+
+    official = {f["id"]: f["display_name"] for f in factions.get("factions", [])}
+    expected_factions = {
+        "ALE": "Os Aleluiados",
+        "LEM": "Lá Ele Mil Vezes",
+        "NTM": "Nós Tem o Molho",
+    }
+    if official != expected_factions:
+        fail(f"faction canon drift: {official}")
+
+    canon_belts = graph.get("belt_order")
+    if len(canon_belts) != 5:
+        fail("five-belt progression required")
+
+    print("SKILL_TREE_VISUAL_BIBLE_OK")
+    print(f"pages={len(pages)} paths={len(paths)} shipping={visual.get('shipping')}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## EPIC 71 — Skill Tree Visual Bible

Salva e formaliza o pacote visual completo da árvore de habilidades do CRIA DO TATAME sem transformar arte gerada em autoridade de gameplay.

### Fonte preservada
- 10/10 pranchas originais arquivadas persistentemente em `/CRIA DO TATAME/Visual Bible/Skill Tree v1/` na Library.
- SHA-256 e Library IDs registrados em `data/visual/skill_tree_visual_manifest_v1.json`.
- Binaries no repo: **pending Phase 2 ingestion**; nenhum PNG é fingido como commitado.

### Adicionado
- `data/progression/skill_graph_v1.json`
- `data/visual/skill_tree_visual_manifest_v1.json`
- `data/visual/skill_tree_ui_contract_v1.json`
- `docs/art/SKILL_TREE_VISUAL_BIBLE_v1.md`
- `assets/ref/skill_tree/README.md`
- `tools/data/validate_skill_tree_visual_bible.py`
- `reports/epic71_skill_tree_visual_bible.json`
- gate `validate:skill-tree-visual` ligado ao `npm run quality`

### Cânone travado
Cinco caminhos: Pressão, Técnica, Mobilidade, Finalização e Resiliência. Visual oficial segue o nível premium do mapa: chrome preto/dourado, alto contraste, grafos conectados, preview contextual e identidade por cor.

### Fail-closed
- `shipping=false`.
- imagens são autoridade visual/layout, **não texto ou números**.
- custos/efeitos/balanceamento continuam pendentes de EPIC55/56.
- grafias oficiais de facção continuam `Os Aleluiados`, `Lá Ele Mil Vezes`, `Nós Tem o Molho`.
- faixa canônica: branca → azul → roxa → marrom → preta.
- runtime deve reconstruir a tela com Godot Controls + dados; nunca carregar a prancha como UI interativa.

### Phase 2 pending
Copiar os 10 PNGs exatos da Library para o repo, gerar sidecars license/provenance/qa e registrar no `assets/manifest_v2.json`.

### Gate
Não mesclar até CI completo ficar verde no head exato do PR.