### PR TITLE
EPIC 72 — BJJ intelligence fail-closed foundation

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -8,4 +8,6 @@ Regras:
 - skills não substituem contratos em `data/production/` nem o cânone em `docs/canon/`;
 - nenhum agente pode declarar conclusão sem evidência de integração e teste;
 - não armazenar prompts de outros produtos, credenciais, conversas exportadas ou saídas brutas;
-- toda skill adicionada deve possuir versão, finalidade, limites e validação.
+- toda skill adicionada deve possuir versão, finalidade, limites e validação;
+- skills especializadas vivem em `.agents/skills/` e devem preservar a autoridade do runtime/cânone;
+- `cria-bjj-fight-intelligence@1.0.0` é o router de domínio para as skills BJJ adicionadas no EPIC 72.

--- a/.agents/skills/cria-bjj-fight-intelligence/SKILL.md
+++ b/.agents/skills/cria-bjj-fight-intelligence/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: cria-bjj-fight-intelligence
+version: 1.0.0
+status: canonical_candidate
+project: CRIA DO TATAME
+fail_closed: true
+shipping_default: false
+generative: auxiliary_only
+human_bjj_gate: required
+---
+
+# CRIA BJJ FIGHT INTELLIGENCE
+
+Router de domínio para Brazilian Jiu-Jitsu GI/NO-GI, biomecânica, cinesiologia, vídeo técnico, animação pareada e contratos de combate do CRIA DO TATAME.
+
+## Autoridade
+
+1. `data/production/` e cânone executável vigente;
+2. ruleset e catálogo de técnicas consumido;
+3. evidência de combate real com licença/proveniência;
+4. biomecânica/cinesiologia medida ou revisada;
+5. position/connection/contact graph;
+6. reducer e `CombatManager` existentes;
+7. motion/pixel presentation;
+8. geração de IA somente como candidata.
+
+Arte, VLM, LLM e motion generativo nunca promovem técnica nem asset.
+
+## Gramática
+
+`POSITION → CONNECTION → CONTROL → KUZUSHI → TRANSITION → STABILIZE → THREAT → REACTION → NEXT_STATE`
+
+Transição: `READ → CONNECT → KUZUSHI → COMMIT → TRANSITION → STABILIZE`.
+Finalização: `CONTROL → ISOLATE → POSITION → LOCK → THREAT → TAP → RELEASE`.
+Escape: `SURVIVE → FRAME → CREATE_SPACE → HIP_MOVE → RECOVER_STRUCTURE → RE-GUARD`.
+
+## Módulos vinculados
+
+- `cria-video-intelligence@0.1.0` — ingestão, custódia, anotação, pose e evidência;
+- `cria-pixel-motion-pipeline@0.1.0` — paired master motion → pixel frames;
+- `cria-combat-runtime@0.1.0` — contrato de conexão/branches/stamina para adapter futuro do runtime existente.
+
+## Regras fail-closed
+
+- `UNKNOWN != PASS`;
+- licença desconhecida bloqueia ingestão além de V1;
+- mocap ausente bloqueia claim biomecânico medido;
+- conflito com `production_manifest_v02.json` permanece DRAFT/BLOCKED até decisão explícita;
+- `human_bjj_gate` só aceita decisão de revisor humano;
+- técnica pareada exige atacante, defensor, shared origin, timing, `sync_map` e contact graph;
+- nenhuma nova skill cria manager/autoload/runtime concorrente;
+- `shipping=true` é proibido neste pacote.
+
+## Frame contract de referência
+
+128×128 por ator, pivot `[64,96]`, apresentação a 12 fps, nearest-neighbor, sem anti-aliasing. Valores por técnica podem permanecer candidatos até reconciliados com o manifesto visual canônico.
+
+## Outputs
+
+- dossier técnico;
+- rule/position/contact graph;
+- motion spec;
+- sync map plan;
+- biomech QA;
+- corpus evidence ledger;
+- frame plan;
+- runtime adapter spec;
+- verdict: `CANDIDATE | REWORK | BLOCKED`.

--- a/.agents/skills/cria-combat-runtime/SKILL.md
+++ b/.agents/skills/cria-combat-runtime/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: cria-combat-runtime
+version: 0.1.0
+parent: cria-bjj-fight-intelligence@1.0.0
+fail_closed: true
+shipping_default: false
+generative: auxiliary_only
+runtime_implementation_status: SPEC_ONLY
+runtime_authority: CombatManager
+---
+
+# CRIA COMBAT RUNTIME — DOMAIN ADAPTER SPEC
+
+Especifica como evidência BJJ pode alimentar o runtime existente. **Não cria segundo manager, reducer, singleton ou autoload.** Qualquer implementação futura entra por adapter/fachada no `CombatManager` canônico e exige lote próprio.
+
+## Connection quality antes do botão
+
+Componentes candidatos:
+- `grip_security`;
+- `head_position`;
+- `hip_connection`;
+- `inside_position`;
+- `elbow_position`;
+- `frame_integrity`;
+- `base_integrity`.
+
+Nenhum threshold numérico é canônico até calibração.
+
+## Branches
+
+Uma técnica pode possuir branches com `diverge_at` no `sync_map`. A branch só muda presentation/state quando o reducer autoritativo aceitar o evento. Sprite não move estado de gameplay.
+
+## Stamina
+
+Separar conceitos candidatos:
+- `grip_isometric_cost`;
+- `pressure_cost`;
+- `scramble_burst_cost`;
+- `failed_attack_cost`;
+- `recovery_under_control`.
+
+Valores = `PENDING_CALIBRATION`.
+
+## Pontuação/ruleset
+
+Scoring e legalidade são adapters versionados por ruleset; o motion físico não define ponto. Estabilização só gera score quando o ruleset adapter vigente confirmar os requisitos.
+
+## Proibições
+
+- LLM/VLM no loop crítico;
+- network AI para decidir combate;
+- segundo CombatManager;
+- números de balanceamento inventados;
+- promoção de dossier candidato para runtime sem migração e testes.

--- a/.agents/skills/cria-pixel-motion-pipeline/SKILL.md
+++ b/.agents/skills/cria-pixel-motion-pipeline/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: cria-pixel-motion-pipeline
+version: 0.1.0
+parent: cria-bjj-fight-intelligence@1.0.0
+fail_closed: true
+shipping_default: false
+generative: auxiliary_only
+frame_spec: 128x128 | pivot [64,96] | 12fps | nearest | no-AA
+---
+
+# CRIA PIXEL MOTION PIPELINE
+
+Converte movimento BJJ pareado validado em apresentação pixel-art. Não cria biomecânica.
+
+## Pipeline
+
+`validated paired motion → key poses → Blender/orthographic reference → pixel candidate → deterministic cleanup → attacker/defender split → sync_map → hitbox/contact metadata → preview → QA`.
+
+## Regras
+
+- nunca gerar atacante e defensor como movimentos independentes e tentar encaixar depois;
+- shared origin e sync map são obrigatórios;
+- identidade do personagem deve permanecer estável entre frames;
+- zero AA, nearest-neighbor, alpha/paleta conforme gate de asset vigente;
+- contact points não podem flutuar ou trocar membro;
+- submission animation encerra em tap + release, sem espetáculo de hiperextensão;
+- outputs brutos/generated permanecem `shipping=false`.
+
+## QA mínimo
+
+Estrutural: dimensões, pivot, alpha, palette, sidecars.
+Temporal: drift, flicker, limb swap, duplicate frame, loop.
+BJJ: posição, grip, base, kuzushi, transição, estabilização.
+Biomecânica: ROM plausível, pelvis/base, contact geometry, queda segura.
+Humano: gate obrigatório antes de qualquer promoção.

--- a/.agents/skills/cria-video-intelligence/SKILL.md
+++ b/.agents/skills/cria-video-intelligence/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: cria-video-intelligence
+version: 0.1.0
+parent: cria-bjj-fight-intelligence@1.0.0
+fail_closed: true
+shipping_default: false
+generative: auxiliary_only
+stop_condition: CORPUS_GAP | LICENSE_UNKNOWN | SOURCE_BYTES_MISSING
+---
+
+# CRIA VIDEO INTELLIGENCE
+
+Transforma vídeo autorizado de BJJ em evidência auditável. Não declara que “assistiu tudo”; trabalha por corpus versionado e cobertura mensurável.
+
+## V1 — Ingestão + cadeia de custódia
+
+Obrigatório antes de análise:
+- source ID e URL/localizador estável;
+- licença/termos ou autorização registrada;
+- bytes/materialização disponível;
+- SHA-256 dos bytes analisados;
+- data de aquisição;
+- modalidade/ruleset quando conhecido;
+- provenance ledger.
+
+Sem isso: `CUSTODY_BLOCKED` e V2–V6 não executam.
+
+## V2 — Event annotation
+
+Schema mínimo:
+`{t, actor, state_before, action, state_after, grip_family, side, result, score_event}`.
+
+Eventos sem frame/timestamp verificável recebem `UNVERIFIED`.
+
+## V3 — Pose/keypoints
+
+Backends candidatos: MediaPipe/MMPose/RTMPose; modelos/datasets non-commercial permanecem research-only. Guardar identidade A/B de forma estável, confidence e oclusões.
+
+## V4–V6
+
+V4: recuperação 3D/SMPL somente quando licenciada e tecnicamente adequada.
+V5: OpenSim/biomecânica e contact graph; não inventar força/torque.
+V6: estatística de transições/lateralidade/stamina com tamanho amostral e regras de agregação explícitos.
+
+## Safety/evidence
+
+Vídeo de terceiro é evidência/referência, nunca spritesheet copiado. Não versionar frames protegidos sem permissão. Outputs derivados devem preservar referência de fonte e status de licença.

--- a/data/bjj/corpus/baiana_single_leg_v1.json
+++ b/data/bjj/corpus/baiana_single_leg_v1.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "bjj_corpus_entry_v1",
+  "technique_id": "baiana_single_leg",
+  "pipeline": "cria-video-intelligence@0.1.0",
+  "shipping": false,
+  "custody": {
+    "source_id": null,
+    "source_url": null,
+    "license_status": "UNKNOWN",
+    "sha256": null,
+    "status": "CUSTODY_BLOCKED",
+    "reason": "Prompt references a BJJ Data clip but does not provide an exact source identifier, license record, or materialized bytes."
+  },
+  "stages": {
+    "V1_ingestion_custody": {"status":"BLOCKED","missing":["exact_source_id","source_url_or_locator","license_or_authorization","materialized_bytes","sha256"]},
+    "V2_event_annotation": {"status":"NOT_STARTED_BLOCKED_BY_V1","schema_fields":["t","actor","state_before","action","state_after","grip_family","side","result","score_event"]},
+    "V3_pose_keypoints": {"status":"NOT_STARTED_BLOCKED_BY_V1","candidate_backends":["MediaPipe","MMPose_RTMPose"],"actor_identity_lock":true},
+    "V4_3d_recovery": {"status":"OUT_OF_SCOPE_THIS_EPIC"},
+    "V5_biomechanics": {"status":"OUT_OF_SCOPE_THIS_EPIC"},
+    "V6_statistics": {"status":"OUT_OF_SCOPE_THIS_EPIC"}
+  },
+  "expected_technique_phases": ["READ","CONNECT","KUZUSHI","COMMIT","TRANSITION","STABILIZE"],
+  "evidence_claim":"NO_VIDEO_ANALYSIS_PERFORMED"
+}

--- a/data/bjj/dossiers/001_baiana_single_leg_human_gate.json
+++ b/data/bjj/dossiers/001_baiana_single_leg_human_gate.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "bjj_human_gate_session_v1",
+  "dossier_id": "001",
+  "technique_id": "baiana_single_leg",
+  "parent_skill": "cria-bjj-fight-intelligence@1.0.0",
+  "decision_owner": "human_bjj_reviewer",
+  "assistant_may_recommend_but_not_sign": true,
+  "human_decision": "PENDING",
+  "shipping": false,
+  "blocks": [
+    {"id":"G1_READ","frames":[0,3],"recommendation":"APROVA","human_decision":"PENDING"},
+    {"id":"G2_CONNECT","frames":[4,6],"recommendation":"REWORK(2)","reason":"head position ambiguous in candidate A f5-f6","human_decision":"PENDING"},
+    {"id":"G3_KUZUSHI","frames":[7,9],"recommendation":"APROVA","human_decision":"PENDING"},
+    {"id":"G4_COMMIT","frames":[10,14],"recommendation":"APROVA_CONDICIONAL","condition":"head of attacker never under defender pelvis; penetration/leg connection requires evidence","human_decision":"PENDING"},
+    {"id":"G5_TRANSITION","frames":[15,19],"recommendation":"APROVA","condition":"spike gate remains blocking","human_decision":"PENDING"},
+    {"id":"G6_STABILIZE","frames":[20,23],"recommendation":"APROVA","human_decision":"PENDING"},
+    {"id":"G7_IDENTIDADE","frames":[0,23],"recommendation":"APROVA","human_decision":"PENDING"},
+    {"id":"G8_EVIDENCIA","frames":null,"recommendation":"BLOCKED","reason":"exact licensed source/mocap not materialized","human_decision":"PENDING"}
+  ],
+  "maximum_status_without_G8":"CANDIDATE_APPROVED_BY_HUMAN",
+  "current_status":"HUMAN_GATE_PENDING_AND_SHIPPING_BLOCKED"
+}

--- a/data/bjj/dossiers/003_raspagem_tesoura.json
+++ b/data/bjj/dossiers/003_raspagem_tesoura.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "bjj_dossier_v1",
+  "dossier_id": "003",
+  "technique_id": "raspagem_tesoura",
+  "parent_skill": "cria-bjj-fight-intelligence@1.0.0",
+  "status": "DRAFT_CONFLICT_PENDING_RESOLUTION",
+  "shipping": false,
+  "human_bjj_gate": "REQUIRED",
+  "authority_snapshot": {
+    "source": "data/visual/production_manifest_v02.json@cfb1afa18b0b4bdc5c3eb567276ea1d83823ce98",
+    "entry": "player_bottom_guard",
+    "exit": "player_top_guard",
+    "frames_target": 28
+  },
+  "proposal": {
+    "modes": ["GI", "NO_GI"],
+    "grammar": "transition",
+    "frame_spec": {"size": [128,128], "pivot": [64,96], "fps": 12, "frames_total": 24, "nearest": true, "anti_aliasing": false},
+    "entry": "guard.closed_bottom",
+    "success_states": ["mount_top", "side_control_top"],
+    "phases": [
+      {"id":"READ","frames":[0,3],"bottom":"closed guard; grip/posture control","top":"posture pressured"},
+      {"id":"CONNECT","frames":[4,6],"bottom":"open guard; hip post + shin frame","top":"base adjusts forward"},
+      {"id":"KUZUSHI","frames":[7,9],"bottom":"diagonal pull and hip angle","top":"COM displaced toward swept side"},
+      {"id":"COMMIT","frames":[10,14],"bottom":"scissor lever/wedge action","top":"post attempt available"},
+      {"id":"TRANSITION","frames":[15,19],"bottom":"follow grips and rise","top":"protected lateral fall"},
+      {"id":"STABILIZE","frames":[20,23],"bottom":"top control candidate","top":"defensive breakdown"}
+    ],
+    "branches": [
+      {"id":"B1_post_hand","diverge_at":10,"result":"closed_guard_or_hip_bump_setup"},
+      {"id":"B2_stack","diverge_at":10,"result":"open_guard_recovery","risk":"stack_pass"},
+      {"id":"B3_knee_race","diverge_at":4,"result":"timing_dependent_knee_cut_race"}
+    ],
+    "biomech_qa": {
+      "neck_B":"posture pull only; no lateral cervical torque",
+      "knee_B":"lever at thigh/knee line; no reaping claim",
+      "wrist_B":"grip within ordinary control ROM; not wrist lock",
+      "spine_A":"neutral trunk preference; no forced lumbar hyperextension",
+      "fall_B":"protected lateral fall; head impact forbidden"
+    },
+    "gi_nogi_adapter": {
+      "GI":"collar+sleeve candidate grip family; cloth tension is presentation only",
+      "NO_GI":"wrist/tie candidate connection; reconnection timing requires mocap/corpus validation"
+    },
+    "evidence_status":"CANDIDATE_PENDING_RULEBOOK_AND_MOCAP_VALIDATION"
+  },
+  "conflicts": [
+    {"field":"frames_target","authority":28,"proposal":24,"resolution":"BLOCKED_PENDING_EXPLICIT_CANON_DECISION"},
+    {"field":"entry_state","authority":"player_bottom_guard","proposal":"guard.closed_bottom","resolution":"BLOCKED_PENDING_STATE_MAPPING"},
+    {"field":"success_state","authority":"player_top_guard","proposal":["mount_top","side_control_top"],"resolution":"BLOCKED_PENDING_TECHNIQUE_GRAPH_REVIEW"}
+  ],
+  "rule_claims": [
+    {"claim":"IBJJF sweep scoring/stabilization semantics","status":"UNVERIFIED_PENDING_CURRENT_RULEBOOK_SOURCE"},
+    {"claim":"ADCC adapter semantics","status":"UNVERIFIED_PENDING_CURRENT_RULESET_SOURCE"}
+  ]
+}

--- a/data/schemas/bjj_corpus_entry_v1.schema.json
+++ b/data/schemas/bjj_corpus_entry_v1.schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "bjj_corpus_entry_v1",
+  "type": "object",
+  "required": ["technique_id", "pipeline", "custody", "stages", "shipping"],
+  "properties": {
+    "technique_id": {"type": "string"},
+    "shipping": {"const": false},
+    "pipeline": {"const": "cria-video-intelligence@0.1.0"},
+    "custody": {
+      "type": "object",
+      "required": ["source_id", "source_url", "license_status", "sha256", "status"],
+      "properties": {
+        "source_id": {"type": ["string", "null"]},
+        "source_url": {"type": ["string", "null"]},
+        "license_status": {"enum": ["CLEARED", "UNKNOWN", "RESEARCH_ONLY", "BLOCKED"]},
+        "sha256": {"type": ["string", "null"]},
+        "status": {"enum": ["READY", "CUSTODY_BLOCKED"]}
+      }
+    },
+    "stages": {"type": "object"}
+  }
+}

--- a/data/schemas/bjj_dossier_v1.schema.json
+++ b/data/schemas/bjj_dossier_v1.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "bjj_dossier_v1",
+  "type": "object",
+  "required": ["dossier_id", "technique_id", "status", "shipping", "authority_snapshot", "proposal", "conflicts"],
+  "properties": {
+    "dossier_id": {"type": "string"},
+    "technique_id": {"type": "string"},
+    "status": {"enum": ["DRAFT", "DRAFT_CONFLICT_PENDING_RESOLUTION", "CANDIDATE", "BLOCKED", "REWORK"]},
+    "shipping": {"const": false},
+    "authority_snapshot": {"type": "object"},
+    "proposal": {"type": "object"},
+    "conflicts": {"type": "array", "items": {"type": "object", "required": ["field", "authority", "proposal", "resolution"]}},
+    "human_bjj_gate": {"enum": ["PENDING", "REQUIRED", "PASS", "FAIL", "REWORK"]}
+  }
+}

--- a/docs/production/BJJ_INTELLIGENCE_EPIC72.md
+++ b/docs/production/BJJ_INTELLIGENCE_EPIC72.md
@@ -1,0 +1,34 @@
+# EPIC 72 — BJJ Intelligence Foundation
+
+**Status:** ACTIVE / CANDIDATE CONTRACTS  
+**Base:** `main @ cfb1afa18b0b4bdc5c3eb567276ea1d83823ce98`  
+**Issue:** #85
+
+## Objetivo
+
+Adicionar skills e dados fail-closed para vídeo técnico, motion pixel e futuros adapters de combate sem tocar no runtime crítico.
+
+## Autoridade preservada
+
+`CombatManager` continua única autoridade de combate. As novas skills são conhecimento/produção offline e não alteram `project.godot`, autoloads ou cenas.
+
+## Dossiê #003
+
+A proposta `raspagem_tesoura` conflita com `production_manifest_v02`: proposta 24 frames / `guard.closed_bottom` / mount ou side; autoridade atual 28 frames / `player_bottom_guard` / `player_top_guard`. O dossiê fica `DRAFT_CONFLICT_PENDING_RESOLUTION`; nenhum dado ativo foi substituído.
+
+## Dossiê #001 human gate
+
+G1–G7 permanecem recomendações. G2 recomenda rework de head position; G8 está bloqueado por evidência. A IA não pode assinar `human_bjj_gate`, logo a decisão humana fica PENDING.
+
+## Corpus baiana V1–V3
+
+O prompt menciona um clipe de referência, mas não fornece exact source ID, licença/autorização nem bytes materializados. A skill V define `LICENSE_UNKNOWN | SOURCE_BYTES_MISSING` como condição de parada. Resultado correto:
+
+- V1: `CUSTODY_BLOCKED`;
+- V2: `NOT_STARTED_BLOCKED_BY_V1`;
+- V3: `NOT_STARTED_BLOCKED_BY_V1`;
+- claim: `NO_VIDEO_ANALYSIS_PERFORMED`.
+
+## Rollback
+
+Remover os arquivos adicionados neste EPIC e restaurar `package.json`; nenhum runtime/asset precisa de rollback.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "validate:factions-v4": "python tools/audit/validate_faction_migration_v4_2.py",
     "validate:phase1-data": "python tools/data/validate_phase1_data.py",
     "validate:skill-tree-visual": "python tools/data/validate_skill_tree_visual_bible.py",
+    "validate:bjj-intelligence": "python tools/bjj/validate_bjj_intelligence.py && python -m unittest discover -s tests/bjj_intelligence -p 'test_*.py'",
     "validate:python": "python tools/validate_json.py",
     "validate:node": "node tools/node/validate_json.mjs",
     "validate:data": "node tools/node/validate_game_data.mjs",
@@ -27,7 +28,7 @@
     "cloud:batch": "python tools/ai_asset_pipeline/cloud/prepare_batch.py --output-dir tools/ai_asset_pipeline/generated_outputs/candidate_batches",
     "animations:generate": "python tools/animation/generate_character_animation_pack.py",
     "validate:animations": "python tools/animation/generate_character_animation_pack.py --validate-only",
-    "quality": "npm run validate:governance && npm run validate:canon && npm run validate:factions-v4 && npm run validate:phase1-data && npm run validate:skill-tree-visual && npm run validate:python && npm run validate:node && npm run validate:data && npm run validate:cloud && npm run test:cloud && npm run validate:animations && npm run validate:asset-protocol && npm run validate:repository && npm run validate:runtime && npm run validate:release && npm run validate:supreme && npm run validate:deck",
+    "quality": "npm run validate:governance && npm run validate:canon && npm run validate:factions-v4 && npm run validate:phase1-data && npm run validate:skill-tree-visual && npm run validate:bjj-intelligence && npm run validate:python && npm run validate:node && npm run validate:data && npm run validate:cloud && npm run test:cloud && npm run validate:animations && npm run validate:asset-protocol && npm run validate:repository && npm run validate:runtime && npm run validate:release && npm run validate:supreme && npm run validate:deck",
     "build:android:windows": "powershell -ExecutionPolicy Bypass -File tools/build/build_android_debug.ps1",
     "build:android:linux": "bash tools/build/build_android_debug.sh",
     "build:windows": "powershell -ExecutionPolicy Bypass -File tools/build/build_windows_debug.ps1"

--- a/tests/bjj_intelligence/test_fail_closed_contracts.py
+++ b/tests/bjj_intelligence/test_fail_closed_contracts.py
@@ -1,0 +1,32 @@
+import importlib.util
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+VALIDATOR = ROOT / "tools" / "bjj" / "validate_bjj_intelligence.py"
+
+spec = importlib.util.spec_from_file_location("validate_bjj_intelligence", VALIDATOR)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+
+class BJJIntelligenceFailClosedTests(unittest.TestCase):
+    def test_repository_contract_is_fail_closed(self):
+        self.assertEqual(module.validate(), [])
+
+    def test_human_gate_is_not_ai_signed(self):
+        gate = module.load("data/bjj/dossiers/001_baiana_single_leg_human_gate.json")
+        self.assertTrue(gate["assistant_may_recommend_but_not_sign"])
+        self.assertEqual(gate["human_decision"], "PENDING")
+        self.assertFalse(gate["shipping"])
+
+    def test_unknown_license_blocks_video_stages(self):
+        corpus = module.load("data/bjj/corpus/baiana_single_leg_v1.json")
+        self.assertEqual(corpus["custody"]["license_status"], "UNKNOWN")
+        self.assertEqual(corpus["custody"]["status"], "CUSTODY_BLOCKED")
+        self.assertEqual(corpus["stages"]["V2_event_annotation"]["status"], "NOT_STARTED_BLOCKED_BY_V1")
+        self.assertEqual(corpus["stages"]["V3_pose_keypoints"]["status"], "NOT_STARTED_BLOCKED_BY_V1")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/bjj/validate_bjj_intelligence.py
+++ b/tools/bjj/validate_bjj_intelligence.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def load(path):
+    return json.loads((ROOT / path).read_text(encoding="utf-8"))
+
+
+def fail(errors, msg):
+    errors.append(msg)
+
+
+def validate():
+    errors = []
+    required_skills = {
+        ".agents/skills/cria-bjj-fight-intelligence/SKILL.md": ["version: 1.0.0", "fail_closed: true", "shipping_default: false", "generative: auxiliary_only"],
+        ".agents/skills/cria-video-intelligence/SKILL.md": ["version: 0.1.0", "stop_condition: CORPUS_GAP | LICENSE_UNKNOWN | SOURCE_BYTES_MISSING"],
+        ".agents/skills/cria-pixel-motion-pipeline/SKILL.md": ["version: 0.1.0", "generative: auxiliary_only"],
+        ".agents/skills/cria-combat-runtime/SKILL.md": ["version: 0.1.0", "runtime_authority: CombatManager", "runtime_implementation_status: SPEC_ONLY"],
+    }
+    for path, needles in required_skills.items():
+        p = ROOT / path
+        if not p.exists():
+            fail(errors, f"missing skill {path}")
+            continue
+        text = p.read_text(encoding="utf-8")
+        for needle in needles:
+            if needle not in text:
+                fail(errors, f"{path}: missing contract marker {needle}")
+
+    manifest = load("data/visual/production_manifest_v02.json")
+    tech = {x["id"]: x for x in manifest.get("paired_techniques", [])}
+    canonical = tech.get("raspagem_tesoura")
+    if not canonical:
+        fail(errors, "production manifest missing raspagem_tesoura")
+    dossier = load("data/bjj/dossiers/003_raspagem_tesoura.json")
+    if dossier.get("shipping") is not False:
+        fail(errors, "dossier 003 must be shipping=false")
+    proposal = dossier.get("proposal", {})
+    has_conflict = canonical and (
+        proposal.get("frame_spec", {}).get("frames_total") != canonical.get("frames_target")
+        or proposal.get("entry") != canonical.get("entry")
+        or proposal.get("success_states") != [canonical.get("exit")]
+    )
+    if has_conflict and dossier.get("status") != "DRAFT_CONFLICT_PENDING_RESOLUTION":
+        fail(errors, "dossier 003 conflicts with authority but is not blocked")
+    if has_conflict and len(dossier.get("conflicts", [])) < 1:
+        fail(errors, "dossier 003 must enumerate authority conflicts")
+
+    gate = load("data/bjj/dossiers/001_baiana_single_leg_human_gate.json")
+    if gate.get("assistant_may_recommend_but_not_sign") is not True:
+        fail(errors, "AI must not sign human_bjj_gate")
+    if gate.get("human_decision") != "PENDING":
+        fail(errors, "human gate must remain pending until explicit human review")
+    if gate.get("shipping") is not False:
+        fail(errors, "baiana human-gate dossier must remain shipping=false")
+
+    corpus = load("data/bjj/corpus/baiana_single_leg_v1.json")
+    custody = corpus.get("custody", {})
+    if custody.get("license_status") == "UNKNOWN":
+        if custody.get("status") != "CUSTODY_BLOCKED":
+            fail(errors, "unknown license must block custody")
+        for stage in ("V2_event_annotation", "V3_pose_keypoints"):
+            if not str(corpus.get("stages", {}).get(stage, {}).get("status", "")).endswith("BLOCKED_BY_V1"):
+                fail(errors, f"{stage} must be blocked by V1")
+    if corpus.get("evidence_claim") != "NO_VIDEO_ANALYSIS_PERFORMED":
+        fail(errors, "cannot claim video analysis without source bytes")
+
+    return errors
+
+
+if __name__ == "__main__":
+    problems = validate()
+    if problems:
+        for problem in problems:
+            print("FAIL:", problem)
+        raise SystemExit(1)
+    print("BJJ INTELLIGENCE CONTRACT OK; FAIL-CLOSED BLOCKS PRESERVED")


### PR DESCRIPTION
Closes #85

## Entregue
- router `cria-bjj-fight-intelligence@1.0.0`;
- skills `cria-video-intelligence`, `cria-pixel-motion-pipeline`, `cria-combat-runtime` v0.1.0;
- schemas, validator e unittest fail-closed;
- Dossiê #003 registrado sem sobrepor autoridade atual;
- sessão do Dossiê #001 preserva `human_bjj_gate=PENDING`;
- V1 da `baiana_single_leg` inicia cadeia de custódia e bloqueia V2–V3 porque fonte/licença/bytes não foram materializados;
- `npm run quality` passa a incluir `validate:bjj-intelligence`.

## Conflitos detectados, não escondidos
`raspagem_tesoura` proposta: 24 frames + `guard.closed_bottom` + mount/side. Autoridade atual em `production_manifest_v02`: 28 frames + `player_bottom_guard` + `player_top_guard`. O dossiê fica `DRAFT_CONFLICT_PENDING_RESOLUTION`.

## Fora do escopo
- nenhum `CombatManager`/autoload/project.godot alterado;
- nenhum asset promovido;
- nenhum mocap ou análise de vídeo alegado sem evidência;
- nenhum shipping.

## Rollback
Remover os novos skills/data/schemas/tests/tools/docs e restaurar o script do `package.json`.

## Base
`main @ cfb1afa18b0b4bdc5c3eb567276ea1d83823ce98`.
