### PR TITLE
[EPIC 25] HUD v2 four-card hand + fail-closed CardSlot

### DIFF
--- a/data/combat_deck_schema.json
+++ b/data/combat_deck_schema.json
@@ -14,7 +14,7 @@
       "properties": {
         "active": {"const": 5},
         "passive": {"const": 3},
-        "hand": {"const": 3}
+        "hand": {"const": 4}
       },
       "additionalProperties": false
     },
@@ -62,6 +62,13 @@
         "clash_effect": {"type": "object"},
         "response_to_families": {"type": "array", "items": {"type": "string"}},
         "valid_states": {"type": "array", "items": {"type": "string"}},
+        "formats": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"enum": ["GI", "NO-GI"]}
+        },
+        "rarity": {"enum": ["comum", "incomum", "rara", "epica"]},
         "xp": {"type": "integer", "minimum": 0},
         "xp_to_next": {"type": "integer", "minimum": 1},
         "unlocked": {"type": "boolean"}

--- a/data/ruan_deck_inicial.json
+++ b/data/ruan_deck_inicial.json
@@ -2,7 +2,7 @@
   "schema_version": "1.0.0",
   "owner_id": "ruan_macacao",
   "belt": "branca",
-  "limits": {"active": 5, "passive": 3, "hand": 3},
+  "limits": {"active": 5, "passive": 3, "hand": 4},
   "cards": [
     {
       "id": "card_grip_de_ferro_01",
@@ -17,6 +17,8 @@
       "clash_effect": {"grip_pressure_bonus": 0.08},
       "response_to_families": [],
       "valid_states": ["PLAYER_STANDING_NEUTRAL"],
+      "formats": ["GI", "NO-GI"],
+      "rarity": "rara",
       "xp": 0,
       "xp_to_next": 100,
       "unlocked": true
@@ -34,6 +36,8 @@
       "clash_effect": {"takedown_entry_bonus": 0.08},
       "response_to_families": [],
       "valid_states": ["PLAYER_STANDING_NEUTRAL"],
+      "formats": ["GI", "NO-GI"],
+      "rarity": "rara",
       "xp": 0,
       "xp_to_next": 100,
       "unlocked": true
@@ -51,6 +55,8 @@
       "clash_effect": {"defense_efficiency_bonus": 0.12},
       "response_to_families": ["queda"],
       "valid_states": ["PLAYER_STANDING_NEUTRAL"],
+      "formats": ["GI", "NO-GI"],
+      "rarity": "rara",
       "xp": 15,
       "xp_to_next": 180,
       "unlocked": true
@@ -68,6 +74,8 @@
       "clash_effect": {"off_balance_bonus": 0.08},
       "response_to_families": [],
       "valid_states": ["PLAYER_BOTTOM_GUARD"],
+      "formats": ["GI", "NO-GI"],
+      "rarity": "rara",
       "xp": 0,
       "xp_to_next": 100,
       "unlocked": true
@@ -85,6 +93,8 @@
       "clash_effect": {"stabilization_bonus": 0.08},
       "response_to_families": [],
       "valid_states": ["PLAYER_TOP_SIDE"],
+      "formats": ["GI", "NO-GI"],
+      "rarity": "rara",
       "xp": 0,
       "xp_to_next": 100,
       "unlocked": true
@@ -102,6 +112,8 @@
       "clash_effect": {},
       "response_to_families": ["pegada", "pressao"],
       "valid_states": ["PLAYER_STANDING_NEUTRAL"],
+      "formats": ["GI", "NO-GI"],
+      "rarity": "comum",
       "xp": 0,
       "xp_to_next": 100,
       "unlocked": true
@@ -119,6 +131,8 @@
       "clash_effect": {"defense_efficiency_bonus": 0.10},
       "response_to_families": ["dominante", "finalizacao"],
       "valid_states": ["PLAYER_BOTTOM_MOUNT"],
+      "formats": ["GI", "NO-GI"],
+      "rarity": "rara",
       "xp": 20,
       "xp_to_next": 180,
       "unlocked": true
@@ -136,6 +150,8 @@
       "clash_effect": {"defense_efficiency_bonus": 0.08},
       "response_to_families": ["controle", "passagem"],
       "valid_states": ["PLAYER_BOTTOM_SIDE"],
+      "formats": ["GI", "NO-GI"],
+      "rarity": "comum",
       "xp": 0,
       "xp_to_next": 100,
       "unlocked": true
@@ -153,6 +169,8 @@
       "clash_effect": {"submission_pressure_bonus": 0.08},
       "response_to_families": [],
       "valid_states": ["PLAYER_TOP_MOUNT"],
+      "formats": ["GI", "NO-GI"],
+      "rarity": "epica",
       "xp": 0,
       "xp_to_next": 120,
       "unlocked": false
@@ -170,6 +188,8 @@
       "clash_effect": {"submission_pressure_bonus": 0.10},
       "response_to_families": [],
       "valid_states": ["PLAYER_BACK_ATTACK"],
+      "formats": ["GI", "NO-GI"],
+      "rarity": "epica",
       "xp": 0,
       "xp_to_next": 120,
       "unlocked": false

--- a/docs/gameplay/COMBAT_DECK_SYSTEM_V01.md
+++ b/docs/gameplay/COMBAT_DECK_SYSTEM_V01.md
@@ -2,19 +2,20 @@
 
 ## Objetivo
 
-O deck representa estudo, repetição e especialização. Ele não substitui o combate posicional: uma carta só produz bônus se a técnica existir no catálogo, estiver na mão, for compatível com o estado atual e puder pagar seus recursos.
+O deck representa estudo, repetição e especialização. Ele não substitui o combate posicional: uma carta só produz bônus se a técnica existir no catálogo, estiver na mão, for compatível com o estado atual, com o formato atual e puder pagar seus recursos.
 
 ## Contratos
 
 - 5 cartas ativas equipadas;
 - 3 fundamentos passivos;
-- mão determinística de 3 cartas;
+- mão determinística de 4 cartas;
 - níveis 1 a 5 limitados pela faixa;
 - XP individual por uso: 10 no sucesso e 3 na tentativa válida;
 - aperfeiçoamento no Terreiro por XP da técnica ou treino pago com Mestre Dendê;
-- carta usada vai para rotação e a próxima é comprada sem alocação por frame;
+- carta usada volta para a rotação determinística e a próxima é comprada sem alocação por frame;
 - deck e XP persistem no save;
-- técnicas vêm exclusivamente de `data/techniques.json`.
+- técnicas vêm exclusivamente de `data/techniques.json`;
+- `formats` aceita `GI` e/ou `NO-GI`; formato desconhecido falha fechado.
 
 ## Disputa de nível
 
@@ -31,8 +32,8 @@ O bônus total é limitado entre -0,30 e +0,35. Mesmo em domínio técnico, o su
 
 ## Integração
 
-1. `DeckManager` carrega `ruan_deck_inicial.json` e registra a mão.
-2. O HUD permite selecionar uma carta compatível sem pausar.
+1. `DeckManager` carrega `ruan_deck_inicial.json` e registra a mão de quatro cartas.
+2. `CombatDeckHUD` renderiza `CardSlot` e bloqueia visualmente formato, posição, unlock e recursos incompatíveis.
 3. `CombatManager.execute_technique()` procura a carta ligada à técnica.
 4. `TechniqueClashResolver` compara ataque e defesa.
 5. `TechniqueResolver` recebe apenas o modificador limitado.
@@ -41,9 +42,11 @@ O bônus total é limitado entre -0,30 e +0,35. Mesmo em domínio técnico, o su
 
 ## UI
 
-O Terreiro abre o `DeckBuilder`, com coleção à esquerda e slots do Gi à direita. O jogador pode tocar para equipar ou arrastar para substituir um slot. Durante a luta, `CombatDeckHUD` reutiliza três botões fixos e só habilita cartas válidas na posição atual.
+O Terreiro abre o `DeckBuilder`, com coleção à esquerda e slots do Gi à direita. O jogador pode tocar para equipar ou arrastar para substituir um slot. Durante a luta, `CombatDeckHUD` reutiliza quatro `CardSlot`s fixos e só permite seleção quando os gates locais estão satisfeitos.
 
-Atalhos: teclas `1`, `2`, `3`; controle pelo direcional esquerdo, cima e direito; touch pelos três botões fixos. A ativação não pausa a simulação.
+O HUD mostra `DECK 5 · MÃO 4`; não existe `discard_pile` no runtime atual. A rotação usa `draw_cursor` determinístico.
+
+Atalhos: teclas `1`, `2`, `3`, `4`; controle pelo direcional esquerdo, cima, direito e baixo; touch pelos quatro slots. A ativação não pausa a simulação.
 
 ## Segurança e canon
 
@@ -52,12 +55,14 @@ Atalhos: teclas `1`, `2`, `3`; controle pelo direcional esquerdo, cima e direito
 - Finalizações terminam em tap, escape ou intervenção técnica.
 - Não há animação de lesão como prêmio.
 - IA generativa não participa do runtime.
+- Cartas bloqueadas ou incompatíveis permanecem fail-closed.
 
 ## Validação
 
 ```bash
 python tools/validate_lore_output.py data/ruan_deck_inicial.json
+godot --headless --script res://src/tests/test_deck_hand.gd
 npm run quality
 ```
 
-O validador rejeita técnica inexistente, carta duplicada, slot incompatível, carta bloqueada equipada, excesso de slots, nível acima da faixa e identificadores legados.
+O validador rejeita técnica inexistente, carta duplicada, slot incompatível, carta bloqueada equipada, formato inválido, excesso de slots, nível acima da faixa e identificadores legados.

--- a/scenes/ui/CombatDeckHUD.gd
+++ b/scenes/ui/CombatDeckHUD.gd
@@ -1,10 +1,11 @@
 extends CanvasLayer
 
 const VisualTheme = preload("res://src/ui/CriaVisualTheme.gd")
+const PHASE_NAMES := ["DISTANCE", "GRIP", "CLINCH", "TAKEDOWN", "GROUND", "TRANSITION", "TECHNICAL", "RESET"]
 
 @export_enum("GI", "NO-GI") var combat_format := "GI"
 
-var card_slots: Array[CardSlot] = []
+var card_slots: Array = []
 var current_state := "PLAYER_STANDING_NEUTRAL"
 var current_resources: Dictionary = {"gas": 0.0, "focus": 0.0, "moral": 0.0}
 
@@ -47,7 +48,7 @@ func _sync_from_runtime() -> void:
 
 func _on_hand_changed(hand: Array, selected_card_id: String) -> void:
 	for index in range(card_slots.size()):
-		var slot := card_slots[index]
+		var slot = card_slots[index]
 		if index >= hand.size():
 			slot.visible = false
 			continue
@@ -78,7 +79,7 @@ func _unhandled_input(event: InputEvent) -> void:
 func _press_slot(index: int) -> void:
 	if index < 0 or index >= card_slots.size():
 		return
-	var slot := card_slots[index]
+	var slot = card_slots[index]
 	if slot.visible and not slot.is_blocked():
 		_on_card_pressed(slot.card_id)
 
@@ -110,6 +111,8 @@ func _refresh_status() -> void:
 	$Panel/Layout/Status/PositionLabel.text = "POS • %s" % current_state.replace("PLAYER_", "").replace("_", " ")
 	if has_node("/root/CombatManager"):
 		var phase_index := int(CombatManager.phase)
-		var phase_names := CombatManager.CombatPhase.keys()
-		$Panel/Layout/Status/PhaseLabel.text = "FASE • %s" % str(phase_names[phase_index]) if phase_index >= 0 and phase_index < phase_names.size() else "FASE • —"
+		if phase_index >= 0 and phase_index < PHASE_NAMES.size():
+			$Panel/Layout/Status/PhaseLabel.text = "FASE • %s" % PHASE_NAMES[phase_index]
+		else:
+			$Panel/Layout/Status/PhaseLabel.text = "FASE • —"
 	$Panel/Layout/Status/DeckCount.text = "DECK %d · MÃO %d" % [DeckManager.active_deck.size(), DeckManager.hand.size()]

--- a/scenes/ui/CombatDeckHUD.gd
+++ b/scenes/ui/CombatDeckHUD.gd
@@ -2,71 +2,99 @@ extends CanvasLayer
 
 const VisualTheme = preload("res://src/ui/CriaVisualTheme.gd")
 
-var card_buttons: Array[Button] = []
+@export_enum("GI", "NO-GI") var combat_format := "GI"
+
+var card_slots: Array[CardSlot] = []
 var current_state := "PLAYER_STANDING_NEUTRAL"
+var current_resources: Dictionary = {"gas": 0.0, "focus": 0.0, "moral": 0.0}
 
 func _ready() -> void:
-	card_buttons.clear()
-	card_buttons.append($Panel/Layout/Cards/Card1)
-	card_buttons.append($Panel/Layout/Cards/Card2)
-	card_buttons.append($Panel/Layout/Cards/Card3)
-	$Panel.add_theme_stylebox_override("panel", VisualTheme.panel_style(0.92, VisualTheme.GOLD, 2, 8))
+	card_slots = [
+		$Panel/Layout/Cards/Card1,
+		$Panel/Layout/Cards/Card2,
+		$Panel/Layout/Cards/Card3,
+		$Panel/Layout/Cards/Card4,
+	]
+	$Panel.add_theme_stylebox_override("panel", VisualTheme.panel_style(0.94, VisualTheme.GOLD, 2, 8))
 	VisualTheme.style_heading($Panel/Layout/Header/Title, 14, VisualTheme.HONOR)
 	$Panel/Layout/Header/Clash.add_theme_color_override("font_color", VisualTheme.CYAN)
-	for index in range(card_buttons.size()):
-		VisualTheme.apply_action_button(card_buttons[index], VisualTheme.GOLD)
-		card_buttons[index].pressed.connect(_on_card_pressed.bind(index))
+	$Panel/Layout/Status/PositionLabel.add_theme_color_override("font_color", VisualTheme.OFF_WHITE)
+	$Panel/Layout/Status/PhaseLabel.add_theme_color_override("font_color", VisualTheme.HONOR)
+	$Panel/Layout/Status/DeckCount.add_theme_color_override("font_color", VisualTheme.CYAN)
+	for slot in card_slots:
+		slot.pressed_slot.connect(_on_card_pressed)
 	if not SignalBus.combat_deck_hand_changed.is_connected(_on_hand_changed):
 		SignalBus.combat_deck_hand_changed.connect(_on_hand_changed)
 	if not SignalBus.combat_state_changed.is_connected(_on_state_changed):
 		SignalBus.combat_state_changed.connect(_on_state_changed)
 	if not SignalBus.technique_clash_resolved.is_connected(_on_clash):
 		SignalBus.technique_clash_resolved.connect(_on_clash)
+	if not SignalBus.resources_changed.is_connected(_on_resources_changed):
+		SignalBus.resources_changed.connect(_on_resources_changed)
+	if not SignalBus.technique_started.is_connected(_on_technique_started):
+		SignalBus.technique_started.connect(_on_technique_started)
+	DeckManager.set_combat_format(combat_format)
+	_sync_from_runtime()
 	_on_hand_changed(DeckManager.get_hand(), DeckManager.selected_card_id)
 
-func _on_hand_changed(hand: Array, selected_card_id: String) -> void:
-	for index in range(card_buttons.size()):
-		var button := card_buttons[index]
-		if index >= hand.size():
-			button.text = "—"
-			button.disabled = true
-			button.set_meta("card_id", "")
-			continue
-		var card: Dictionary = hand[index]
-		var card_id := str(card.get("id", ""))
-		var cost: Dictionary = card.get("activation_cost", {})
-		var level := int(card.get("level", 1))
-		button.text = "%s\n%s  F%d G%d" % [
-			str(card.get("name", "Técnica")),
-			"◆".repeat(level),
-			int(cost.get("focus", 0)),
-			int(cost.get("gas", 0))
-		]
-		button.set_meta("card_id", card_id)
-		button.disabled = not _is_compatible(card)
-		button.modulate = Color("ffd45a") if card_id == selected_card_id else Color.WHITE
+func _sync_from_runtime() -> void:
+	if has_node("/root/CombatManager"):
+		current_state = CombatManager.get_current_state_name()
+		var fighter: Dictionary = CombatManager.fighters.get(CombatManager.player_id, {})
+		if not fighter.is_empty():
+			current_resources = fighter.duplicate(true)
+	_refresh_status()
 
-func _on_card_pressed(index: int) -> void:
-	if index < 0 or index >= card_buttons.size():
+func _on_hand_changed(hand: Array, selected_card_id: String) -> void:
+	for index in range(card_slots.size()):
+		var slot := card_slots[index]
+		if index >= hand.size():
+			slot.visible = false
+			continue
+		slot.visible = true
+		var card: Dictionary = hand[index]
+		slot.setup(card, combat_format, current_resources, current_state, str(card.get("id", "")) == selected_card_id)
+	_refresh_status()
+
+func _on_card_pressed(card_id: String) -> void:
+	if card_id == "":
 		return
-	var card_id := str(card_buttons[index].get_meta("card_id", ""))
-	if card_id != "":
-		DeckManager.select_card(card_id)
+	DeckManager.select_card(card_id)
 
 func _unhandled_input(event: InputEvent) -> void:
 	if event.is_action_pressed("deck_card_1"):
-		_on_card_pressed(0)
+		_press_slot(0)
 		get_viewport().set_input_as_handled()
 	elif event.is_action_pressed("deck_card_2"):
-		_on_card_pressed(1)
+		_press_slot(1)
 		get_viewport().set_input_as_handled()
 	elif event.is_action_pressed("deck_card_3"):
-		_on_card_pressed(2)
+		_press_slot(2)
 		get_viewport().set_input_as_handled()
+	elif event.is_action_pressed("deck_card_4"):
+		_press_slot(3)
+		get_viewport().set_input_as_handled()
+
+func _press_slot(index: int) -> void:
+	if index < 0 or index >= card_slots.size():
+		return
+	var slot := card_slots[index]
+	if slot.visible and not slot.is_blocked():
+		_on_card_pressed(slot.card_id)
 
 func _on_state_changed(_old_state, new_state) -> void:
 	current_state = str(new_state)
 	_on_hand_changed(DeckManager.get_hand(), DeckManager.selected_card_id)
+
+func _on_resources_changed(fighter_id, resources: Dictionary) -> void:
+	if not has_node("/root/CombatManager") or str(fighter_id) != str(CombatManager.player_id):
+		return
+	current_resources = resources.duplicate(true)
+	_on_hand_changed(DeckManager.get_hand(), DeckManager.selected_card_id)
+
+func _on_technique_started(technique_id, actor_id) -> void:
+	if has_node("/root/CombatManager") and str(actor_id) == str(CombatManager.player_id):
+		$Panel/Layout/Status/PhaseLabel.text = "FASE • %s" % str(technique_id).to_upper()
 
 func _on_clash(result: Dictionary) -> void:
 	var outcome := str(result.get("outcome", "contested"))
@@ -77,6 +105,11 @@ func _on_clash(result: Dictionary) -> void:
 		"counter_window": $Panel/Layout/Header/Clash.text = "JANELA DE CONTRA  %+0.1f" % delta
 		_: $Panel/Layout/Header/Clash.text = "DISPUTA  %+0.1f" % delta
 
-func _is_compatible(card: Dictionary) -> bool:
-	var states: Array = card.get("valid_states", [])
-	return states.is_empty() or states.has(current_state)
+func _refresh_status() -> void:
+	$Panel/Layout/Header/Format.text = combat_format
+	$Panel/Layout/Status/PositionLabel.text = "POS • %s" % current_state.replace("PLAYER_", "").replace("_", " ")
+	if has_node("/root/CombatManager"):
+		var phase_index := int(CombatManager.phase)
+		var phase_names := CombatManager.CombatPhase.keys()
+		$Panel/Layout/Status/PhaseLabel.text = "FASE • %s" % str(phase_names[phase_index]) if phase_index >= 0 and phase_index < phase_names.size() else "FASE • —"
+	$Panel/Layout/Status/DeckCount.text = "DECK %d · MÃO %d" % [DeckManager.active_deck.size(), DeckManager.hand.size()]

--- a/scenes/ui/CombatDeckHUD.tscn
+++ b/scenes/ui/CombatDeckHUD.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=2 format=3]
+[gd_scene load_steps=3 format=3]
 
 [ext_resource type="Script" path="res://scenes/ui/CombatDeckHUD.gd" id="1"]
+[ext_resource type="PackedScene" path="res://scenes/ui/card_slot.tscn" id="2_card"]
 
 [node name="CombatDeckHUD" type="CanvasLayer"]
 layer = 4
@@ -8,10 +9,10 @@ script = ExtResource("1")
 
 [node name="Panel" type="Panel" parent="."]
 anchors_preset = 0
-anchor_left = 0.49
-anchor_top = 0.49
-anchor_right = 0.98
-anchor_bottom = 0.655
+anchor_left = 0.43
+anchor_top = 0.46
+anchor_right = 0.985
+anchor_bottom = 0.71
 
 [node name="Layout" type="VBoxContainer" parent="Panel"]
 layout_mode = 1
@@ -32,9 +33,32 @@ layout_mode = 2
 size_flags_horizontal = 3
 text = "MENTE NO TATAME • MÃO ATUAL"
 
+[node name="Format" type="Label" parent="Panel/Layout/Header"]
+layout_mode = 2
+text = "GI"
+
 [node name="Clash" type="Label" parent="Panel/Layout/Header"]
 layout_mode = 2
 text = "AGUARDANDO DISPUTA"
+horizontal_alignment = 2
+
+[node name="Status" type="HBoxContainer" parent="Panel/Layout"]
+layout_mode = 2
+theme_override_constants/separation = 12
+
+[node name="PositionLabel" type="Label" parent="Panel/Layout/Status"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "POS • EM PÉ"
+
+[node name="PhaseLabel" type="Label" parent="Panel/Layout/Status"]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "FASE • DISTANCE"
+
+[node name="DeckCount" type="Label" parent="Panel/Layout/Status"]
+layout_mode = 2
+text = "DECK 5 · MÃO 4"
 horizontal_alignment = 2
 
 [node name="Cards" type="HBoxContainer" parent="Panel/Layout"]
@@ -42,20 +66,18 @@ layout_mode = 2
 size_flags_vertical = 3
 theme_override_constants/separation = 6
 
-[node name="Card1" type="Button" parent="Panel/Layout/Cards"]
-custom_minimum_size = Vector2(0, 68)
+[node name="Card1" parent="Panel/Layout/Cards" instance=ExtResource("2_card")]
 layout_mode = 2
 size_flags_horizontal = 3
-text = "CARTA 1"
 
-[node name="Card2" type="Button" parent="Panel/Layout/Cards"]
-custom_minimum_size = Vector2(0, 68)
+[node name="Card2" parent="Panel/Layout/Cards" instance=ExtResource("2_card")]
 layout_mode = 2
 size_flags_horizontal = 3
-text = "CARTA 2"
 
-[node name="Card3" type="Button" parent="Panel/Layout/Cards"]
-custom_minimum_size = Vector2(0, 68)
+[node name="Card3" parent="Panel/Layout/Cards" instance=ExtResource("2_card")]
 layout_mode = 2
 size_flags_horizontal = 3
-text = "CARTA 3"
+
+[node name="Card4" parent="Panel/Layout/Cards" instance=ExtResource("2_card")]
+layout_mode = 2
+size_flags_horizontal = 3

--- a/scenes/ui/card_slot.tscn
+++ b/scenes/ui/card_slot.tscn
@@ -1,0 +1,71 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://src/ui/card_slot.gd" id="1_slot"]
+
+[node name="CardSlot" type="PanelContainer"]
+custom_minimum_size = Vector2(132, 112)
+mouse_filter = 0
+script = ExtResource("1_slot")
+
+[node name="Margin" type="MarginContainer" parent="."]
+layout_mode = 2
+theme_override_constants/margin_left = 7
+theme_override_constants/margin_top = 6
+theme_override_constants/margin_right = 7
+theme_override_constants/margin_bottom = 6
+
+[node name="VBox" type="VBoxContainer" parent="Margin"]
+layout_mode = 2
+theme_override_constants/separation = 2
+
+[node name="Header" type="HBoxContainer" parent="Margin/VBox"]
+layout_mode = 2
+
+[node name="CardIcon" type="Label" parent="Margin/VBox/Header"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(20, 18)
+layout_mode = 2
+text = "◈"
+
+[node name="RarityBadge" type="Label" parent="Margin/VBox/Header"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 10
+text = "◆"
+horizontal_alignment = 2
+
+[node name="CardName" type="Label" parent="Margin/VBox"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "CARTA"
+text_overrun_behavior = 3
+
+[node name="CardSt" type="Label" parent="Margin/VBox"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "⚡0  F0  ★1"
+
+[node name="CardPos" type="Label" parent="Margin/VBox"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "POS"
+text_overrun_behavior = 3
+
+[node name="CardFmt" type="Label" parent="Margin/VBox"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "GI+NO-GI"
+
+[node name="LockOverlay" type="Label" parent="."]
+unique_name_in_owner = true
+visible = false
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 2
+text = "🔒"
+horizontal_alignment = 1
+vertical_alignment = 1

--- a/src/autoloads/DeckManager.gd
+++ b/src/autoloads/DeckManager.gd
@@ -2,7 +2,7 @@ extends Node
 
 const ACTIVE_LIMIT := 5
 const PASSIVE_LIMIT := 3
-const HAND_SIZE := 3
+const HAND_SIZE := 4
 const BELT_LEVEL_LIMIT := {
 	"branca": 2,
 	"azul": 3,
@@ -19,6 +19,7 @@ var passive_deck: Array[String] = []
 var hand: Array[String] = []
 var draw_cursor := 0
 var selected_card_id := ""
+var combat_format := "GI"
 
 func _ready() -> void:
 	_ensure_input_actions()
@@ -78,11 +79,27 @@ func get_collection() -> Array:
 	output.sort_custom(func(a: Dictionary, b: Dictionary) -> bool: return str(a.get("name", "")) < str(b.get("name", "")))
 	return output
 
+func set_combat_format(value: String) -> bool:
+	var normalized := value.strip_edges().to_upper()
+	if normalized not in ["GI", "NO-GI"]:
+		combat_format = ""
+		selected_card_id = ""
+		_emit_hand_changed()
+		return false
+	combat_format = normalized
+	if selected_card_id != "" and not _format_is_valid(cards.get(selected_card_id, {})):
+		selected_card_id = ""
+	_emit_hand_changed()
+	return true
+
 func select_card(card_id: String) -> bool:
 	if not hand.has(card_id) or not cards.has(card_id):
 		return false
+	var card: Dictionary = cards.get(card_id, {})
+	if not bool(card.get("unlocked", false)) or not _format_is_valid(card):
+		return false
 	selected_card_id = card_id
-	SignalBus.combat_card_selected.emit(cards[card_id].duplicate(true))
+	SignalBus.combat_card_selected.emit(card.duplicate(true))
 	_emit_hand_changed()
 	return true
 
@@ -97,7 +114,9 @@ func get_attack_card(technique_id: String, resources: Dictionary, current_state:
 		var card: Dictionary = cards.get(card_id, {})
 		if str(card.get("technique_id", "")) != technique_id:
 			continue
-		if not _state_is_valid(card, current_state) or not can_activate(card, resources):
+		if not bool(card.get("unlocked", false)):
+			continue
+		if not _format_is_valid(card) or not _state_is_valid(card, current_state) or not can_activate(card, resources):
 			continue
 		return card.duplicate(true)
 	return {}
@@ -107,6 +126,8 @@ func get_defense_card(attack_family: String, resources: Dictionary, current_stat
 	for card_id in passive_deck + hand:
 		var card: Dictionary = cards.get(card_id, {})
 		if not bool(card.get("unlocked", false)):
+			continue
+		if not _format_is_valid(card):
 			continue
 		var responses: Array = card.get("response_to_families", [])
 		if not responses.has(attack_family):
@@ -248,6 +269,12 @@ func _state_is_valid(card: Dictionary, current_state: String) -> bool:
 	var states: Array = card.get("valid_states", [])
 	return states.is_empty() or states.has(current_state)
 
+func _format_is_valid(card: Dictionary) -> bool:
+	if combat_format == "":
+		return false
+	var formats: Array = card.get("formats", ["GI", "NO-GI"])
+	return formats.has(combat_format)
+
 func _emit_hand_changed() -> void:
 	SignalBus.combat_deck_hand_changed.emit(get_hand(), selected_card_id)
 
@@ -261,7 +288,8 @@ func _ensure_input_actions() -> void:
 	var bindings := [
 		{"action": "deck_card_1", "key": KEY_1, "joy": JOY_BUTTON_DPAD_LEFT},
 		{"action": "deck_card_2", "key": KEY_2, "joy": JOY_BUTTON_DPAD_UP},
-		{"action": "deck_card_3", "key": KEY_3, "joy": JOY_BUTTON_DPAD_RIGHT}
+		{"action": "deck_card_3", "key": KEY_3, "joy": JOY_BUTTON_DPAD_RIGHT},
+		{"action": "deck_card_4", "key": KEY_4, "joy": JOY_BUTTON_DPAD_DOWN}
 	]
 	for binding in bindings:
 		var action := StringName(binding["action"])

--- a/src/tests/test_deck_hand.gd
+++ b/src/tests/test_deck_hand.gd
@@ -1,0 +1,80 @@
+extends SceneTree
+## Headless smoke do contrato canônico: DeckManager + CardSlot.
+## godot --headless --script res://src/tests/test_deck_hand.gd
+
+const SLOT_SCENE := "res://scenes/ui/card_slot.tscn"
+
+func _init() -> void:
+	call_deferred("_run")
+
+func _run() -> void:
+	assert(has_node("/root/DeckManager"), "DeckManager autoload ausente")
+	assert(FileAccess.file_exists(SLOT_SCENE), "card_slot.tscn ausente")
+
+	var cards: Array = [
+		_card("c1", "Baiana", ["GI", "NO-GI"], true, {"focus": 1, "gas": 2}),
+		_card("c2", "Arco e Flecha", ["GI"], true, {"focus": 1}),
+		_card("c3", "Sprawl", ["GI", "NO-GI"], true, {}),
+		_card("c4", "Tesoura", ["GI", "NO-GI"], true, {"focus": 1}),
+		_card("c5", "Knee Cut", ["GI", "NO-GI"], true, {"gas": 1}),
+		_card("c6", "Heel Hook", ["NO-GI"], false, {"focus": 2}),
+	]
+	var source := {
+		"schema_version": "1.0.0",
+		"owner_id": "ruan_macacao",
+		"belt": "branca",
+		"limits": {"active": 5, "passive": 3, "hand": 4},
+		"cards": cards,
+		"equipped": {"active": ["c1", "c2", "c3", "c4", "c5"], "passive": []}
+	}
+	var configured: Dictionary = DeckManager.configure_from_data(source)
+	assert(configured.get("ok", false), "configure_from_data falhou")
+	assert(DeckManager.hand.size() == 4, "mão inicial deve ter 4 cartas")
+	assert(DeckManager.active_deck.size() == 5, "deck ativo deve manter 5 cartas")
+
+	assert(DeckManager.set_combat_format("NO-GI"), "NO-GI deve ser formato válido")
+	assert(not DeckManager.select_card("c2"), "Arco e Flecha GI-only deve bloquear em NO-GI")
+	assert(DeckManager.select_card("c1"), "carta GI+NO-GI deve selecionar")
+	DeckManager.consume_used_card("c1", true)
+	assert(DeckManager.hand.size() == 4, "mão deve recompor para 4")
+	var hand_ids: Array[String] = []
+	for item in DeckManager.get_hand():
+		hand_ids.append(str(item.get("id", "")))
+	assert(hand_ids.has("c5"), "rotação determinística deve puxar a quinta carta")
+	assert(not DeckManager.select_card("c6"), "carta bloqueada não pode ser selecionada")
+
+	var packed := load(SLOT_SCENE) as PackedScene
+	assert(packed != null, "falha ao carregar CardSlot")
+	var slot: CardSlot = packed.instantiate()
+	get_root().add_child(slot)
+	var rich_resources := {"gas": 100.0, "focus": 100.0, "moral": 100.0}
+	slot.setup(cards[1], "NO-GI", rich_resources, "PLAYER_STANDING_NEUTRAL")
+	assert(slot.is_blocked() and slot.block_reason == "FORMAT", "slot deve bloquear formato incompatível")
+	slot.setup(cards[0], "NO-GI", {"gas": 0.0, "focus": 0.0, "moral": 100.0}, "PLAYER_STANDING_NEUTRAL")
+	assert(slot.is_blocked() and slot.block_reason == "STAMINA", "slot deve bloquear recurso insuficiente")
+	slot.setup(cards[0], "NO-GI", rich_resources, "PLAYER_STANDING_NEUTRAL")
+	assert(not slot.is_blocked(), "slot deve liberar carta válida com recursos")
+
+	print("✅ test_deck_hand: mão 4 + formato + lock + recursos + CardSlot PASSOU")
+	quit(0)
+
+func _card(id: String, title: String, formats: Array, unlocked: bool, activation_cost: Dictionary) -> Dictionary:
+	return {
+		"id": id,
+		"name": title,
+		"kind": "active",
+		"category": "queda",
+		"technique_id": "test_%s" % id,
+		"level": 1,
+		"base_power": 10,
+		"activation_cost": activation_cost,
+		"passive_effect": {},
+		"clash_effect": {},
+		"response_to_families": [],
+		"valid_states": ["PLAYER_STANDING_NEUTRAL"],
+		"formats": formats,
+		"rarity": "rara",
+		"xp": 0,
+		"xp_to_next": 100,
+		"unlocked": unlocked,
+	}

--- a/src/tests/test_deck_hand.gd
+++ b/src/tests/test_deck_hand.gd
@@ -8,7 +8,7 @@ func _init() -> void:
 	call_deferred("_run")
 
 func _run() -> void:
-	assert(has_node("/root/DeckManager"), "DeckManager autoload ausente")
+	assert(get_root().get_node_or_null("DeckManager") != null, "DeckManager autoload ausente")
 	assert(FileAccess.file_exists(SLOT_SCENE), "card_slot.tscn ausente")
 
 	var cards: Array = [

--- a/src/ui/card_slot.gd
+++ b/src/ui/card_slot.gd
@@ -50,7 +50,8 @@ func setup(
 ) -> void:
 	_spec = spec.duplicate(true)
 	card_id = str(spec.get("id", ""))
-	name_lbl.text = str(spec.get("name", spec.get("pt", card_id if card_id != "" else "CARTA")))
+	var fallback_name := card_id if card_id != "" else "CARTA"
+	name_lbl.text = str(spec.get("name", spec.get("pt", fallback_name)))
 	var technique := _get_technique(spec)
 	var technique_gas := _technique_cost(technique, "gas")
 	var activation: Dictionary = spec.get("activation_cost", {})
@@ -59,9 +60,13 @@ func setup(
 	st_lbl.text = "⚡%d  F%d  ★%d" % [int(round(technique_gas)), extra_focus, level]
 	pos_lbl.text = _position_label(spec.get("valid_states", []))
 	var formats: Array = spec.get("formats", ["GI", "NO-GI"])
-	fmt_lbl.text = "+".join(formats)
+	var format_labels := PackedStringArray()
+	for format_value in formats:
+		format_labels.append(str(format_value))
+	fmt_lbl.text = "+".join(format_labels)
 	icon_lbl.text = _category_icon(str(spec.get("category", "transicao")))
-	var rarity := str(spec.get("rarity", "epica" if str(spec.get("category", "")) == "finalizacao" else "rara"))
+	var rarity_fallback := "epica" if str(spec.get("category", "")) == "finalizacao" else "rara"
+	var rarity := str(spec.get("rarity", rarity_fallback))
 	rarity_badge.text = "◆" if rarity == "epica" else "◇"
 	rarity_badge.modulate = Color("8b00ff") if rarity == "epica" else VisualTheme.GOLD
 
@@ -133,7 +138,7 @@ func _position_label(states_variant) -> String:
 	var states: Array = states_variant if typeof(states_variant) == TYPE_ARRAY else []
 	if states.is_empty():
 		return "QUALQUER POS."
-	var labels: Array[String] = []
+	var labels := PackedStringArray()
 	for state in states:
 		labels.append(str(STATE_LABELS.get(str(state), str(state))))
 	return " / ".join(labels)

--- a/src/ui/card_slot.gd
+++ b/src/ui/card_slot.gd
@@ -1,0 +1,161 @@
+class_name CardSlot
+extends PanelContainer
+## Slot interativo da mão canônica do DeckManager.
+## Fail-closed para formato, posição, unlock e recursos.
+
+signal pressed_slot(card_id: String)
+
+const VisualTheme = preload("res://src/ui/CriaVisualTheme.gd")
+
+const STATE_LABELS := {
+	"PLAYER_STANDING_NEUTRAL": "EM PÉ",
+	"PLAYER_TOP_CLINCH": "CLINCH TOP",
+	"PLAYER_BOTTOM_CLINCH": "CLINCH BOTTOM",
+	"PLAYER_TOP_GUARD": "GUARDA TOP",
+	"PLAYER_BOTTOM_GUARD": "GUARDA",
+	"PLAYER_TOP_SIDE": "LATERAL TOP",
+	"PLAYER_BOTTOM_SIDE": "LATERAL BOTTOM",
+	"PLAYER_TOP_MOUNT": "MONTADA",
+	"PLAYER_BOTTOM_MOUNT": "SOB MONTADA",
+	"PLAYER_BACK_ATTACK": "COSTAS",
+	"PLAYER_BACK_DEFENSE": "DEF. COSTAS",
+	"PLAYER_SUBMISSION_ATTACK": "FINALIZAÇÃO",
+	"PLAYER_SUBMISSION_DEFENSE": "DEF. FINALIZAÇÃO",
+	"RESET": "RESET"
+}
+
+@onready var name_lbl: Label = %CardName
+@onready var st_lbl: Label = %CardSt
+@onready var pos_lbl: Label = %CardPos
+@onready var fmt_lbl: Label = %CardFmt
+@onready var icon_lbl: Label = %CardIcon
+@onready var lock_ov: Label = %LockOverlay
+@onready var rarity_badge: Label = %RarityBadge
+
+var card_id: String = ""
+var block_reason: String = ""
+var _spec: Dictionary = {}
+
+func _ready() -> void:
+	mouse_default_cursor_shape = Control.CURSOR_POINTING_HAND
+	focus_mode = Control.FOCUS_ALL
+	_apply_style(false, false)
+
+func setup(
+	spec: Dictionary,
+	combat_format: String,
+	resources: Dictionary,
+	current_state: String,
+	selected: bool = false
+) -> void:
+	_spec = spec.duplicate(true)
+	card_id = str(spec.get("id", ""))
+	name_lbl.text = str(spec.get("name", spec.get("pt", card_id if card_id != "" else "CARTA")))
+	var technique := _get_technique(spec)
+	var technique_gas := _technique_cost(technique, "gas")
+	var activation: Dictionary = spec.get("activation_cost", {})
+	var extra_focus := int(activation.get("focus", 0))
+	var level := int(spec.get("level", 1))
+	st_lbl.text = "⚡%d  F%d  ★%d" % [int(round(technique_gas)), extra_focus, level]
+	pos_lbl.text = _position_label(spec.get("valid_states", []))
+	var formats: Array = spec.get("formats", ["GI", "NO-GI"])
+	fmt_lbl.text = "+".join(formats)
+	icon_lbl.text = _category_icon(str(spec.get("category", "transicao")))
+	var rarity := str(spec.get("rarity", "epica" if str(spec.get("category", "")) == "finalizacao" else "rara"))
+	rarity_badge.text = "◆" if rarity == "epica" else "◇"
+	rarity_badge.modulate = Color("8b00ff") if rarity == "epica" else VisualTheme.GOLD
+
+	block_reason = _block_reason(spec, technique, combat_format, resources, current_state)
+	lock_ov.visible = block_reason != ""
+	lock_ov.text = "🔒\n%s" % block_reason if block_reason != "" else ""
+	tooltip_text = block_reason if block_reason != "" else str(spec.get("note", ""))
+	_apply_style(selected, block_reason != "")
+
+func is_blocked() -> bool:
+	return block_reason != ""
+
+func _gui_input(event: InputEvent) -> void:
+	if is_blocked():
+		return
+	if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
+		pressed_slot.emit(card_id)
+		accept_event()
+	elif event is InputEventKey and event.pressed and (event.keycode == KEY_ENTER or event.keycode == KEY_SPACE):
+		pressed_slot.emit(card_id)
+		accept_event()
+
+func _block_reason(
+	spec: Dictionary,
+	technique: Dictionary,
+	combat_format: String,
+	resources: Dictionary,
+	current_state: String
+) -> String:
+	if card_id == "":
+		return "CARD"
+	if not bool(spec.get("unlocked", false)):
+		return "LOCKED"
+	var formats: Array = spec.get("formats", ["GI", "NO-GI"])
+	if combat_format == "" or not formats.has(combat_format):
+		return "FORMAT"
+	var states: Array = spec.get("valid_states", [])
+	if not states.is_empty() and not states.has(current_state):
+		return "POSIÇÃO"
+	var activation: Dictionary = spec.get("activation_cost", {})
+	var total_gas := float(activation.get("gas", 0.0)) + _technique_cost(technique, "gas")
+	var total_focus := float(activation.get("focus", 0.0)) + _technique_cost(technique, "focus")
+	var total_moral := _technique_cost(technique, "moral")
+	if float(resources.get("gas", 0.0)) < total_gas:
+		return "STAMINA"
+	if float(resources.get("focus", 0.0)) < total_focus:
+		return "FOCO"
+	if float(resources.get("moral", 0.0)) < total_moral:
+		return "MORAL"
+	return ""
+
+func _get_technique(spec: Dictionary) -> Dictionary:
+	if not has_node("/root/DataRegistry"):
+		return {}
+	var technique_id := str(spec.get("technique_id", ""))
+	if technique_id == "":
+		return {}
+	return DataRegistry.get_technique(technique_id)
+
+func _technique_cost(technique: Dictionary, resource: String) -> float:
+	if technique.is_empty():
+		return 0.0
+	var cost: Dictionary = technique.get("cost", technique.get("custo", {}))
+	if resource == "focus":
+		return float(cost.get("focus", cost.get("foco", technique.get("focus_cost", 0.0))))
+	return float(cost.get(resource, technique.get("%s_cost" % resource, 0.0)))
+
+func _position_label(states_variant) -> String:
+	var states: Array = states_variant if typeof(states_variant) == TYPE_ARRAY else []
+	if states.is_empty():
+		return "QUALQUER POS."
+	var labels: Array[String] = []
+	for state in states:
+		labels.append(str(STATE_LABELS.get(str(state), str(state))))
+	return " / ".join(labels)
+
+func _category_icon(category: String) -> String:
+	match category:
+		"finalizacao": return "◈"
+		"queda": return "▼"
+		"passagem": return "→"
+		"raspagem": return "↻"
+		"controle": return "■"
+		"defesa": return "◆"
+		"pegada": return "✦"
+		_: return "●"
+
+func _apply_style(selected: bool, blocked: bool) -> void:
+	if blocked:
+		add_theme_stylebox_override("panel", VisualTheme.panel_style(0.92, Color("4a4a4a"), 2, 6))
+		modulate = Color(0.48, 0.48, 0.48, 1.0)
+	elif selected:
+		add_theme_stylebox_override("panel", VisualTheme.panel_style(0.98, VisualTheme.HONOR, 3, 6))
+		modulate = Color.WHITE
+	else:
+		add_theme_stylebox_override("panel", VisualTheme.panel_style(0.94, VisualTheme.GOLD, 2, 6))
+		modulate = Color.WHITE

--- a/tests/runtime_smoke.gd
+++ b/tests/runtime_smoke.gd
@@ -125,7 +125,7 @@ func _test_combat_deck() -> void:
 		return
 	deck_manager.call("configure_from_data", data_registry.get("combat_deck"))
 	var hand: Array = deck_manager.call("get_hand")
-	_assert(hand.size() == 3, "Mao inicial do deck nao possui 3 cartas")
+	_assert(hand.size() == 4, "Mao inicial do deck nao possui 4 cartas")
 	var techniques: Dictionary = data_registry.get("techniques")
 	for card_value in deck_manager.call("get_collection"):
 		var card: Dictionary = card_value

--- a/tools/validate_lore_output.py
+++ b/tools/validate_lore_output.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 from __future__ import annotations
 
 import argparse

--- a/tools/validate_lore_output.py
+++ b/tools/validate_lore_output.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 from __future__ import annotations
 
 import argparse
@@ -51,8 +50,8 @@ def validate_deck(path: Path) -> dict[str, Any]:
     max_level = BELT_LEVEL_LIMIT.get(belt, 0)
 
     limits = deck.get("limits", {})
-    if limits != {"active": 5, "passive": 3, "hand": 3}:
-        errors.append("limites devem ser 5 ativas, 3 passivas e mão de 3")
+    if limits != {"active": 5, "passive": 3, "hand": 4}:
+        errors.append("limites devem ser 5 ativas, 3 passivas e mão de 4")
 
     cards = deck.get("cards", [])
     card_ids = [str(card.get("id", "")) for card in cards]
@@ -77,6 +76,9 @@ def validate_deck(path: Path) -> dict[str, Any]:
             errors.append(f"{card_id}: nível {level} excede limite {max_level} da faixa {belt}")
         if float(card.get("base_power", -1)) < 0 or float(card.get("base_power", 31)) > 30:
             errors.append(f"{card_id}: base_power fora de 0..30")
+        formats = card.get("formats", ["GI", "NO-GI"])
+        if not isinstance(formats, list) or not formats or any(fmt not in {"GI", "NO-GI"} for fmt in formats):
+            errors.append(f"{card_id}: formats inválido")
         if technique_id in technique_names and str(card.get("name", "")) != technique_names[technique_id]:
             warnings.append(f"{card_id}: nome difere do catálogo ({technique_names[technique_id]})")
 


### PR DESCRIPTION
## Escopo

Integra o HUD v2 ao runtime canônico existente, sem criar `DeckSystem`/`CombatEngine` paralelos.

### Implementado
- `CardSlot` interativo com gates fail-closed de unlock, formato, posição e recursos.
- `CombatDeckHUD` migrado de 3 botões para 4 slots canônicos.
- `DeckManager.HAND_SIZE` = 4 e binding `deck_card_4` (4 / D-pad baixo).
- gate de `formats` no `DeckManager` (`GI` / `NO-GI`, formato desconhecido bloqueia).
- schema e `ruan_deck_inicial.json` alinhados para mão de 4.
- `validate_lore_output.py` atualizado.
- smoke dedicado `src/tests/test_deck_hand.gd` para mão 4 + formato + lock + recursos + rotação determinística.
- `tests/runtime_smoke.gd` migrado de mão 3 para mão 4.
- documentação do contrato atualizada; HUD exibe `DECK 5 · MÃO 4`, sem inventar `discard_pile`.

### Decisões arquiteturais
- `DeckManager` permanece autoridade única do deck.
- `CombatManager` permanece autoridade única do combate.
- Nenhum `cards_combate.json` paralelo foi introduzido.
- O custo visual do slot deriva da técnica canônica; `activation_cost` continua sendo sobretaxa da carta.

### Gates
O ambiente local desta conversa não possui binário `godot`, portanto o teste headless dedicado não pôde ser executado localmente. Os workflows do GitHub estão sendo usados como gate real do branch.

Status no head atual:
- Repository Governance ✅
- Validate Cria Data ✅
- Cria Runtime Audit ✅
- Repository Quality ✅
- Full Game Hardening ⏳

PR mantido como draft até o hardening final ficar verde.
