### PR TITLE
feat(combat): stage deterministic BJJ reducer v2 for Ruan × Davi slice

### DIFF
--- a/.github/workflows/bjj-reducer-v2.yml
+++ b/.github/workflows/bjj-reducer-v2.yml
@@ -1,0 +1,46 @@
+name: BJJ Reducer V2 Slice
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "data/bjj/**"
+      - "data/combat/bjj_*"
+      - "src/combat/BJJ*.gd"
+      - "src/ai/BJJ*.gd"
+      - "tests/bjj_reducer_v2_smoke.gd"
+      - "tests/test_bjj_reducer_v2_contract.py"
+      - "tools/data/validate_bjj_reducer_v2_slice.py"
+      - "package.json"
+      - ".github/workflows/bjj-reducer-v2.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  contract-and-godot-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Validate reducer-v2 contract
+        run: |
+          python tools/data/validate_bjj_reducer_v2_slice.py
+          python -m unittest discover -s tests -p 'test_bjj_reducer_v2_contract.py'
+      - name: Download Godot 4.2.2
+        run: |
+          curl -L --fail --retry 3 \
+            -o godot.zip \
+            https://github.com/godotengine/godot/releases/download/4.2.2-stable/Godot_v4.2.2-stable_linux.x86_64.zip
+          unzip -q godot.zip
+          mv Godot_v4.2.2-stable_linux.x86_64 godot
+          chmod +x godot
+          ./godot --version
+      - name: Import project
+        run: timeout 180 ./godot --headless --editor --path . --import
+      - name: BJJ reducer-v2 smoke
+        run: ./godot --headless --path . --script res://tests/bjj_reducer_v2_smoke.gd

--- a/data/bjj/bjj_kg_slice_ruan_davi_v1.json
+++ b/data/bjj/bjj_kg_slice_ruan_davi_v1.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "cria.bjj_kg.slice_fixture.v1",
+  "version": "1.0.0",
+  "status": "SLICE_FIXTURE_NONCANONICAL",
+  "purpose": "Executable Ruan x Davi fixture for reducer-v2 validation while the full 40/120/10 F1 payload remains incomplete in chat.",
+  "runtime_authority": false,
+  "full_graph_claim": false,
+  "rules_authority": "data/combat/bjj_rulesets_verified_v1.json",
+  "positions": [
+    {"id":"standing_neutral","pt":"Em Pé Neutro","cat":"standing","side":"neutral"},
+    {"id":"front_headlock","pt":"Front Headlock","cat":"clinch","side":"top"},
+    {"id":"closed_guard","pt":"Guarda Fechada","cat":"guard","side":"bottom"},
+    {"id":"half_guard_top","pt":"Meia-Guarda (Topo)","cat":"half","side":"top"},
+    {"id":"knee_shield_half","pt":"Meia-Guarda Knee-Shield","cat":"half","side":"bottom"},
+    {"id":"side_control","pt":"Cem Quilos / Side","cat":"dominant","side":"top"},
+    {"id":"mount_high","pt":"Montada Alta","cat":"dominant","side":"top"},
+    {"id":"back_mount_seatbelt","pt":"Costas c/ Seatbelt","cat":"dominant","side":"top"},
+    {"id":"inside_ashi_garami","pt":"Ashi Garami Interno","cat":"leglock","side":"top"},
+    {"id":"submission","pt":"Finalização","cat":"terminal","side":"neutral"}
+  ],
+  "techniques": [
+    {
+      "id":"t001","pt":"Baiana Double-Leg","type":"takedown","from":"standing_neutral","to":"half_guard_top",
+      "actor_role_from":"neutral","actor_role_to":"top","authoring_prior":0.55,"prior_status":"UNCALIBRATED_EXPERT_HEURISTIC","empirical_success":null,
+      "gas":20,"availability":{"gi":true,"nogi":true},
+      "legality":{"ibjjf_v6":{"allowed":true,"belt_or_skill_division":["slice_any"],"age_division":["adult"]},"adcc_championship_current":{"allowed":true,"belt_or_skill_division":["slice_any"],"age_division":["adult"]},"clandestine_cria_v1":{"allowed":true,"belt_or_skill_division":["slice_any"],"age_division":["adult"]}},
+      "counters":[{"technique_id":"slice_sprawl","outcome":"redirect_to_front_headlock"}],
+      "scoring_event":"takedown","stabilization_seconds":3.0
+    },
+    {
+      "id":"slice_sprawl","pt":"Sprawl + Front Headlock","type":"defense","from":"standing_neutral","to":"front_headlock",
+      "actor_role_from":"neutral","actor_role_to":"top","authoring_prior":1.0,"prior_status":"UNCALIBRATED_EXPERT_HEURISTIC","empirical_success":null,
+      "gas":8,"availability":{"gi":true,"nogi":true},
+      "legality":{"ibjjf_v6":{"allowed":true,"belt_or_skill_division":["slice_any"],"age_division":["adult"]},"adcc_championship_current":{"allowed":true,"belt_or_skill_division":["slice_any"],"age_division":["adult"]},"clandestine_cria_v1":{"allowed":true,"belt_or_skill_division":["slice_any"],"age_division":["adult"]}},
+      "counters":[]
+    },
+    {
+      "id":"t005","pt":"Puxada de Guarda","type":"transition","from":"standing_neutral","to":"closed_guard",
+      "actor_role_from":"neutral","actor_role_to":"bottom","authoring_prior":0.90,"prior_status":"UNCALIBRATED_EXPERT_HEURISTIC","empirical_success":null,
+      "gas":5,"availability":{"gi":true,"nogi":true},
+      "legality":{"ibjjf_v6":{"allowed":true,"belt_or_skill_division":["slice_any"],"age_division":["adult"]},"adcc_championship_current":{"allowed":true,"belt_or_skill_division":["slice_any"],"age_division":["adult"]},"clandestine_cria_v1":{"allowed":true,"belt_or_skill_division":["slice_any"],"age_division":["adult"]}},
+      "counters":[]
+    },
+    {
+      "id":"t025","pt":"Body-Lock Pass","type":"pass","from":"half_guard_top","to":"side_control",
+      "actor_role_from":"top","actor_role_to":"top","authoring_prior":0.55,"prior_status":"UNCALIBRATED_EXPERT_HEURISTIC","empirical_success":null,
+      "gas":18,"availability":{"gi":true,"nogi":true},
+      "legality":{"ibjjf_v6":{"allowed":true,"belt_or_skill_division":["slice_any"],"age_division":["adult"]},"adcc_championship_current":{"allowed":true,"belt_or_skill_division":["slice_any"],"age_division":["adult"]},"clandestine_cria_v1":{"allowed":true,"belt_or_skill_division":["slice_any"],"age_division":["adult"]}},
+      "counters":[{"technique_id":"t049","outcome":"redirect_to_knee_shield"}],
+      "scoring_event":"guard_pass","stabilization_seconds":3.0
+    },
+    {
+      "id":"t049","pt":"Knee-Shield Frame","type":"defense","from":"half_guard_top","to":"knee_shield_half",
+      "actor_role_from":"bottom","actor_role_to":"bottom","authoring_prior":0.60,"prior_status":"UNCALIBRATED_EXPERT_HEURISTIC","empirical_success":null,
+      "gas":6,"availability":{"gi":true,"nogi":true},
+      "legality":{"ibjjf_v6":{"allowed":true,"belt_or_skill_division":["slice_any"],"age_division":["adult"]},"adcc_championship_current":{"allowed":true,"belt_or_skill_division":["slice_any"],"age_division":["adult"]},"clandestine_cria_v1":{"allowed":true,"belt_or_skill_division":["slice_any"],"age_division":["adult"]}},
+      "counters":[]
+    },
+    {
+      "id":"slice_side_to_mount","pt":"Side Control → Montada Alta","type":"transition","from":"side_control","to":"mount_high",
+      "actor_role_from":"top","actor_role_to":"top","authoring_prior":1.0,"prior_status":"UNCALIBRATED_EXPERT_HEURISTIC","empirical_success":null,
+      "gas":8,"availability":{"gi":true,"nogi":true},
+      "legality":{"ibjjf_v6":{"allowed":true,"belt_or_skill_division":["slice_any"],"age_division":["adult"]},"adcc_championship_current":{"allowed":true,"belt_or_skill_division":["slice_any"],"age_division":["adult"]},"clandestine_cria_v1":{"allowed":true,"belt_or_skill_division":["slice_any"],"age_division":["adult"]}},
+      "counters":[],"scoring_event":"mount","stabilization_seconds":3.0
+    },
+    {
+      "id":"t057","pt":"Chave de Braço (Mount)","type":"submission","from":"mount_high","to":"submission",
+      "actor_role_from":"top","actor_role_to":"neutral","authoring_prior":1.0,"prior_status":"UNCALIBRATED_EXPERT_HEURISTIC","empirical_success":null,
+      "gas":16,"availability":{"gi":true,"nogi":true},
+      "legality":{"ibjjf_v6":{"allowed":true,"belt_or_skill_division":["slice_any"],"age_division":["adult"]},"adcc_championship_current":{"allowed":true,"belt_or_skill_division":["slice_any"],"age_division":["adult"]},"clandestine_cria_v1":{"allowed":true,"belt_or_skill_division":["slice_any"],"age_division":["adult"]}},
+      "counters":[]
+    },
+    {
+      "id":"slice_heel_hook","pt":"Heel Hook Interno — slice legality gate","type":"submission","from":"inside_ashi_garami","to":"submission",
+      "actor_role_from":"top","actor_role_to":"neutral","authoring_prior":1.0,"prior_status":"UNCALIBRATED_EXPERT_HEURISTIC","empirical_success":null,
+      "gas":14,"availability":{"gi":false,"nogi":true},
+      "restricted_leglock":true,
+      "legality":{"ibjjf_v6":{"allowed":false,"belt_or_skill_division":["slice_any"],"age_division":["adult"]},"adcc_championship_current":{"allowed":true,"belt_or_skill_division":["slice_any"],"age_division":["adult"]},"clandestine_cria_v1":{"allowed":true,"belt_or_skill_division":["slice_any"],"age_division":["adult"]}},
+      "counters":[]
+    }
+  ],
+  "chains": [],
+  "source_status": {
+    "received_complete_positions": true,
+    "received_complete_techniques": false,
+    "last_complete_received_technique_id": "t092",
+    "next_received_fragment_started_at": "t093",
+    "received_complete_chains": false,
+    "promotion_blocked": true
+  }
+}

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -26,6 +26,7 @@ Este arquivo é a porta de entrada da documentação ativa. Antes de criar um do
 
 - [`CRIA_DO_TATAME_SUPREME_BUILD_SPEC_V1.md`](CRIA_DO_TATAME_SUPREME_BUILD_SPEC_V1.md) — escopo de produto;
 - [`gameplay/COMBAT_DECK_SYSTEM_V01.md`](gameplay/COMBAT_DECK_SYSTEM_V01.md) — deck atual integrado à `main`;
+- [`gameplay/BJJ_REDUCER_V2_SLICE.md`](gameplay/BJJ_REDUCER_V2_SLICE.md) — contrato draft do reducer orientado a grafo para o vertical slice Ruan × Davi;
 - `canon/` — personagens, facções, mundo e narrativa aprovados;
 - `gameplay/` — combate, progressão, regras e economia.
 
@@ -52,6 +53,7 @@ Este arquivo é a porta de entrada da documentação ativa. Antes de criar um do
 - [`../tools/audit/validate_canon_contract_v4_1.py`](../tools/audit/validate_canon_contract_v4_1.py) — gate do cânone e da D10;
 - [`../tools/audit/validate_faction_migration_v4_2.py`](../tools/audit/validate_faction_migration_v4_2.py) — gate das três facções, aliases e save v5;
 - [`../tools/art/validate_sprite_forge.py`](../tools/art/validate_sprite_forge.py) — gate de consistência entre ações de personagens;
+- [`../tools/data/validate_bjj_reducer_v2_slice.py`](../tools/data/validate_bjj_reducer_v2_slice.py) — gate fail-closed do reducer v2 e do fixture Ruan × Davi;
 - [`../tools/ai_asset_pipeline/cloud/validate_cloud_pipeline.py`](../tools/ai_asset_pipeline/cloud/validate_cloud_pipeline.py) — gate offline do adaptador de nuvem.
 
 ## Status dos documentos
@@ -61,7 +63,7 @@ Use um destes estados no início de documentos novos quando o contexto não for 
 - `CANONICAL` — fonte ativa e autoritativa;
 - `ACTIVE` — documento de trabalho vigente;
 - `DRAFT` — proposta ainda não integrada;
-- `SUPERSEDED` — substituído; deve apontar para o sucessor;
+- `SUPERSEDED` — substituído; deve apontar para seu sucessor;
 - `ARCHIVED` — histórico, não orienta implementação.
 
 Prompts, relatórios antigos, concept arts e branches não são automaticamente fontes canônicas.

--- a/docs/gameplay/BJJ_REDUCER_V2_SLICE.md
+++ b/docs/gameplay/BJJ_REDUCER_V2_SLICE.md
@@ -1,0 +1,55 @@
+# BJJ Reducer V2 — Vertical Slice Contract
+
+**Status:** DRAFT  
+**Branch:** `feat/bjj-reducer-v2-slice`  
+**Runtime authority:** **NO**  
+**Target:** prove the Ruan × Davi graph-driven combat path without replacing the canonical `CombatManager`.
+
+## Scope
+
+This batch stages the first executable Knowledge Graph reducer behind a noncanonical slice fixture.
+
+It deliberately does **not** claim that the complete F1 Knowledge Graph exists in the repository. The chat payload received so far is complete only through `t092`; the next message fragments at `t093`, and the final chains were not received intact. The canonical `data/bjj/bjj_knowledge_graph_v1.json` therefore remains absent until it can pass the full `40 positions / 120 techniques / 10 chains` promotion gate.
+
+## Artifacts
+
+- `data/bjj/bjj_kg_slice_ruan_davi_v1.json` — executable, noncanonical Ruan × Davi fixture;
+- `src/combat/BJJGraphLoader.gd` — fail-closed loader and graph validation;
+- `src/combat/BJJRulesEngineV1.gd` — versioned scoring and legality queries;
+- `src/combat/BJJGraphReducerV2.gd` — pure seeded reducer;
+- `src/ai/BJJUtilityScorerV2.gd` — deterministic utility ranking with stable tie-break;
+- `tools/data/validate_bjj_reducer_v2_slice.py` — repository-level gate;
+- `tests/test_bjj_reducer_v2_contract.py` — contract regression tests;
+- `tests/bjj_reducer_v2_smoke.gd` — Godot deterministic smoke.
+
+## Contract corrections relative to the original chat sketch
+
+1. `base` is not treated as measured probability. Runtime authoring uses `authoring_prior`, with `empirical_success=null` until F3.
+2. Static `pts:[IBJJF,ADCC]` tuples are forbidden as scoring authority. Scoring is emitted as an event and awarded only after the configured stabilization period.
+3. Legality is not a `gi/nogi` boolean alone. The slice checks ruleset, modality, skill/belt division and age division.
+4. Counter references are semantic objects with an explicit outcome.
+5. Both attacker and defender pay resource cost when a counter is attempted.
+6. Invalid or unaffordable actions do not advance the deterministic replay tick.
+7. Candidate IDs are sorted and the Utility AI tie-breaks by ID to remove dictionary-order nondeterminism.
+8. The reducer uses a seed/tick/action salt; it never calls `randomize()` or `randf()`.
+9. The current `CombatManager`, `DeckManager`, signals and state machine remain canonical until the vertical slice adapter is proven.
+
+## Promotion gates
+
+The reducer may be integrated into the Ruan × Davi slice only after:
+
+- `npm run quality` passes;
+- the dedicated reducer-v2 contract workflow passes;
+- Godot imports/parses the new scripts;
+- identical seed + action sequence yields identical state/log;
+- IBJJF and ADCC scoring tests pass with stabilization;
+- legality and counter tests pass;
+- the existing runtime smokes remain green.
+
+Replacing the legacy state machine is **not** part of this batch. The next batch is an adapter into the existing `CombatManager`, preserving public APIs and rollback.
+
+## Repository truth reconciliation
+
+Several items previously described as “chat-only” already exist in `main` under canonical or successor names. Examples include `world_map_v4.json`, `acts_v3.json`, `endings_v2.json`, `tekuro_fragments_v2.json`, `training_exercises_v2.json`, `validate_phase1_data.py`, and `skill_graph_v1.json` (successor to the earlier `skills_v1` draft name).
+
+Top-level `asset_registry.json` and `docs/MESTRE.md` are intentionally not introduced as competing sources of truth. Asset authority remains the existing manifest/sidecar pipeline; repository authority remains the executable production contracts plus `docs/INDEX.md`, `docs/DECISIONS.md` and repository governance.

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "validate:deck": "python tools/validate_lore_output.py data/ruan_deck_inicial.json",
     "validate:bjj-kg-authoring": "python tools/data/validate_bjj_kg_authoring_contract.py",
     "test:bjj-kg-authoring": "python -m unittest discover -s tests -p 'test_bjj_kg_authoring_contract.py'",
+    "validate:bjj-reducer-v2": "python tools/data/validate_bjj_reducer_v2_slice.py",
+    "test:bjj-reducer-v2": "python -m unittest discover -s tests -p 'test_bjj_reducer_v2_contract.py'",
     "assets:manifest": "node tools/node/generate_asset_manifest.mjs",
     "assets:queue": "python tools/ai_asset_pipeline/build_production_queue_v02.py",
     "assets:spriteframes": "python tools/art/build_spriteframes.py",
@@ -36,7 +38,7 @@
     "cloud:batch": "python tools/ai_asset_pipeline/cloud/prepare_batch.py --output-dir tools/ai_asset_pipeline/generated_outputs/candidate_batches",
     "animations:generate": "python tools/animation/generate_character_animation_pack.py",
     "validate:animations": "python tools/animation/generate_character_animation_pack.py --validate-only",
-    "quality": "npm run validate:governance && npm run validate:canon && npm run validate:factions-v4 && npm run validate:phase1-data && npm run validate:skill-tree-visual && npm run validate:python && npm run validate:node && npm run validate:data && npm run validate:cloud && npm run test:cloud && npm run validate:animations && npm run validate:asset-protocol && npm run validate:sprite-forge && npm run validate:sprite-forge-phase1 && npm run test:sprite-forge && npm run test:sprite-forge-phase1 && npm run validate:bjj-kg-authoring && npm run test:bjj-kg-authoring && npm run validate:repository && npm run validate:runtime && npm run validate:release && npm run validate:supreme && npm run validate:deck",
+    "quality": "npm run validate:governance && npm run validate:canon && npm run validate:factions-v4 && npm run validate:phase1-data && npm run validate:skill-tree-visual && npm run validate:python && npm run validate:node && npm run validate:data && npm run validate:cloud && npm run test:cloud && npm run validate:animations && npm run validate:asset-protocol && npm run validate:sprite-forge && npm run validate:sprite-forge-phase1 && npm run test:sprite-forge && npm run test:sprite-forge-phase1 && npm run validate:bjj-kg-authoring && npm run test:bjj-kg-authoring && npm run validate:bjj-reducer-v2 && npm run test:bjj-reducer-v2 && npm run validate:repository && npm run validate:runtime && npm run validate:release && npm run validate:supreme && npm run validate:deck",
     "build:android:windows": "powershell -ExecutionPolicy Bypass -File tools/build/build_android_debug.ps1",
     "build:android:linux": "bash tools/build/build_android_debug.sh",
     "build:windows": "powershell -ExecutionPolicy Bypass -File tools/build/build_windows_debug.ps1"

--- a/src/ai/BJJUtilityScorerV2.gd
+++ b/src/ai/BJJUtilityScorerV2.gd
@@ -1,0 +1,54 @@
+class_name BJJUtilityScorerV2
+extends RefCounted
+
+const DEFAULT_POSITION_VALUES := {
+	"standing_neutral": 0.10,
+	"front_headlock": 0.55,
+	"closed_guard": 0.35,
+	"half_guard_top": 0.50,
+	"knee_shield_half": 0.30,
+	"side_control": 0.75,
+	"mount_high": 0.95,
+	"back_mount_seatbelt": 0.90,
+	"inside_ashi_garami": 0.70,
+	"submission": 1.00
+}
+
+func choose(candidates: Array, nemesis_bias: Dictionary = {}, position_values: Dictionary = {}) -> String:
+	var values := DEFAULT_POSITION_VALUES.duplicate(true)
+	for key in position_values.keys():
+		values[key] = position_values[key]
+	var ranked := rank(candidates, nemesis_bias, values)
+	if ranked.is_empty():
+		return ""
+	return str(ranked[0].get("id", ""))
+
+func rank(candidates: Array, nemesis_bias: Dictionary = {}, position_values: Dictionary = {}) -> Array:
+	var values := DEFAULT_POSITION_VALUES.duplicate(true)
+	for key in position_values.keys():
+		values[key] = position_values[key]
+	var scored: Array = []
+	for raw_candidate in candidates:
+		if typeof(raw_candidate) != TYPE_DICTIONARY:
+			continue
+		var candidate: Dictionary = raw_candidate
+		var tid := str(candidate.get("id", ""))
+		var score := 0.0
+		score += float(candidate.get("authoring_prior", 0.0)) * 40.0
+		score += float(candidate.get("potential_points", 0.0)) * 8.0
+		score += float(values.get(str(candidate.get("to", "")), 0.0)) * 20.0
+		score -= float(candidate.get("counter_count", 0)) * 6.0
+		score -= float(candidate.get("gas", 0.0)) * 0.3
+		score += float(nemesis_bias.get(tid, 0.0))
+		var item := candidate.duplicate(true)
+		item["utility_score"] = score
+		scored.append(item)
+	scored.sort_custom(_sort_ranked)
+	return scored
+
+func _sort_ranked(a: Dictionary, b: Dictionary) -> bool:
+	var score_a := float(a.get("utility_score", -INF))
+	var score_b := float(b.get("utility_score", -INF))
+	if not is_equal_approx(score_a, score_b):
+		return score_a > score_b
+	return str(a.get("id", "")) < str(b.get("id", ""))

--- a/src/combat/BJJGraphLoader.gd
+++ b/src/combat/BJJGraphLoader.gd
@@ -1,0 +1,132 @@
+class_name BJJGraphLoader
+extends RefCounted
+
+const FULL_MIN_POSITIONS := 40
+const FULL_MIN_TECHNIQUES := 120
+const FULL_MIN_CHAINS := 10
+const COUNTER_OUTCOMES := {
+	"deny_to_same_state": true,
+	"redirect_to_scramble": true,
+	"redirect_to_front_headlock": true,
+	"redirect_to_knee_shield": true,
+	"reverse_to_top": true,
+	"submission_threat": true,
+	"reset_to_neutral": true
+}
+
+static func load_from_path(path: String, require_full: bool = true) -> Dictionary:
+	if not FileAccess.file_exists(path):
+		return {"ok": false, "errors": ["kg_file_missing:%s" % path], "kg": {}}
+	var file := FileAccess.open(path, FileAccess.READ)
+	if file == null:
+		return {"ok": false, "errors": ["kg_file_unreadable:%s" % path], "kg": {}}
+	var parsed = JSON.parse_string(file.get_as_text())
+	file.close()
+	if typeof(parsed) != TYPE_DICTIONARY:
+		return {"ok": false, "errors": ["kg_root_must_be_dictionary"], "kg": {}}
+	var errors := validate_graph(parsed, require_full)
+	return {"ok": errors.is_empty(), "errors": errors, "kg": parsed if errors.is_empty() else {}}
+
+static func validate_graph(kg: Dictionary, require_full: bool = true) -> Array:
+	var errors: Array = []
+	var positions: Array = kg.get("positions", kg.get("posicoes", []))
+	var techniques: Array = kg.get("techniques", kg.get("tecnicas", []))
+	var chains: Array = kg.get("chains", [])
+	if require_full:
+		if positions.size() < FULL_MIN_POSITIONS:
+			errors.append("full_kg_requires_at_least_40_positions")
+		if techniques.size() < FULL_MIN_TECHNIQUES:
+			errors.append("full_kg_requires_at_least_120_techniques")
+		if chains.size() < FULL_MIN_CHAINS:
+			errors.append("full_kg_requires_at_least_10_chains")
+		if bool(kg.get("full_graph_claim", true)) == false:
+			errors.append("full_kg_cannot_be_slice_fixture")
+
+	var pos_ids := {}
+	for raw_position in positions:
+		if typeof(raw_position) != TYPE_DICTIONARY:
+			errors.append("position_must_be_dictionary")
+			continue
+		var position: Dictionary = raw_position
+		var pid := str(position.get("id", ""))
+		if pid == "":
+			errors.append("position_id_missing")
+			continue
+		if pos_ids.has(pid):
+			errors.append("duplicate_position:%s" % pid)
+		pos_ids[pid] = true
+
+	var tech_ids := {}
+	for raw_technique in techniques:
+		if typeof(raw_technique) != TYPE_DICTIONARY:
+			errors.append("technique_must_be_dictionary")
+			continue
+		var technique: Dictionary = raw_technique
+		var tid := str(technique.get("id", ""))
+		if tid == "":
+			errors.append("technique_id_missing")
+			continue
+		if tech_ids.has(tid):
+			errors.append("duplicate_technique:%s" % tid)
+		tech_ids[tid] = true
+		var from_id := str(technique.get("from", technique.get("de", "")))
+		var to_id := str(technique.get("to", technique.get("para", "")))
+		if not pos_ids.has(from_id):
+			errors.append("technique_from_missing:%s:%s" % [tid, from_id])
+		if not pos_ids.has(to_id):
+			errors.append("technique_to_missing:%s:%s" % [tid, to_id])
+		if not technique.has("actor_role_from") or not technique.has("actor_role_to"):
+			errors.append("technique_actor_roles_required:%s" % tid)
+		if technique.has("pts"):
+			errors.append("static_pts_tuple_forbidden:%s" % tid)
+		var prior = technique.get("authoring_prior", null)
+		if typeof(prior) not in [TYPE_FLOAT, TYPE_INT]:
+			errors.append("authoring_prior_required:%s" % tid)
+		else:
+			var prior_f := float(prior)
+			if prior_f < 0.0 or prior_f > 1.0:
+				errors.append("authoring_prior_out_of_range:%s" % tid)
+		if str(technique.get("prior_status", "")) != "UNCALIBRATED_EXPERT_HEURISTIC":
+			errors.append("authoring_prior_status_invalid:%s" % tid)
+		if technique.get("empirical_success", null) != null:
+			errors.append("empirical_success_must_be_null_before_f3:%s" % tid)
+		var availability: Dictionary = technique.get("availability", {})
+		if not availability.has("gi") or not availability.has("nogi"):
+			errors.append("gi_nogi_availability_required:%s" % tid)
+		var legality: Dictionary = technique.get("legality", {})
+		if legality.is_empty():
+			errors.append("ruleset_legality_required:%s" % tid)
+		for ruleset_id in legality.keys():
+			var gate: Dictionary = legality[ruleset_id]
+			if not gate.has("allowed") or not gate.has("belt_or_skill_division") or not gate.has("age_division"):
+				errors.append("legality_dimensions_incomplete:%s:%s" % [tid, str(ruleset_id)])
+		var counters: Array = technique.get("counters", [])
+		for counter_value in counters:
+			if typeof(counter_value) != TYPE_DICTIONARY:
+				errors.append("counter_must_have_semantics:%s" % tid)
+				continue
+			var outcome := str(counter_value.get("outcome", ""))
+			if not COUNTER_OUTCOMES.has(outcome):
+				errors.append("counter_outcome_invalid:%s:%s" % [tid, outcome])
+
+	for raw_technique in techniques:
+		if typeof(raw_technique) != TYPE_DICTIONARY:
+			continue
+		var technique: Dictionary = raw_technique
+		var tid := str(technique.get("id", ""))
+		for counter_value in technique.get("counters", []):
+			if typeof(counter_value) != TYPE_DICTIONARY:
+				continue
+			var counter_id := str(counter_value.get("technique_id", ""))
+			if not tech_ids.has(counter_id):
+				errors.append("counter_target_missing:%s:%s" % [tid, counter_id])
+
+	for chain_value in chains:
+		if typeof(chain_value) != TYPE_DICTIONARY:
+			errors.append("chain_must_be_dictionary")
+			continue
+		var steps: Array = chain_value.get("steps", [])
+		for step_id in steps:
+			if not tech_ids.has(str(step_id)):
+				errors.append("chain_step_missing:%s" % str(step_id))
+	return errors

--- a/src/combat/BJJGraphReducerV2.gd
+++ b/src/combat/BJJGraphReducerV2.gd
@@ -1,0 +1,261 @@
+class_name BJJGraphReducerV2
+extends RefCounted
+
+const RulesEngineScript = preload("res://src/combat/BJJRulesEngineV1.gd")
+
+var kg: Dictionary = {}
+var techniques: Dictionary = {}
+var positions: Dictionary = {}
+var rules_engine: BJJRulesEngineV1
+var validation_errors: Array = []
+
+func _init(kg_data: Dictionary, rules_data: Dictionary):
+	kg = kg_data.duplicate(true)
+	rules_engine = RulesEngineScript.new(rules_data)
+	for raw_position in kg.get("positions", kg.get("posicoes", [])):
+		if typeof(raw_position) == TYPE_DICTIONARY:
+			var position: Dictionary = raw_position
+			positions[str(position.get("id", ""))] = position
+	for raw_technique in kg.get("techniques", kg.get("tecnicas", [])):
+		if typeof(raw_technique) == TYPE_DICTIONARY:
+			var technique: Dictionary = raw_technique
+			techniques[str(technique.get("id", ""))] = technique
+	if not positions.has("standing_neutral"):
+		validation_errors.append("standing_neutral_missing")
+	if not positions.has("submission"):
+		validation_errors.append("submission_terminal_missing")
+
+func is_ready() -> bool:
+	return validation_errors.is_empty() and not techniques.is_empty()
+
+func new_state(ruleset: String, gi: bool, seed: int, belt_or_skill_division: String = "slice_any", age_division: String = "adult") -> Dictionary:
+	return {
+		"pos": "standing_neutral",
+		"top": 0,
+		"gi": gi,
+		"ruleset": ruleset,
+		"belt_or_skill_division": belt_or_skill_division,
+		"age_division": age_division,
+		"seed": seed,
+		"tick": 0,
+		"winner": 0,
+		"pending_score": {},
+		"p1": {"gas": 100.0, "score": 0, "grip": 50.0},
+		"p2": {"gas": 100.0, "score": 0, "grip": 50.0},
+		"log": []
+	}
+
+func available_actions(state: Dictionary, player: int) -> Array:
+	var out: Array = []
+	var ids: Array = techniques.keys()
+	ids.sort()
+	for tid_value in ids:
+		var tid := str(tid_value)
+		var technique: Dictionary = techniques[tid]
+		if _technique_available_for_player(technique, state, player):
+			out.append(tid)
+	return out
+
+func reduce(state: Dictionary, action: Dictionary) -> Dictionary:
+	var s: Dictionary = state.duplicate(true)
+	if int(s.get("winner", 0)) != 0:
+		return s
+	if str(action.get("kind", "technique")) == "stabilize":
+		return _reduce_stabilization(s, action)
+
+	var attack_id := str(action.get("atk", ""))
+	var attack_player := int(action.get("atk_player", 0))
+	if attack_player not in [1, 2] or not techniques.has(attack_id):
+		return s
+	var attack: Dictionary = techniques[attack_id]
+	if not _technique_available_for_player(attack, s, attack_player):
+		return s
+
+	s["tick"] = int(s.get("tick", 0)) + 1
+	_pay_gas(s, attack_player, float(attack.get("gas", 0.0)))
+	var defense_player := 2 if attack_player == 1 else 1
+	var defense_id := str(action.get("def", ""))
+	if defense_id != "":
+		var counter_relation := _counter_relation(attack, defense_id)
+		if not counter_relation.is_empty() and techniques.has(defense_id):
+			var counter: Dictionary = techniques[defense_id]
+			if _technique_available_for_player(counter, s, defense_player):
+				_pay_gas(s, defense_player, float(counter.get("gas", 0.0)))
+				var counter_roll := _rng(s, defense_player * 31 + _string_salt(defense_id))
+				var counter_chance := clampf(float(counter.get("authoring_prior", 0.0)) + _grip_modifier(s, counter, defense_player), 0.0, 1.0)
+				if counter_roll < counter_chance:
+					_apply_counter_success(s, counter, counter_relation, defense_player)
+					_append_log(s, {"ev":"counter","t":defense_id,"against":attack_id,"by":defense_player,"outcome":str(counter_relation.get("outcome", "")),"roll":counter_roll,"chance":counter_chance})
+					return s
+
+	var attack_roll := _rng(s, attack_player * 17 + _string_salt(attack_id))
+	var attack_chance := clampf(float(attack.get("authoring_prior", 0.0)) + _grip_modifier(s, attack, attack_player), 0.0, 1.0)
+	if attack_roll < attack_chance:
+		_apply_technique_success(s, attack, attack_player)
+		_append_log(s, {"ev":"hit","t":attack_id,"by":attack_player,"roll":attack_roll,"chance":attack_chance})
+	else:
+		_append_log(s, {"ev":"miss","t":attack_id,"by":attack_player,"roll":attack_roll,"chance":attack_chance})
+	return s
+
+func query(state: Dictionary, player: int) -> Array:
+	var out: Array = []
+	for tid_value in available_actions(state, player):
+		var tid := str(tid_value)
+		var technique: Dictionary = techniques[tid]
+		var event_id := str(technique.get("scoring_event", ""))
+		out.append({
+			"id": tid,
+			"type": str(technique.get("type", technique.get("tipo", ""))),
+			"authoring_prior": float(technique.get("authoring_prior", 0.0)),
+			"empirical_success": technique.get("empirical_success", null),
+			"gas": float(technique.get("gas", 0.0)),
+			"to": str(technique.get("to", technique.get("para", ""))),
+			"scoring_event": event_id,
+			"potential_points": rules_engine.points_for_event(str(state.get("ruleset", "")), event_id),
+			"counter_count": int(technique.get("counters", []).size())
+		})
+	return out
+
+func _reduce_stabilization(s: Dictionary, action: Dictionary) -> Dictionary:
+	var pending: Dictionary = s.get("pending_score", {})
+	if pending.is_empty():
+		return s
+	var player := int(action.get("player", 0))
+	if player != int(pending.get("player", 0)):
+		return s
+	var seconds := maxf(0.0, float(action.get("seconds", 0.0)))
+	if seconds <= 0.0:
+		return s
+	s["tick"] = int(s.get("tick", 0)) + 1
+	pending["stabilized_seconds"] = float(pending.get("stabilized_seconds", 0.0)) + seconds
+	if float(pending.get("stabilized_seconds", 0.0)) >= float(pending.get("required_seconds", 3.0)):
+		var points := rules_engine.points_for_event(str(s.get("ruleset", "")), str(pending.get("event", "")))
+		if points > 0:
+			var fighter_key := _fighter_key(player)
+			var fighter: Dictionary = s.get(fighter_key, {}).duplicate(true)
+			fighter["score"] = int(fighter.get("score", 0)) + points
+			s[fighter_key] = fighter
+			_append_log(s, {"ev":"score","event":str(pending.get("event", "")),"by":player,"points":points})
+		s["pending_score"] = {}
+	else:
+		s["pending_score"] = pending
+	return s
+
+func _technique_available_for_player(technique: Dictionary, state: Dictionary, player: int) -> bool:
+	var current_pos := str(state.get("pos", ""))
+	var from_id := str(technique.get("from", technique.get("de", "")))
+	if from_id != current_pos:
+		return false
+	var expected_player := _player_for_role(state, str(technique.get("actor_role_from", "neutral")))
+	if expected_player != 0 and expected_player != player:
+		return false
+	if not rules_engine.technique_allowed(technique, state, positions):
+		return false
+	var fighter: Dictionary = state.get(_fighter_key(player), {})
+	if float(fighter.get("gas", 0.0)) < float(technique.get("gas", 0.0)):
+		return false
+	return true
+
+func _player_for_role(state: Dictionary, role: String) -> int:
+	var top := int(state.get("top", 0))
+	match role:
+		"top": return top
+		"bottom":
+			if top == 1: return 2
+			if top == 2: return 1
+			return 0
+		_: return 0
+
+func _apply_counter_success(s: Dictionary, counter: Dictionary, relation: Dictionary, player: int) -> void:
+	var outcome := str(relation.get("outcome", ""))
+	if outcome != "deny_to_same_state":
+		_apply_position(s, str(counter.get("to", counter.get("para", s.get("pos", "")))), str(counter.get("actor_role_to", "neutral")), player)
+	_apply_grip_effect(s, counter, player)
+	s["pending_score"] = {}
+	if str(counter.get("to", counter.get("para", ""))) == "submission":
+		s["winner"] = player
+
+func _apply_technique_success(s: Dictionary, technique: Dictionary, player: int) -> void:
+	var to_id := str(technique.get("to", technique.get("para", s.get("pos", ""))))
+	_apply_position(s, to_id, str(technique.get("actor_role_to", "neutral")), player)
+	_apply_grip_effect(s, technique, player)
+	var event_id := str(technique.get("scoring_event", ""))
+	if event_id != "" and rules_engine.points_for_event(str(s.get("ruleset", "")), event_id) > 0:
+		s["pending_score"] = {
+			"event": event_id,
+			"player": player,
+			"required_seconds": maxf(0.0, float(technique.get("stabilization_seconds", 3.0))),
+			"stabilized_seconds": 0.0,
+			"position": to_id
+		}
+	else:
+		s["pending_score"] = {}
+	if to_id == "submission":
+		s["winner"] = player
+
+func _apply_position(s: Dictionary, to_id: String, actor_role_to: String, player: int) -> void:
+	s["pos"] = to_id
+	match actor_role_to:
+		"top": s["top"] = player
+		"bottom": s["top"] = 2 if player == 1 else 1
+		"neutral": s["top"] = 0
+
+func _apply_grip_effect(s: Dictionary, technique: Dictionary, player: int) -> void:
+	var ttype := str(technique.get("type", technique.get("tipo", "")))
+	if ttype == "grip":
+		_adjust_grip(s, player, 8.0)
+	elif ttype == "grip_break":
+		_adjust_grip(s, 2 if player == 1 else 1, -6.0)
+
+func _grip_modifier(s: Dictionary, technique: Dictionary, player: int) -> float:
+	var ttype := str(technique.get("type", technique.get("tipo", "")))
+	if ttype not in ["takedown", "pass", "grip"]:
+		return 0.0
+	var mine: Dictionary = s.get(_fighter_key(player), {})
+	var opponent := 2 if player == 1 else 1
+	var theirs: Dictionary = s.get(_fighter_key(opponent), {})
+	return clampf((float(mine.get("grip", 50.0)) - float(theirs.get("grip", 50.0))) / 200.0, -0.15, 0.15)
+
+func _counter_relation(attack: Dictionary, defense_id: String) -> Dictionary:
+	for raw_relation in attack.get("counters", []):
+		if typeof(raw_relation) != TYPE_DICTIONARY:
+			continue
+		var relation: Dictionary = raw_relation
+		if str(relation.get("technique_id", "")) == defense_id:
+			return relation
+	return {}
+
+func _pay_gas(s: Dictionary, player: int, amount: float) -> void:
+	var key := _fighter_key(player)
+	var fighter: Dictionary = s.get(key, {}).duplicate(true)
+	fighter["gas"] = maxf(0.0, float(fighter.get("gas", 0.0)) - maxf(0.0, amount))
+	s[key] = fighter
+
+func _adjust_grip(s: Dictionary, player: int, delta: float) -> void:
+	var key := _fighter_key(player)
+	var fighter: Dictionary = s.get(key, {}).duplicate(true)
+	fighter["grip"] = clampf(float(fighter.get("grip", 50.0)) + delta, 0.0, 100.0)
+	s[key] = fighter
+
+func _fighter_key(player: int) -> String:
+	return "p1" if player == 1 else "p2"
+
+func _rng(state: Dictionary, salt: int) -> float:
+	var h: int = int(state.get("seed", 0)) * 1000003 + int(state.get("tick", 0)) * 9176 + salt * 7919
+	h = int((h * 1103515245 + 12345) % 2147483647)
+	if h < 0:
+		h = -h
+	return float(h % 1000000) / 1000000.0
+
+func _string_salt(value: String) -> int:
+	var out := 17
+	for index in range(value.length()):
+		out = int((out * 31 + value.unicode_at(index)) % 1000003)
+	return out
+
+func _append_log(s: Dictionary, event: Dictionary) -> void:
+	var log: Array = s.get("log", []).duplicate(true)
+	var item := event.duplicate(true)
+	item["tick"] = int(s.get("tick", 0))
+	log.append(item)
+	s["log"] = log

--- a/src/combat/BJJRulesEngineV1.gd
+++ b/src/combat/BJJRulesEngineV1.gd
@@ -1,0 +1,74 @@
+class_name BJJRulesEngineV1
+extends RefCounted
+
+var rules: Dictionary = {}
+
+func _init(rules_data: Dictionary = {}):
+	rules = rules_data.duplicate(true)
+
+func canonical_ruleset_id(value: String) -> String:
+	match value:
+		"ibjjf", "ibjjf_v6": return "ibjjf_v6"
+		"adcc", "adcc_championship_current": return "adcc_championship_current"
+		"clandestina", "clandestine_cria_v1": return "clandestine_cria_v1"
+		_: return value
+
+func technique_allowed(technique: Dictionary, state: Dictionary, positions: Dictionary) -> bool:
+	var availability: Dictionary = technique.get("availability", {})
+	if bool(state.get("gi", true)):
+		if availability.get("gi", false) != true:
+			return false
+	else:
+		if availability.get("nogi", false) != true:
+			return false
+
+	var ruleset_id := canonical_ruleset_id(str(state.get("ruleset", "")))
+	var legality: Dictionary = technique.get("legality", {})
+	if not legality.has(ruleset_id):
+		return false
+	var gate: Dictionary = legality[ruleset_id]
+	if gate.get("allowed", false) != true:
+		return false
+	var requested_belt := str(state.get("belt_or_skill_division", "slice_any"))
+	var requested_age := str(state.get("age_division", "adult"))
+	var belts: Array = gate.get("belt_or_skill_division", [])
+	var ages: Array = gate.get("age_division", [])
+	if not belts.has(requested_belt) and not belts.has("any") and not belts.has("slice_any"):
+		return false
+	if not ages.has(requested_age) and not ages.has("any"):
+		return false
+
+	if bool(technique.get("restricted_leglock", false)):
+		var from_id := str(technique.get("from", technique.get("de", "")))
+		var from_node: Dictionary = positions.get(from_id, {})
+		if str(from_node.get("cat", "")) != "leglock":
+			return false
+	return true
+
+func points_for_event(ruleset_value: String, event_id: String) -> int:
+	var ruleset_id := canonical_ruleset_id(ruleset_value)
+	if ruleset_id == "clandestine_cria_v1":
+		return 0
+	var rulesets: Dictionary = rules.get("rulesets", {})
+	var spec: Dictionary = rulesets.get(ruleset_id, {})
+	var points: Dictionary = spec.get("points", {})
+	match ruleset_id:
+		"ibjjf_v6":
+			match event_id:
+				"takedown": return int(points.get("takedown", 0))
+				"sweep": return int(points.get("sweep", 0))
+				"knee_on_belly": return int(points.get("knee_on_belly", 0))
+				"guard_pass": return int(points.get("guard_pass", 0))
+				"mount": return int(points.get("mount", 0))
+				"back_control": return int(points.get("back_control", 0))
+		"adcc_championship_current":
+			match event_id:
+				"takedown": return int(points.get("takedown_to_guard_or_half", 0))
+				"clean_takedown": return int(points.get("clean_takedown_past_guard", 0))
+				"sweep": return int(points.get("sweep_to_guard_or_half", 0))
+				"clean_sweep": return int(points.get("clean_sweep_past_guard", 0))
+				"knee_on_belly": return int(points.get("knee_on_stomach", 0))
+				"guard_pass": return int(points.get("guard_pass", 0))
+				"mount": return int(points.get("mount", 0))
+				"back_control": return int(points.get("back_mount_hooks_or_body_triangle", 0))
+	return 0

--- a/tests/bjj_reducer_v2_smoke.gd
+++ b/tests/bjj_reducer_v2_smoke.gd
@@ -1,0 +1,107 @@
+extends SceneTree
+
+const LoaderScript = preload("res://src/combat/BJJGraphLoader.gd")
+const ReducerScript = preload("res://src/combat/BJJGraphReducerV2.gd")
+const UtilityScript = preload("res://src/ai/BJJUtilityScorerV2.gd")
+
+var failures: Array[String] = []
+var checks := 0
+
+func _initialize() -> void:
+	call_deferred("_run")
+
+func _assert(condition: bool, message: String) -> void:
+	checks += 1
+	if not condition:
+		failures.append(message)
+		push_error("[BJJReducerV2Smoke] " + message)
+
+func _load_json(path: String) -> Dictionary:
+	if not FileAccess.file_exists(path):
+		return {}
+	var file := FileAccess.open(path, FileAccess.READ)
+	if file == null:
+		return {}
+	var parsed = JSON.parse_string(file.get_as_text())
+	file.close()
+	return parsed if typeof(parsed) == TYPE_DICTIONARY else {}
+
+func _run() -> void:
+	var loaded: Dictionary = LoaderScript.load_from_path("res://data/bjj/bjj_kg_slice_ruan_davi_v1.json", false)
+	_assert(bool(loaded.get("ok", false)), "slice fixture should validate: %s" % str(loaded.get("errors", [])))
+	var full_attempt: Dictionary = LoaderScript.load_from_path("res://data/bjj/bjj_kg_slice_ruan_davi_v1.json", true)
+	_assert(not bool(full_attempt.get("ok", true)), "slice fixture must fail the full 40/120/10 gate")
+	var kg: Dictionary = loaded.get("kg", {})
+	var rules := _load_json("res://data/combat/bjj_rulesets_verified_v1.json")
+	var reducer = ReducerScript.new(kg, rules)
+	_assert(reducer.is_ready(), "reducer should initialize with validated slice fixture")
+
+	var state: Dictionary = reducer.new_state("ibjjf", true, 12345)
+	_assert(str(state.get("pos", "")) == "standing_neutral", "new_state must start standing_neutral")
+	_assert(int(state.get("top", -1)) == 0, "new_state must start neutral top=0")
+	var standing_actions: Array = reducer.available_actions(state, 1)
+	_assert(standing_actions.has("t001"), "standing actions must include t001")
+	_assert(standing_actions.has("t005"), "standing actions must include t005")
+
+	var counter_state: Dictionary = reducer.reduce(state, {"atk":"t001", "def":"slice_sprawl", "atk_player":1})
+	_assert(str(counter_state.get("pos", "")) == "front_headlock", "successful sprawl counter must redirect to front_headlock")
+	_assert(int(counter_state.get("top", 0)) == 2, "countering defender must become top")
+	_assert(float(counter_state.get("p1", {}).get("gas", 100.0)) == 80.0, "attacker must pay gas on countered attempt")
+	_assert(float(counter_state.get("p2", {}).get("gas", 100.0)) == 92.0, "defender must pay gas for attempted counter")
+
+	var deterministic_a: Dictionary = reducer.reduce(state, {"atk":"t005", "def":"", "atk_player":1})
+	var deterministic_b: Dictionary = reducer.reduce(state, {"atk":"t005", "def":"", "atk_player":1})
+	_assert(deterministic_a == deterministic_b, "same seed and same action must produce identical state")
+
+	var score_state := reducer.new_state("ibjjf", true, 99)
+	score_state["pos"] = "side_control"
+	score_state["top"] = 1
+	score_state = reducer.reduce(score_state, {"atk":"slice_side_to_mount", "def":"", "atk_player":1})
+	_assert(str(score_state.get("pos", "")) == "mount_high", "mount transition should move to mount_high")
+	_assert(int(score_state.get("p1", {}).get("score", -1)) == 0, "points must not be awarded before stabilization")
+	_assert(not score_state.get("pending_score", {}).is_empty(), "mount should create pending score event")
+	score_state = reducer.reduce(score_state, {"kind":"stabilize", "player":1, "seconds":3.0})
+	_assert(int(score_state.get("p1", {}).get("score", -1)) == 4, "IBJJF mount must score 4 after stabilization")
+
+	var adcc_state := reducer.new_state("adcc", false, 99)
+	adcc_state["pos"] = "side_control"
+	adcc_state["top"] = 1
+	adcc_state = reducer.reduce(adcc_state, {"atk":"slice_side_to_mount", "def":"", "atk_player":1})
+	adcc_state = reducer.reduce(adcc_state, {"kind":"stabilize", "player":1, "seconds":3.0})
+	_assert(int(adcc_state.get("p1", {}).get("score", -1)) == 2, "ADCC mount must score 2 after stabilization")
+
+	var submission_state := reducer.new_state("ibjjf", true, 77)
+	submission_state["pos"] = "mount_high"
+	submission_state["top"] = 1
+	submission_state = reducer.reduce(submission_state, {"atk":"t057", "def":"", "atk_player":1})
+	_assert(int(submission_state.get("winner", 0)) == 1, "successful submission must set winner")
+
+	var gi_leg_state := reducer.new_state("ibjjf", true, 77)
+	gi_leg_state["pos"] = "inside_ashi_garami"
+	gi_leg_state["top"] = 1
+	_assert(not reducer.available_actions(gi_leg_state, 1).has("slice_heel_hook"), "restricted heel hook must be filtered in gi/IBJJF slice")
+	var adcc_leg_state := reducer.new_state("adcc", false, 77)
+	adcc_leg_state["pos"] = "inside_ashi_garami"
+	adcc_leg_state["top"] = 1
+	_assert(reducer.available_actions(adcc_leg_state, 1).has("slice_heel_hook"), "heel hook fixture should be available in no-gi ADCC slice")
+
+	var tired_state := reducer.new_state("ibjjf", true, 13)
+	tired_state["p1"]["gas"] = 0.0
+	_assert(not reducer.available_actions(tired_state, 1).has("t001"), "technique must be blocked when gas is insufficient")
+	var before_tick := int(tired_state.get("tick", 0))
+	var after_invalid: Dictionary = reducer.reduce(tired_state, {"atk":"t001", "def":"", "atk_player":1})
+	_assert(int(after_invalid.get("tick", -1)) == before_tick, "invalid/unaffordable action must not advance replay tick")
+
+	var utility = UtilityScript.new()
+	var candidates: Array = reducer.query(state, 1)
+	var first_choice := utility.choose(candidates, {})
+	var second_choice := utility.choose(candidates, {})
+	_assert(first_choice != "", "utility scorer must choose an available technique")
+	_assert(first_choice == second_choice, "utility scorer tie-breaking must be deterministic")
+
+	if failures.is_empty():
+		print("BJJ REDUCER V2 SMOKE PASS: %d checks" % checks)
+		quit(0)
+	else:
+		push_error("BJJ REDUCER V2 SMOKE FAIL: %d/%d failed" % [failures.size(), checks])
+		quit(1)

--- a/tests/test_bjj_reducer_v2_contract.py
+++ b/tests/test_bjj_reducer_v2_contract.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "tools/data/validate_bjj_reducer_v2_slice.py"
+spec = importlib.util.spec_from_file_location("validate_bjj_reducer_v2_slice", MODULE_PATH)
+assert spec and spec.loader
+validator = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(validator)
+
+
+def load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+class BJJReducerV2ContractTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.fixture = load_json(ROOT / "data/bjj/bjj_kg_slice_ruan_davi_v1.json")
+        self.authoring = load_json(ROOT / "data/combat/bjj_kg_authoring_contract_v1.json")
+        self.rules = load_json(ROOT / "data/combat/bjj_rulesets_verified_v1.json")
+
+    def test_current_fixture_passes(self) -> None:
+        self.assertEqual(validator.validate_fixture(self.fixture, self.authoring, self.rules), [])
+
+    def test_rejects_raw_base_and_static_pts_authority(self) -> None:
+        fixture = copy.deepcopy(self.fixture)
+        fixture["techniques"][0]["base"] = 0.55
+        fixture["techniques"][0]["pts"] = [2, 2]
+        errors = validator.validate_fixture(fixture, self.authoring, self.rules)
+        self.assertTrue(any("raw base field forbidden" in item for item in errors))
+        self.assertTrue(any("static pts tuple forbidden" in item for item in errors))
+
+    def test_rejects_empirical_success_before_f3(self) -> None:
+        fixture = copy.deepcopy(self.fixture)
+        fixture["techniques"][0]["empirical_success"] = 0.42
+        errors = validator.validate_fixture(fixture, self.authoring, self.rules)
+        self.assertTrue(any("empirical_success must be null before F3" in item for item in errors))
+
+    def test_rejects_counter_without_outcome(self) -> None:
+        fixture = copy.deepcopy(self.fixture)
+        fixture["techniques"][0]["counters"][0].pop("outcome")
+        errors = validator.validate_fixture(fixture, self.authoring, self.rules)
+        self.assertTrue(any("invalid counter outcome" in item for item in errors))
+
+    def test_rejects_incomplete_legality_dimensions(self) -> None:
+        fixture = copy.deepcopy(self.fixture)
+        fixture["techniques"][0]["legality"]["ibjjf_v6"].pop("age_division")
+        errors = validator.validate_fixture(fixture, self.authoring, self.rules)
+        self.assertTrue(any("incomplete legality for ibjjf_v6" in item for item in errors))
+
+    def test_rejects_false_full_graph_claim(self) -> None:
+        fixture = copy.deepcopy(self.fixture)
+        fixture["full_graph_claim"] = True
+        errors = validator.validate_fixture(fixture, self.authoring, self.rules)
+        self.assertTrue(any("cannot claim to be the full graph" in item for item in errors))
+
+    def test_adcc_authority_is_not_four_four(self) -> None:
+        bad_rules = copy.deepcopy(self.rules)
+        points = bad_rules["rulesets"]["adcc_championship_current"]["points"]
+        points["mount"] = 4
+        points["back_mount_hooks_or_body_triangle"] = 4
+        errors = validator.validate_fixture(self.fixture, self.authoring, bad_rules)
+        self.assertIn("versioned ADCC authority regressed", errors)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/data/validate_bjj_reducer_v2_slice.py
+++ b/tools/data/validate_bjj_reducer_v2_slice.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Fail-closed validation for the BJJ reducer-v2 pre-integration slice."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+FIXTURE = ROOT / "data/bjj/bjj_kg_slice_ruan_davi_v1.json"
+FULL_KG = ROOT / "data/bjj/bjj_knowledge_graph_v1.json"
+AUTHORING = ROOT / "data/combat/bjj_kg_authoring_contract_v1.json"
+RULES = ROOT / "data/combat/bjj_rulesets_verified_v1.json"
+REDUCER = ROOT / "src/combat/BJJGraphReducerV2.gd"
+LOADER = ROOT / "src/combat/BJJGraphLoader.gd"
+UTILITY = ROOT / "src/ai/BJJUtilityScorerV2.gd"
+SMOKE = ROOT / "tests/bjj_reducer_v2_smoke.gd"
+
+ALLOWED_COUNTER_OUTCOMES = {
+    "deny_to_same_state",
+    "redirect_to_scramble",
+    "redirect_to_front_headlock",
+    "redirect_to_knee_shield",
+    "reverse_to_top",
+    "submission_threat",
+    "reset_to_neutral",
+}
+
+
+def load(path: Path) -> dict:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"{path}: root must be object")
+    return value
+
+
+def validate_fixture(fixture: dict, authoring: dict, rules: dict) -> list[str]:
+    errors: list[str] = []
+    if fixture.get("status") != "SLICE_FIXTURE_NONCANONICAL":
+        errors.append("slice fixture must remain explicitly noncanonical")
+    if fixture.get("runtime_authority") is not False:
+        errors.append("slice fixture cannot have runtime authority")
+    if fixture.get("full_graph_claim") is not False:
+        errors.append("slice fixture cannot claim to be the full graph")
+    if fixture.get("rules_authority") != "data/combat/bjj_rulesets_verified_v1.json":
+        errors.append("slice fixture must reference versioned rules authority")
+
+    source_status = fixture.get("source_status", {})
+    if source_status.get("last_complete_received_technique_id") != "t092":
+        errors.append("source ledger must preserve t092 as last complete received technique")
+    if source_status.get("received_complete_techniques") is not False:
+        errors.append("source ledger cannot claim complete techniques")
+    if source_status.get("received_complete_chains") is not False:
+        errors.append("source ledger cannot claim complete chains")
+    if source_status.get("promotion_blocked") is not True:
+        errors.append("promotion must remain blocked until full payload exists")
+
+    if authoring.get("runtime_authority") is not False:
+        errors.append("authoring contract unexpectedly gained runtime authority")
+    if authoring.get("success_model", {}).get("authoring_prior_field") != "authoring_prior":
+        errors.append("authoring contract must use authoring_prior")
+    if authoring.get("scoring_model", {}).get("forbid_unversioned_pts_tuple_as_authority") is not True:
+        errors.append("static pts tuples must remain forbidden")
+
+    positions = fixture.get("positions", [])
+    techniques = fixture.get("techniques", [])
+    pos_ids = {str(item.get("id", "")) for item in positions if isinstance(item, dict)}
+    tech_ids = {str(item.get("id", "")) for item in techniques if isinstance(item, dict)}
+    if "standing_neutral" not in pos_ids or "submission" not in pos_ids:
+        errors.append("slice fixture requires standing_neutral and submission")
+
+    for tech in techniques:
+        if not isinstance(tech, dict):
+            errors.append("technique must be object")
+            continue
+        tid = str(tech.get("id", ""))
+        if "base" in tech:
+            errors.append(f"{tid}: raw base field forbidden; use authoring_prior")
+        prior = tech.get("authoring_prior")
+        if not isinstance(prior, (int, float)) or isinstance(prior, bool) or not 0.0 <= float(prior) <= 1.0:
+            errors.append(f"{tid}: invalid authoring_prior")
+        if tech.get("prior_status") != "UNCALIBRATED_EXPERT_HEURISTIC":
+            errors.append(f"{tid}: prior status must remain uncalibrated")
+        if tech.get("empirical_success") is not None:
+            errors.append(f"{tid}: empirical_success must be null before F3")
+        if "pts" in tech:
+            errors.append(f"{tid}: static pts tuple forbidden")
+        if str(tech.get("from", "")) not in pos_ids or str(tech.get("to", "")) not in pos_ids:
+            errors.append(f"{tid}: edge references missing position")
+        if tech.get("actor_role_from") not in {"neutral", "top", "bottom"}:
+            errors.append(f"{tid}: invalid actor_role_from")
+        if tech.get("actor_role_to") not in {"neutral", "top", "bottom"}:
+            errors.append(f"{tid}: invalid actor_role_to")
+        availability = tech.get("availability", {})
+        if not isinstance(availability, dict) or set(availability) != {"gi", "nogi"}:
+            errors.append(f"{tid}: availability must explicitly contain gi/nogi")
+        legality = tech.get("legality", {})
+        for ruleset_id in ("ibjjf_v6", "adcc_championship_current", "clandestine_cria_v1"):
+            gate = legality.get(ruleset_id, {}) if isinstance(legality, dict) else {}
+            if not {"allowed", "belt_or_skill_division", "age_division"}.issubset(gate):
+                errors.append(f"{tid}: incomplete legality for {ruleset_id}")
+        for counter in tech.get("counters", []):
+            if not isinstance(counter, dict):
+                errors.append(f"{tid}: counter must be semantic object")
+                continue
+            counter_id = str(counter.get("technique_id", ""))
+            if counter_id not in tech_ids:
+                errors.append(f"{tid}: missing counter target {counter_id}")
+            if counter.get("outcome") not in ALLOWED_COUNTER_OUTCOMES:
+                errors.append(f"{tid}: invalid counter outcome {counter.get('outcome')}")
+
+    adcc = rules.get("rulesets", {}).get("adcc_championship_current", {}).get("points", {})
+    if adcc.get("mount") != 2 or adcc.get("back_mount_hooks_or_body_triangle") != 3:
+        errors.append("versioned ADCC authority regressed")
+    return errors
+
+
+def validate_repository() -> list[str]:
+    errors: list[str] = []
+    required = [FIXTURE, AUTHORING, RULES, REDUCER, LOADER, UTILITY, SMOKE]
+    for path in required:
+        if not path.exists():
+            errors.append(f"missing required reducer-v2 artifact: {path.relative_to(ROOT)}")
+    if errors:
+        return errors
+    try:
+        errors.extend(validate_fixture(load(FIXTURE), load(AUTHORING), load(RULES)))
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        errors.append(f"parse failure: {exc}")
+        return errors
+
+    if FULL_KG.exists():
+        try:
+            full = load(FULL_KG)
+            positions = full.get("positions", full.get("posicoes", []))
+            techniques = full.get("techniques", full.get("tecnicas", []))
+            chains = full.get("chains", [])
+            if len(positions) < 40 or len(techniques) < 120 or len(chains) < 10:
+                errors.append("canonical bjj_knowledge_graph_v1.json exists without full 40/120/10 payload")
+        except (OSError, ValueError, json.JSONDecodeError) as exc:
+            errors.append(f"canonical KG parse failure: {exc}")
+
+    reducer_text = REDUCER.read_text(encoding="utf-8")
+    if "randomize()" in reducer_text or "randf()" in reducer_text:
+        errors.append("BJJGraphReducerV2 must not use unseeded Godot RNG")
+    if "authoring_prior" not in reducer_text:
+        errors.append("BJJGraphReducerV2 must consume authoring_prior")
+    if "pending_score" not in reducer_text:
+        errors.append("BJJGraphReducerV2 must defer scoring until stabilization")
+    return errors
+
+
+def main() -> int:
+    errors = validate_repository()
+    if errors:
+        for error in errors:
+            print("FAIL", error)
+        print(f"BJJ reducer-v2 slice gate failed: {len(errors)} error(s)")
+        return 1
+    print("BJJ reducer-v2 slice PASS: deterministic adapter core staged; full KG promotion remains blocked")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Escopo

Implementa o lote F2 hardened para o vertical slice Ruan × Davi sem substituir o `CombatManager` canônico e sem fabricar o F1 completo a partir do payload truncado do chat.

### Incluído
- fixture executável não canônico `data/bjj/bjj_kg_slice_ruan_davi_v1.json`;
- `BJJGraphLoader` fail-closed;
- `BJJRulesEngineV1` com scoring versionado e legality multidimensional;
- `BJJGraphReducerV2` determinístico/seeded;
- `BJJUtilityScorerV2` com tie-break estável;
- smoke Godot dedicado;
- validator + testes Python;
- integração no `npm run quality`;
- workflow `BJJ Reducer V2 Slice`;
- documentação/index.

## Proteções
- `base` não é tratado como dado empírico: usa `authoring_prior` + `empirical_success=null`;
- `pts[]` não é autoridade de scoring;
- scoring depende de evento + estabilização;
- counters têm outcome explícito e consomem recurso do defensor;
- ação inválida/sem gás não avança tick;
- legality considera ruleset + gi/nogi + divisão + idade;
- o fixture não pode passar pelo gate de full KG 40/120/10;
- `CombatManager`, `DeckManager`, HUD e save permanecem intocados neste PR.

## Estado do F1
O payload completo `40 posições / 120 técnicas / 10 chains` ainda não foi recebido íntegro: `t001–t092` chegaram completos e os envios seguintes truncam no início de `t093`. Por isso `data/bjj/bjj_knowledge_graph_v1.json` permanece ausente e a promoção fica bloqueada.

## Próximo lote após merge
Adapter do reducer v2 no `CombatManager` existente, atrás de feature flag/rollback, exclusivamente no fluxo Ruan × Davi.
