### PR TITLE
feat(narrative): materialize v4 candidate with Parte Zero and truth overlay

### DIFF
--- a/.github/workflows/narrative-v4-candidate.yml
+++ b/.github/workflows/narrative-v4-candidate.yml
@@ -1,0 +1,38 @@
+name: Narrative V4 Candidate
+
+on:
+  pull_request:
+    paths:
+      - 'data/narrative/**'
+      - 'docs/narrative/**'
+      - 'tools/data/validate_narrative_v4_candidate.py'
+      - 'tests/test_narrative_v4_candidate.py'
+      - 'package.json'
+      - '.github/workflows/narrative-v4-candidate.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'data/narrative/**'
+      - 'docs/narrative/**'
+      - 'tools/data/validate_narrative_v4_candidate.py'
+      - 'tests/test_narrative_v4_candidate.py'
+      - 'package.json'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Validate narrative v4 candidate
+        run: python tools/data/validate_narrative_v4_candidate.py
+      - name: Test narrative v4 candidate
+        run: python -m unittest discover -s tests -p 'test_narrative_v4_candidate.py'
+      - name: Assert legacy authority untouched
+        run: |
+          git diff --exit-code origin/${{ github.base_ref || 'main' }} -- data/narrative/canon_v3.json data/narrative/acts_v3.json data/narrative/dialogues.json data/narrative/endings_v2.json || {
+            echo 'Legacy narrative authority changed in v4 candidate batch.'
+            exit 1
+          }

--- a/.github/workflows/narrative-v4-candidate.yml
+++ b/.github/workflows/narrative-v4-candidate.yml
@@ -23,6 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
@@ -31,8 +33,16 @@ jobs:
       - name: Test narrative v4 candidate
         run: python -m unittest discover -s tests -p 'test_narrative_v4_candidate.py'
       - name: Assert legacy authority untouched
+        shell: bash
         run: |
-          git diff --exit-code origin/${{ github.base_ref || 'main' }} -- data/narrative/canon_v3.json data/narrative/acts_v3.json data/narrative/dialogues.json data/narrative/endings_v2.json || {
-            echo 'Legacy narrative authority changed in v4 candidate batch.'
-            exit 1
-          }
+          BASE_REF="${{ github.base_ref }}"
+          if [ -z "$BASE_REF" ]; then BASE_REF="main"; fi
+          git fetch origin "$BASE_REF"
+          git diff --exit-code "origin/$BASE_REF" -- \
+            data/narrative/canon_v3.json \
+            data/narrative/acts_v3.json \
+            data/narrative/dialogues.json \
+            data/narrative/endings_v2.json || {
+              echo 'Legacy narrative authority changed in v4 candidate batch.'
+              exit 1
+            }

--- a/data/narrative/acts_v4.json
+++ b/data/narrative/acts_v4.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "cria_narrative_acts_v4",
+  "version": "4.0.0-candidate.1",
+  "status": "CANON_V4_CANDIDATE",
+  "authority": "data/narrative/canon_v4.json",
+  "acts": [
+    {
+      "id": "ato_1_o_chao",
+      "legacy_title": "O CHAO",
+      "subtitle": "RAIZ",
+      "ages": [19, 20],
+      "belt_range": "branca_para_azul",
+      "player_question": "de onde eu sou?",
+      "required_beats": [
+        {"id":"entrada_terreiro","result":"tese_ser_forte_e_ser_gentil"},
+        {"id":"pertencimento_nucleo","characters":["biel","dandara","leoa"]},
+        {"id":"convite_arena_dique","arena":"arena_do_dique"},
+        {"id":"sparring_davi","opponent":"davi_relampago","result":"rivalidade_tecnica"},
+        {"id":"carro_preto_pratigi","result":"ferida_de_terra_sem_vinganca"},
+        {"id":"primeira_luta_oficial_dique","ruleset":"ibjjf","result":"vitoria_por_pressao_sem_humilhacao"},
+        {"id":"faixa_azul","result":"forca_como_responsabilidade"}
+      ],
+      "causal_exit": "hype + orgulho + necessidade abrem o circuito"
+    },
+    {
+      "id": "ato_2_o_molde",
+      "legacy_title": "O MOLDE",
+      "subtitle": "CIRCUITO",
+      "ages": [21, 22],
+      "belt_range": "azul_para_roxa",
+      "player_question": "quem eu sou para os outros?",
+      "required_beats": [
+        {"id":"circuito_cresce","locations":["ginasio_valenca","palco_do_morro"],"result":"crialive_e_tinker_broker_crescem"},
+        {"id":"tres_portas","factions":["ALE","LEM","NTM"],"result":"reputacao_inicial"},
+        {"id":"galpao_noite","result":"primeiro_testemunho_do_submundo"},
+        {"id":"concha_davi","opponent":"davi_relampago","choices":["revidar","respirar"],"persistent_consequence":true},
+        {"id":"vera_recruta","characters":["vera_salles","ruan_macacao","tinker_bell"],"mandatory":true,"result":"cobertura_inicia"},
+        {"id":"chamado_guardia_memoria","character_ref":"dona_chie","result":"gancho_fragmentos"}
+      ],
+      "causal_exit": "Ruan entra no submundo com dupla finalidade: sobreviver e investigar"
+    },
+    {
+      "id": "ato_3_o_nome",
+      "legacy_title": "O NOME",
+      "subtitle": "SOMBRA",
+      "ages": [23, 24],
+      "belt_range": "roxa_para_marrom",
+      "player_question": "o que eu aceito pagar?",
+      "required_beats": [
+        {"id":"primeiro_clandestino","location":"ferro_velho_da_lapa","opponent":"oni_da_lapa","result":"codigo_submundo_apresentado"},
+        {"id":"degodo_descobre_disfarce","result":"escudo_moral_e_tecnico"},
+        {"id":"infiltracao_tripla","factions":["ALE","LEM","NTM"],"double_purpose":["sobrevivencia","fragmentos_da_verdade"]},
+        {"id":"chefes_territorio","result":"nemesis_legivel"},
+        {"id":"fragmento_foto_antiga","truth_fragment_ref":"frag_01_foto_desfocada","spoken_hidden_name":false},
+        {"id":"o_barco","scene_ref":"3.3a_o_barco","result":"inocente_preso_maos_sujas_sobe"},
+        {"id":"rede_apostas","antagonist_function":"chupeta_candidate","status":"pending_character_registry"},
+        {"id":"pipoca_isca","pipoca_survives":true,"result":"custo_na_proxima_geracao"},
+        {"id":"biel_escorrega","result":"prenuncio_perda_ato4"},
+        {"id":"faixa_marrom","result":"lembrar_caminho_de_volta"}
+      ],
+      "causal_exit": "culpa + maos_sujas + Biel tornam inevitavel a queda"
+    },
+    {
+      "id": "ato_4_a_queda",
+      "legacy_title": "A QUEDA",
+      "subtitle": "TERRITORIO",
+      "ages": [25, 26],
+      "belt_range": "marrom_para_preta",
+      "player_question": "o que eu faco com o que sou?",
+      "required_beats": [
+        {"id":"guerra_territorio","result":"faccoes_e_protecao_de_chupeta_escalam"},
+        {"id":"morte_biel","presentation":"eliptica","silence_seconds":8,"irreversible":true,"revenge_payoff_forbidden":true},
+        {"id":"dende_colapsa","result":"promessa_de_merecer_o_que_ainda_da_para_salvar"},
+        {"id":"dende_admite_silencio","result":"perpetuou_apagamento_sem_ser_autor_unico"},
+        {"id":"o_contrato","branches":["cassio","vera","nenhum"]},
+        {"id":"chie_acolhe","characters":["dona_chie","ruan_macacao"]},
+        {"id":"pratigi_do_avesso","opponent":"ruan_do_avesso","integration_condition":"vencer_sem_furia_e_sem_finalizar"},
+        {"id":"cadeia_documental_sombra","result":"prova_preservada_antes_de_crialive"},
+        {"id":"cost_montage","scene_ref":"4.5_cost_montage"},
+        {"id":"faixa_preta","result":"colega_de_dende"}
+      ],
+      "causal_exit": "Ruan precisa restituir, revelar e devolver"
+    },
+    {
+      "id": "ato_5_o_legado",
+      "legacy_title": "O LEGADO",
+      "subtitle": "VERDADE",
+      "ages": [27, 28],
+      "belt_range": "preta",
+      "player_question": "o que eu deixo depois de mim?",
+      "required_beats": [
+        {"id":"armadilha_chupeta","status":"pending_character_registry","result":"climax_fisico"},
+        {"id":"ruan_vs_chupeta","ruleset":"clandestine_cria_v1","finish_rule":"release_submission_then_stabilize_control","result":"forca_sem_crueldade"},
+        {"id":"operacao_raiz_forte","result":["montenegro_exposto","cassio_exposto","sombra_exposto"]},
+        {"id":"restituicao","scene_ref":"5.4a_restituicao","optional_scenes":4},
+        {"id":"davi_revanche","opponent":"davi_relampago","resolution":["domina","solta","estende_a_mao"]},
+        {"id":"byaku_rematch","opponent":"byaku","condition":"vencer_sem_cortar_a_faixa","unlock":"NO-GI_completo"},
+        {"id":"tinker_revela_detalhe_final","result":"explica_afastamento_e_risco_operacional_sem_revelar_pf_pela_primeira_vez"},
+        {"id":"dandara_abraco","result":"fecho_afetivo"},
+        {"id":"instituto_cria","result":"legado_material"},
+        {"id":"truth_overlay","condition":"truth_fragments>=8","main_ending":false}
+      ],
+      "causal_exit": "calculo_final + epilogos + camada A Verdade"
+    }
+  ],
+  "continuity_rules": {
+    "biel_death_act": 4,
+    "vera_recruitment_act": 2,
+    "tinker_pf_known_before_act5": true,
+    "truth_overlay_not_main_ending": true,
+    "institute_cria_required": true
+  }
+}

--- a/data/narrative/canon_v4.json
+++ b/data/narrative/canon_v4.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "cria_narrative_canon_v4",
+  "version": "4.0.0-candidate.1",
+  "status": "CANON_CANDIDATE_NOT_RUNTIME_AUTHORITY",
+  "current_runtime_authority": "data/narrative/canon_v3.json",
+  "promotion_requires": ["narrative_v4_validator_pass", "repository_quality_pass", "human_canon_approval", "runtime_migration_plan"],
+  "thesis": {
+    "phrase": "Ser forte e ser gentil.",
+    "dramatic_question": "Ruan consegue transformar forca em responsabilidade sem transformar dor em vinganca?",
+    "rating_tone": "16+ por peso moral, sem glamour da violencia",
+    "symbol": "Gorila Silverback"
+  },
+  "setting": {"region": "Baixo Sul da Bahia", "main_hub": "Itubera"},
+  "prologue": "data/narrative/prologue_v1.json",
+  "act_identity_policy": {
+    "stable_ids": ["ato_1_o_chao", "ato_2_o_molde", "ato_3_o_nome", "ato_4_a_queda", "ato_5_o_legado"],
+    "display_subtitles": {
+      "ato_1_o_chao": "RAIZ",
+      "ato_2_o_molde": "CIRCUITO",
+      "ato_3_o_nome": "SOMBRA",
+      "ato_4_a_queda": "TERRITORIO",
+      "ato_5_o_legado": "VERDADE"
+    },
+    "ids_must_not_be_renamed": true
+  },
+  "migration_decisions": {
+    "vera_id": "vera_salles",
+    "vera_recruitment": "end_of_act_2_mandatory",
+    "tinker_knows_operation_from": "act_2",
+    "tinker_act5_reveal": "hidden_final_operation_detail_not_initial_pf_affiliation",
+    "chupeta": {"status": "NEW_CHARACTER_CANDIDATE_PENDING_CHARACTER_REGISTRY", "dramatic_function": "coercion_betting_militia", "must_not_replace": ["cassio_molho", "dr_sombra", "delegado_montenegro"]},
+    "pipoca": {"survives": true, "dramatic_function": "future_generation_at_risk"},
+    "biel": {"death_remains_act_4_irreversible": true},
+    "dende_truth": "perpetuated_silence_but_not_sole_author_of_erasure",
+    "teruko_name_policy": {"spoken_before_truth_threshold": false, "truth_fragments_required": 8, "spoken_after_threshold": true},
+    "truth_layer": {"main_ending": false, "overlay": true},
+    "chupeta_climax": "ruan_releases_submission_then_stabilizes_control",
+    "act5_required_payoffs": ["restituicao", "davi_revanche", "byaku_rematch", "dandara_abraco", "instituto_cria"]
+  },
+  "antagonist_functions": {
+    "cassio_molho": "personal_shortcut_and_temptation",
+    "dr_sombra": "land_capital_and_speculation",
+    "chupeta_candidate": "physical_coercion_betting_and_militia",
+    "delegado_montenegro": "false_institutional_pressure"
+  },
+  "truth_policy": {
+    "fragments_authority": "data/narrative/tekuro_fragments_v2.json",
+    "threshold": 8,
+    "name": "Teruko Nishiuchi",
+    "pre_threshold_public_name_forbidden": true,
+    "post_threshold_name_reveal_required": true,
+    "revenge_interpretation_forbidden": true
+  },
+  "ending_policy": {
+    "main_endings": ["heroi_duas_aguas", "rei_dos_atalhos"],
+    "truth_is_overlay": true,
+    "truth_may_overlay_both": true,
+    "choices_not_score_only": true
+  },
+  "ethics": {
+    "no_real_person_portraits": true,
+    "no_real_org_defamation": true,
+    "violence_has_consequence": true,
+    "revenge_arc_forbidden": true,
+    "regional_language_preserved": true,
+    "crime_glamor_forbidden": true
+  }
+}

--- a/data/narrative/chorus_v1.json
+++ b/data/narrative/chorus_v1.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "cria_narrative_chorus_v1",
+  "version": "1.0.0",
+  "status": "CANON_V4_CANDIDATE",
+  "authority": "data/narrative/canon_v4.json",
+  "purpose": "Narrador comunitario diegetico: comenta, exagera, lembra e corrige a fama de Ruan sem funcionar como narrador onisciente absoluto.",
+  "rules": {
+    "regional_language_preserved": true,
+    "may_exaggerate_public_events": true,
+    "may_not_reveal_hidden_truth_before_gate": true,
+    "may_not_glamorize_crime": true,
+    "silence_is_allowed_as_narrative_event": true
+  },
+  "act_openings": [
+    {"act":0,"line":"Dois menino e um carro de mao. O Baixo Sul inteiro cabia naquilo."},
+    {"act":1,"epigraph":"Menino que nasce de rio nao aprende a nadar: lembra.","function":"belonging"},
+    {"act":2,"epigraph":"Toda porta e uma boca: umas mordem, outras beijam, todas cobram.","function":"recognition"},
+    {"act":3,"epigraph":"No mangue, quem pisa leve nao afunda; quem pisa sozinho, afunda duas vezes.","function":"moral_cost"},
+    {"act":4,"epigraph":"Vento que vem do mar nao pede licenca; vento que vem de homem, menos ainda.","function":"assumption"},
+    {"act":5,"epigraph":"Nome apagado e semente: espera debaixo da terra ate chover justica.","function":"legacy","truth_safe":true}
+  ],
+  "interludes": [
+    {"id":"coro_dique","after":"primeira_luta_oficial_dique","line":"Diz que o menino do Dende derrubou um homem do tamanho de um saveiro. Diz que nao sorriu. Diz que pediu desculpa."},
+    {"id":"coro_pipoca","after":"pipoca_isca","tone":"first_collective_grief","line":"Naquele dia ninguem aumentou historia. O que doeu ja era grande demais."},
+    {"id":"coro_avesso","during":"pratigi_do_avesso","mode":"silence","duration_rule":"scene_owned"}
+  ],
+  "ending_variants": {
+    "heroi_duas_aguas":"O nome ficou grande porque coube mais gente dentro dele.",
+    "rei_dos_atalhos":"Todo mundo sabia o nome. Quase ninguem sabia chegar perto.",
+    "truth_overlay":{"requires_truth_fragments":8,"line":"Teruko Nishiuchi.","name_reveal":true}
+  }
+}

--- a/data/narrative/dialogues_v4.json
+++ b/data/narrative/dialogues_v4.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "cria_dialogues_v4",
+  "version": "4.0.0-candidate.1",
+  "status": "CANON_V4_CANDIDATE",
+  "authority": "data/narrative/canon_v4.json",
+  "rules": {
+    "language": "pt-BR",
+    "regional_grammar_preserved": true,
+    "pre_truth_hidden_name_forbidden": true,
+    "truth_name_unlock_threshold": 8,
+    "revenge_language_forbidden": true
+  },
+  "prologue_dialogues": [
+    {"id":"p0_tinker_duas_corridas","speaker":"tinker_bell","line":"Duas corrida, quatro real. Tu e lento hoje, Macacao."},
+    {"id":"p0_ruan_carga_quebrada","speaker":"ruan_macacao","line":"Lento nao. Cuidadoso. Carga quebrada nao paga."},
+    {"id":"p0_coro_dois_meninos","speaker":"coro","line":"Dois menino e um carro de mao. O Baixo Sul inteiro cabia naquilo."},
+    {"id":"p0_dende_terceiro_jeito","speaker":"mestre_dende","line":"Menino, tu e grande pra brigar e pequeno pra se esconder. Vem ca que eu te ensino um terceiro jeito."},
+    {"id":"p0_dende_tabuleiro_anda","speaker":"mestre_dende","line":"E tu, que joga xadrez: o tatame e um tabuleiro que anda. Vem os dois."},
+    {"id":"p0_degodo_corpo_nao_mente","speaker":"degodo","line":"Gi e roupa. Luta e corpo. E corpo nao mente."},
+    {"id":"p0_tinker_pensa_nao_cansa","speaker":"tinker_bell","line":"Tu ganhou no cansaco, nao na forca. Se tu cansa, tu perde. Se tu pensa, tu nao cansa."},
+    {"id":"p0_coro_um_so_lutador","speaker":"coro","line":"Naquele dia o carro de mao aposentou. E dois menino viraram um so lutador."}
+  ],
+  "act_dialogues": [
+    {"act":1,"scene":"entrada_terreiro","beats":[
+      {"speaker":"mestre_dende","line":"Pressao nao e forca, menino. Pressao e presenca."},
+      {"speaker":"ruan_macacao","line":"Eu vim aprender a vencer."},
+      {"speaker":"mestre_dende","line":"Entao aprende primeiro a cair sem procurar culpado."}
+    ]},
+    {"act":1,"scene":"faixa_azul","beats":[
+      {"speaker":"mestre_dende","line":"Forca sem gentileza e so medo com musculo. Nao me volta pra casa com medo com musculo."}
+    ]},
+    {"act":2,"scene":"concha_davi","beats":[
+      {"speaker":"davi_relampago","line":"Tu e bom, Macacao. Mas bom nao ganha. Quem ganha e quem quer mais."}
+    ]},
+    {"act":2,"scene":"vera_recruta","beats":[
+      {"speaker":"vera_salles","line":"Nao quero um policial. Quero um cria. So quem a rua abraca entra onde o dinheiro mora."},
+      {"speaker":"tinker_bell","line":"Se ele entra, eu desenho a saida."}
+    ]},
+    {"act":3,"scene":"degodo_descobre_disfarce","beats":[
+      {"speaker":"degodo","line":"Se tu cair, eu nao te levanto. Eu desco junto. Mas tu nao volta la sem eu."}
+    ]},
+    {"act":3,"scene":"faixa_marrom","beats":[
+      {"speaker":"mestre_dende","line":"A pergunta nao e se tu desceu. E se tu lembra o caminho de volta."}
+    ]},
+    {"act":4,"scene":"dende_admite_silencio","beats":[
+      {"speaker":"mestre_dende","line":"Eu sabia mais do que te contei."},
+      {"speaker":"mestre_dende","line":"Achei que silencio era protecao. Agora eu sei que silencio tambem protege quem apaga."}
+    ]},
+    {"act":4,"scene":"pratigi_do_avesso","beats":[
+      {"speaker":"ruan_do_avesso","line":"Eu sou o que sobra quando tu chama medo de necessidade."},
+      {"speaker":"ruan_macacao","line":"Tu nao e meu inimigo."},
+      {"speaker":"ruan_do_avesso","line":"Entao prova que consegue me carregar sem me obedecer."}
+    ]},
+    {"act":4,"scene":"faixa_preta","beats":[
+      {"speaker":"mestre_dende","line":"Agora tu nao e meu aluno. Tu e meu colega."}
+    ]},
+    {"act":5,"scene":"ruan_vs_chupeta","character_registry_status":"candidate_pending","beats":[
+      {"speaker":"ruan_macacao","line":"Eu podia. Eu nao vou. E isso que tu nunca vai entender.","mechanical_condition":"submission_released_then_control_stabilized"}
+    ]},
+    {"act":5,"scene":"davi_revanche","beats":[
+      {"speaker":"davi_relampago","line":"Vai apertar?"},
+      {"speaker":"ruan_macacao","line":"Ja acabou."},
+      {"speaker":"davi_relampago","line":"Agora tu entendeu timing."}
+    ]},
+    {"act":5,"scene":"tinker_revela_detalhe_final","beats":[
+      {"speaker":"tinker_bell","line":"Eu nao escondi de tu que a gente tava dentro. Escondi a ultima parte porque Montenegro ja tava ligando meu nome ao teu."},
+      {"speaker":"ruan_macacao","line":"E tu esperava que eu entendesse sozinho?"},
+      {"speaker":"tinker_bell","line":"Nao. Eu esperava voltar vivo pra explicar."}
+    ]}
+  ],
+  "truth_dialogues": [
+    {
+      "id":"truth_name_reveal",
+      "requires_truth_fragments":8,
+      "pre_threshold_forbidden":true,
+      "beats":[
+        {"speaker":"coro","line":"Teruko Nishiuchi."},
+        {"speaker":"crianca_epilogo","line":"Sensei, quem foi Teruko Nishiuchi?"},
+        {"speaker":"sensei_epilogo","line":"Deixa eu te contar."}
+      ]
+    }
+  ]
+}

--- a/data/narrative/endings_v3.json
+++ b/data/narrative/endings_v3.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "cria_endings_v3",
+  "version": "3.0.0-candidate.1",
+  "status": "CANON_V4_CANDIDATE",
+  "authority": "data/narrative/canon_v4.json",
+  "main_endings": [
+    {
+      "id": "heroi_duas_aguas",
+      "title": "Heroi das Duas Aguas",
+      "conditions": {"contract_not":"cassio","verdade_gte_faca":true,"honra_min":25},
+      "resolution": "Ruan fica, ensina e transforma o Terreiro em base concreta do Instituto CRIA.",
+      "core_sequence": ["terreiro_cheio","pipoca_faixa_primeira_crianca","carro_de_mao_retorna","filo_acaraje_amanhecer"],
+      "final_line": "Forca sem gentileza e so medo com musculo.",
+      "tone": "esperancoso_sem_santificacao"
+    },
+    {
+      "id": "rei_dos_atalhos",
+      "title": "Rei dos Atalhos",
+      "conditions_any": [{"contract":"cassio"},{"faca_gt_verdade":true}],
+      "resolution": "Ruan vence externamente, mas sua forca depende de controle, medo e imagem.",
+      "core_sequence": ["tatame_de_luxo","terreiro_materialmente_rico","dende_ausente","coro_ausente"],
+      "tone": "vitoria_externa_perda_interna"
+    }
+  ],
+  "truth_overlay": {
+    "id": "a_verdade",
+    "main_ending": false,
+    "independent": true,
+    "required_fragments": 8,
+    "can_overlay": ["heroi_duas_aguas","rei_dos_atalhos"],
+    "sequence": [
+      {"id":"placa_restaurada","text":"TERUKO NISHIUCHI — UMA DAS RAIZES DO TERREIRO.","requires_truth_fragments":8},
+      {"id":"coro_nomeia","spoken_name":"Teruko Nishiuchi","requires_truth_fragments":8},
+      {"id":"camelia","action":"Ruan planta uma camelia em silencio."},
+      {"id":"anos_depois","dialogue_ref":"truth_name_reveal"}
+    ],
+    "rule": "A verdade amplia o significado do final principal sem apagar escolhas, Maos Sujas ou cicatrizes."
+  },
+  "selection_order": ["main_ending","compatible_epilogues","truth_overlay"],
+  "design_rules": {
+    "truth_layer_is_not_a_third_main_ending": true,
+    "multiple_compatible_epilogues_allowed": true,
+    "maos_sujas_scar_is_never_erased": true,
+    "ending_must_reflect_choices_not_score_only": true,
+    "carro_de_mao_returns_only_in_hero_sequence": true
+  }
+}

--- a/data/narrative/prologue_v1.json
+++ b/data/narrative/prologue_v1.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "cria_narrative_prologue_v1",
+  "version": "1.0.0",
+  "status": "CANON_V4_CANDIDATE",
+  "authority": "data/narrative/canon_v4.json",
+  "id": "parte_zero_o_carro_de_mao",
+  "title": "O CARRO DE MAO",
+  "timeline": {"age": 12, "before_act_1": true},
+  "motif": {"id": "carro_de_mao", "origin": "trabalho_na_feira", "returns_in": ["terreiro_origin", "ending_heroi"]},
+  "scenes": [
+    {
+      "id": "c0_1_feira_itubera",
+      "location": "feira",
+      "presentation": "gameplay",
+      "mechanic": "carro_de_mao_delivery",
+      "summary": "Ruan e Tinker carregam compras por R$2 por corrida e aprendem que cuidado tambem e trabalho.",
+      "dialogue_refs": ["p0_tinker_duas_corridas", "p0_ruan_carga_quebrada", "p0_coro_dois_meninos"]
+    },
+    {
+      "id": "c0_2_a_cobranca",
+      "location": "feira",
+      "presentation": "choice",
+      "summary": "Cobradores tentam tomar o carro e o dinheiro.",
+      "choices": [
+        {"id": "resistir", "effects": {"sombra_seed": 1, "dinheiro": -1}},
+        {"id": "recuar", "effects": {"honra_seed": 1, "dinheiro": -1}}
+      ],
+      "mandatory_exit": "dende_intervem"
+    },
+    {
+      "id": "c0_3_o_pulso",
+      "location": "feira",
+      "presentation": "cutscene",
+      "summary": "Dende desequilibra, controla e senta o cobrador sem lesioná-lo; convida os dois meninos ao Terreiro.",
+      "violence_rule": "control_without_injury",
+      "dialogue_refs": ["p0_dende_terceiro_jeito", "p0_dende_tabuleiro_anda"]
+    },
+    {
+      "id": "c0_4_primeira_roda",
+      "location": "terreiro",
+      "presentation": "gameplay",
+      "mechanic": "soft_sparring_ruan_tinker",
+      "summary": "O tatame remendado chega ao Terreiro em partes transportadas no carro de mao.",
+      "dialogue_refs": ["p0_degodo_corpo_nao_mente"]
+    },
+    {
+      "id": "c0_5_o_tabuleiro",
+      "location": "terreiro",
+      "presentation": "cutscene",
+      "summary": "Tinker reconstrói a luta como mate em tres e o carro de mao vira reliquia do Terreiro.",
+      "dialogue_refs": ["p0_tinker_pensa_nao_cansa", "p0_coro_um_so_lutador"],
+      "title_card_after": "CRIA DO TATAME"
+    }
+  ],
+  "guardrails": {
+    "no_child_graphic_violence": true,
+    "no_crime_glamor": true,
+    "regional_language_preserved": true,
+    "runtime_integration": "pending"
+  }
+}

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -30,6 +30,13 @@ Este arquivo é a porta de entrada da documentação ativa. Antes de criar um do
 - `canon/` — personagens, facções, mundo e narrativa aprovados;
 - `gameplay/` — combate, progressão, regras e economia.
 
+## Narrativa
+
+- [`../data/narrative/canon_v3.json`](../data/narrative/canon_v3.json) — autoridade narrativa ativa;
+- [`narrative/NARRATIVE_V3_TO_V4_MIGRATION.md`](narrative/NARRATIVE_V3_TO_V4_MIGRATION.md) — migração candidata Parte Zero + atos v4; **não é autoridade runtime**;
+- [`../data/narrative/canon_v4.json`](../data/narrative/canon_v4.json) — candidato v4 explicitamente subordinado ao canon v3 até promoção;
+- [`../tools/data/validate_narrative_v4_candidate.py`](../tools/data/validate_narrative_v4_candidate.py) — gate fail-closed do candidato v4.
+
 ## Migrações ativas
 
 - [`migrations/V4_2_FACTIONS_SAVE.md`](migrations/V4_2_FACTIONS_SAVE.md) — explicação simples da migração para `ALE`, `LEM`, `NTM` e save v5.
@@ -54,6 +61,7 @@ Este arquivo é a porta de entrada da documentação ativa. Antes de criar um do
 - [`../tools/audit/validate_faction_migration_v4_2.py`](../tools/audit/validate_faction_migration_v4_2.py) — gate das três facções, aliases e save v5;
 - [`../tools/art/validate_sprite_forge.py`](../tools/art/validate_sprite_forge.py) — gate de consistência entre ações de personagens;
 - [`../tools/data/validate_bjj_reducer_v2_slice.py`](../tools/data/validate_bjj_reducer_v2_slice.py) — gate fail-closed do reducer v2 e do fixture Ruan × Davi;
+- [`../tools/data/validate_narrative_v4_candidate.py`](../tools/data/validate_narrative_v4_candidate.py) — gate de continuidade da migração narrativa v4;
 - [`../tools/ai_asset_pipeline/cloud/validate_cloud_pipeline.py`](../tools/ai_asset_pipeline/cloud/validate_cloud_pipeline.py) — gate offline do adaptador de nuvem.
 
 ## Status dos documentos

--- a/docs/narrative/NARRATIVE_V3_TO_V4_MIGRATION.md
+++ b/docs/narrative/NARRATIVE_V3_TO_V4_MIGRATION.md
@@ -1,0 +1,55 @@
+# Narrative v3 → v4 candidate migration
+
+Status: **candidate, not runtime authority**.
+
+Current runtime/canonical authority remains `data/narrative/canon_v3.json` until explicit promotion.
+
+## Purpose
+
+Materialize the approved full-script direction without silently rewriting existing persistent IDs, endings or runtime assumptions.
+
+## Stable identities
+
+The five act IDs remain unchanged:
+
+- `ato_1_o_chao` — display subtitle `RAIZ`
+- `ato_2_o_molde` — display subtitle `CIRCUITO`
+- `ato_3_o_nome` — display subtitle `SOMBRA`
+- `ato_4_a_queda` — display subtitle `TERRITORIO`
+- `ato_5_o_legado` — display subtitle `VERDADE`
+
+`Parte Zero — O Carro de Mão` is a new pre-Act-1 prologue and does not renumber the five acts.
+
+## Intentional v4 deltas
+
+1. Vera remains `vera_salles`, but recruitment moves from optional Act 3 to mandatory end of Act 2.
+2. Tinker knows the operation from Act 2; the Act-5 reveal becomes the hidden final operational detail / reason for his distancing, not a first-time PF reveal.
+3. Chupeta is a new character candidate for coercion/betting/militia. He cannot replace Cassio, Sombra or Montenegro until character-registry migration is approved.
+4. Pipoca survives and represents the next generation at risk. Biel remains the irreversible Act-4 loss.
+5. Dendê admits that he perpetuated silence; the migration does not make him sole author of Teruko's erasure.
+6. Teruko's name remains forbidden in public/spoken material before `truth_fragments >= 8`; after the gate, the name may be spoken, printed and sung by the Coro.
+7. `A Verdade` remains an overlay compatible with either main ending, not a third mutually exclusive main ending.
+8. Against Chupeta, Ruan releases the submission and stabilizes positional control before intervention. The mechanical payoff is restraint, not prolonged submission.
+9. Act 5 retains restitution, Davi rematch, Byaku rematch, Dandara and Instituto CRIA.
+10. The wheelbarrow motif returns in the hero ending.
+
+## Explicit non-migrations
+
+- No save IDs are renamed.
+- No mission IDs are changed in this batch.
+- `canon_v3.json`, `acts_v3.json`, `dialogues.json` and `endings_v2.json` are not edited.
+- Rating remains the current 16+ tone contract pending a separate content-rating review.
+- Runtime managers and scenes are unchanged.
+
+## Promotion gate
+
+Promotion to active narrative authority requires:
+
+1. `validate_narrative_v4_candidate.py` pass;
+2. repository quality pass;
+3. human canon approval;
+4. mission/runtime mapping plan;
+5. character-registry decision for Chupeta;
+6. save migration review if any persistent narrative state changes.
+
+Rollback is deletion of the v4 candidate files; v3 remains untouched throughout this phase.

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "test:bjj-kg-authoring": "python -m unittest discover -s tests -p 'test_bjj_kg_authoring_contract.py'",
     "validate:bjj-reducer-v2": "python tools/data/validate_bjj_reducer_v2_slice.py",
     "test:bjj-reducer-v2": "python -m unittest discover -s tests -p 'test_bjj_reducer_v2_contract.py'",
+    "validate:narrative-v4": "python tools/data/validate_narrative_v4_candidate.py",
+    "test:narrative-v4": "python -m unittest discover -s tests -p 'test_narrative_v4_candidate.py'",
     "assets:manifest": "node tools/node/generate_asset_manifest.mjs",
     "assets:queue": "python tools/ai_asset_pipeline/build_production_queue_v02.py",
     "assets:spriteframes": "python tools/art/build_spriteframes.py",
@@ -38,7 +40,7 @@
     "cloud:batch": "python tools/ai_asset_pipeline/cloud/prepare_batch.py --output-dir tools/ai_asset_pipeline/generated_outputs/candidate_batches",
     "animations:generate": "python tools/animation/generate_character_animation_pack.py",
     "validate:animations": "python tools/animation/generate_character_animation_pack.py --validate-only",
-    "quality": "npm run validate:governance && npm run validate:canon && npm run validate:factions-v4 && npm run validate:phase1-data && npm run validate:skill-tree-visual && npm run validate:python && npm run validate:node && npm run validate:data && npm run validate:cloud && npm run test:cloud && npm run validate:animations && npm run validate:asset-protocol && npm run validate:sprite-forge && npm run validate:sprite-forge-phase1 && npm run test:sprite-forge && npm run test:sprite-forge-phase1 && npm run validate:bjj-kg-authoring && npm run test:bjj-kg-authoring && npm run validate:bjj-reducer-v2 && npm run test:bjj-reducer-v2 && npm run validate:repository && npm run validate:runtime && npm run validate:release && npm run validate:supreme && npm run validate:deck",
+    "quality": "npm run validate:governance && npm run validate:canon && npm run validate:factions-v4 && npm run validate:phase1-data && npm run validate:skill-tree-visual && npm run validate:python && npm run validate:node && npm run validate:data && npm run validate:cloud && npm run test:cloud && npm run validate:animations && npm run validate:asset-protocol && npm run validate:sprite-forge && npm run validate:sprite-forge-phase1 && npm run test:sprite-forge && npm run test:sprite-forge-phase1 && npm run validate:bjj-kg-authoring && npm run test:bjj-kg-authoring && npm run validate:bjj-reducer-v2 && npm run test:bjj-reducer-v2 && npm run validate:narrative-v4 && npm run test:narrative-v4 && npm run validate:repository && npm run validate:runtime && npm run validate:release && npm run validate:supreme && npm run validate:deck",
     "build:android:windows": "powershell -ExecutionPolicy Bypass -File tools/build/build_android_debug.ps1",
     "build:android:linux": "bash tools/build/build_android_debug.sh",
     "build:windows": "powershell -ExecutionPolicy Bypass -File tools/build/build_windows_debug.ps1"

--- a/tests/test_narrative_v4_candidate.py
+++ b/tests/test_narrative_v4_candidate.py
@@ -1,0 +1,60 @@
+import importlib.util
+import json
+import pathlib
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "tools" / "data" / "validate_narrative_v4_candidate.py"
+
+spec = importlib.util.spec_from_file_location("validate_narrative_v4_candidate", SCRIPT)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(module)
+
+
+class NarrativeV4CandidateTests(unittest.TestCase):
+    def load(self, name: str):
+        return json.loads((ROOT / "data" / "narrative" / name).read_text(encoding="utf-8"))
+
+    def test_validator_passes_candidate(self):
+        self.assertEqual(module.validate(), [])
+
+    def test_v3_remains_runtime_authority(self):
+        canon = self.load("canon_v4.json")
+        self.assertEqual(canon["status"], "CANON_CANDIDATE_NOT_RUNTIME_AUTHORITY")
+        self.assertEqual(canon["current_runtime_authority"], "data/narrative/canon_v3.json")
+
+    def test_act_ids_stay_stable(self):
+        acts = self.load("acts_v4.json")
+        self.assertEqual([a["id"] for a in acts["acts"]], module.EXPECTED_ACT_IDS)
+
+    def test_truth_is_overlay_not_third_main_ending(self):
+        endings = self.load("endings_v3.json")
+        self.assertEqual(len(endings["main_endings"]), 2)
+        self.assertFalse(endings["truth_overlay"]["main_ending"])
+        self.assertEqual(endings["truth_overlay"]["required_fragments"], 8)
+
+    def test_teruko_spoken_only_behind_truth_gate(self):
+        dialogues = self.load("dialogues_v4.json")
+        ungated = json.dumps(dialogues["prologue_dialogues"] + dialogues["act_dialogues"], ensure_ascii=False)
+        self.assertNotIn("Teruko Nishiuchi", ungated)
+        gated = dialogues["truth_dialogues"]
+        self.assertTrue(any("Teruko Nishiuchi" in json.dumps(x, ensure_ascii=False) for x in gated))
+        self.assertTrue(all(x.get("requires_truth_fragments", 0) >= 8 for x in gated))
+
+    def test_chupeta_climax_encodes_restraint(self):
+        acts = self.load("acts_v4.json")
+        found = module._find_beat(acts, "ruan_vs_chupeta")
+        self.assertIsNotNone(found)
+        self.assertEqual(found[1]["finish_rule"], "release_submission_then_stabilize_control")
+
+    def test_prologue_has_five_scenes_and_choice_not_fake_third_choice(self):
+        prologue = self.load("prologue_v1.json")
+        self.assertEqual(len(prologue["scenes"]), 5)
+        choice = next(s for s in prologue["scenes"] if s["id"] == "c0_2_a_cobranca")
+        self.assertEqual([c["id"] for c in choice["choices"]], ["resistir", "recuar"])
+        self.assertEqual(choice["mandatory_exit"], "dende_intervem")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/data/validate_narrative_v4_candidate.py
+++ b/tools/data/validate_narrative_v4_candidate.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Validate the narrative v4 candidate without promoting it to runtime authority."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+N = ROOT / "data" / "narrative"
+
+EXPECTED_ACT_IDS = [
+    "ato_1_o_chao",
+    "ato_2_o_molde",
+    "ato_3_o_nome",
+    "ato_4_a_queda",
+    "ato_5_o_legado",
+]
+
+
+def load(name: str) -> dict:
+    path = N / name
+    if not path.exists():
+        raise AssertionError(f"missing {path.relative_to(ROOT)}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _find_beat(acts: dict, beat_id: str) -> tuple[int, dict] | None:
+    for index, act in enumerate(acts.get("acts", []), start=1):
+        for beat in act.get("required_beats", []):
+            if beat.get("id") == beat_id:
+                return index, beat
+    return None
+
+
+def validate() -> list[str]:
+    errors: list[str] = []
+    canon = load("canon_v4.json")
+    prologue = load("prologue_v1.json")
+    acts = load("acts_v4.json")
+    dialogues = load("dialogues_v4.json")
+    chorus = load("chorus_v1.json")
+    endings = load("endings_v3.json")
+
+    if canon.get("status") != "CANON_CANDIDATE_NOT_RUNTIME_AUTHORITY":
+        errors.append("canon_v4 must remain candidate, not runtime authority")
+    if canon.get("current_runtime_authority") != "data/narrative/canon_v3.json":
+        errors.append("canon_v3 must remain current runtime authority")
+
+    stable = canon.get("act_identity_policy", {}).get("stable_ids", [])
+    if stable != EXPECTED_ACT_IDS:
+        errors.append("stable act IDs changed")
+    actual = [a.get("id") for a in acts.get("acts", [])]
+    if actual != EXPECTED_ACT_IDS:
+        errors.append("acts_v4 IDs/order must preserve v3")
+
+    if prologue.get("id") != "parte_zero_o_carro_de_mao":
+        errors.append("Parte Zero ID missing")
+    if len(prologue.get("scenes", [])) != 5:
+        errors.append("Parte Zero must contain C0.1-C0.5")
+
+    vera = _find_beat(acts, "vera_recruta")
+    if not vera or vera[0] != 2 or not vera[1].get("mandatory"):
+        errors.append("Vera recruitment must be mandatory in Act 2")
+    elif "vera_salles" not in vera[1].get("characters", []):
+        errors.append("Vera ID must remain vera_salles")
+
+    biel = _find_beat(acts, "morte_biel")
+    if not biel or biel[0] != 4 or not biel[1].get("irreversible"):
+        errors.append("Biel irreversible death must remain in Act 4")
+
+    pipoca = _find_beat(acts, "pipoca_isca")
+    if not pipoca or not pipoca[1].get("pipoca_survives"):
+        errors.append("Pipoca must survive the bait beat")
+
+    chupeta = _find_beat(acts, "ruan_vs_chupeta")
+    if not chupeta or chupeta[1].get("finish_rule") != "release_submission_then_stabilize_control":
+        errors.append("Chupeta climax must resolve by released submission then stable control")
+
+    for required in ["restituicao", "davi_revanche", "byaku_rematch", "dandara_abraco", "instituto_cria"]:
+        found = _find_beat(acts, required)
+        if not found or found[0] != 5:
+            errors.append(f"Act 5 payoff missing: {required}")
+
+    truth_policy = canon.get("truth_policy", {})
+    threshold = truth_policy.get("threshold")
+    if threshold != 8:
+        errors.append("truth threshold must remain 8")
+
+    forbidden_name = truth_policy.get("name", "Teruko Nishiuchi")
+    for group_name in ["prologue_dialogues", "act_dialogues"]:
+        for entry in dialogues.get(group_name, []):
+            text = json.dumps(entry, ensure_ascii=False)
+            if forbidden_name in text:
+                errors.append(f"hidden truth name leaked before gate in {group_name}")
+    for entry in dialogues.get("truth_dialogues", []):
+        if forbidden_name in json.dumps(entry, ensure_ascii=False) and entry.get("requires_truth_fragments", 0) < threshold:
+            errors.append("truth dialogue names Teruko without threshold gate")
+
+    truth_chorus = chorus.get("ending_variants", {}).get("truth_overlay", {})
+    if truth_chorus.get("requires_truth_fragments") != 8 or not truth_chorus.get("name_reveal"):
+        errors.append("Coro truth reveal must be gated at 8 fragments")
+
+    mains = endings.get("main_endings", [])
+    if [e.get("id") for e in mains] != ["heroi_duas_aguas", "rei_dos_atalhos"]:
+        errors.append("endings_v3 must keep exactly the two established main endings")
+    overlay = endings.get("truth_overlay", {})
+    if overlay.get("main_ending") is not False or overlay.get("required_fragments") != 8:
+        errors.append("A Verdade must remain an 8-fragment overlay, not a main ending")
+    if set(overlay.get("can_overlay", [])) != {"heroi_duas_aguas", "rei_dos_atalhos"}:
+        errors.append("truth overlay must remain compatible with both main endings")
+
+    hero = next((e for e in mains if e.get("id") == "heroi_duas_aguas"), {})
+    if "carro_de_mao_retorna" not in hero.get("core_sequence", []):
+        errors.append("wheelbarrow motif must return in hero ending")
+
+    decisions = canon.get("migration_decisions", {})
+    if decisions.get("tinker_knows_operation_from") != "act_2":
+        errors.append("Tinker must know the operation from Act 2")
+    if decisions.get("dende_truth") != "perpetuated_silence_but_not_sole_author_of_erasure":
+        errors.append("Dende silence semantics drifted")
+
+    return errors
+
+
+def main() -> int:
+    errors = validate()
+    if errors:
+        for err in errors:
+            print(f"ERROR: {err}")
+        print(f"narrative-v4: FAIL ({len(errors)} errors)")
+        return 1
+    print("narrative-v4: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #97.

## What this materializes
- `prologue_v1.json`: Parte Zero / O Carro de Mão (5 scenes, 2 real choices + mandatory Dendê intervention)
- `canon_v4.json`: candidate authority only; `canon_v3` remains runtime authority
- `acts_v4.json`: stable act IDs with RAIZ/CIRCUITO/SOMBRA/TERRITORIO/VERDADE as display subtitles
- `dialogues_v4.json`: regional dialogue + truth-gated name reveal
- `chorus_v1.json`: diegetic Coro with silence/name-reveal rules
- `endings_v3.json`: two main endings + `A Verdade` overlay
- v3→v4 migration ledger
- fail-closed validator + unittest suite
- quality wiring + dedicated workflow

## Locked migration decisions
- Vera remains `vera_salles`; recruitment moves to mandatory end of Act 2.
- Tinker knows the operation in Act 2; Act-5 reveal is a hidden operational detail, not first-time PF disclosure.
- Chupeta remains a character candidate and cannot replace Cassio/Sombra/Montenegro yet.
- Pipoca survives; Biel remains the irreversible Act-4 loss.
- Dendê perpetuated silence but is not sole author of Teruko's erasure.
- `Teruko Nishiuchi` may be spoken only at `truth_fragments >= 8`.
- Truth remains an overlay, not a third main ending.
- Ruan releases the submission against Chupeta and stabilizes positional control.
- Restitution, Davi, Byaku, Dandara and Instituto CRIA remain Act-5 payoffs.

## Explicitly untouched
`canon_v3.json`, `acts_v3.json`, `dialogues.json`, `endings_v2.json`, missions, runtime managers, saves and scenes.

## Promotion
This PR may land the **candidate package**, but it does not by itself promote v4 to runtime/canonical authority. Promotion still requires human canon approval plus mission/runtime/save mapping.