### PR TITLE
feat(ai): add pinned Qwen 2512 Pixel Art candidate pipeline

### DIFF
--- a/data/ai/model_registry_v02.json
+++ b/data/ai/model_registry_v02.json
@@ -2,7 +2,7 @@
   "schema_version": "2.0.0",
   "contract_id": "cria_do_tatame_hugging_face_model_registry_v02",
   "status": "research_registry",
-  "audited_at": "2026-08-10",
+  "audited_at": "2026-09-09",
   "revision_policy": "resolve_ref_to_immutable_sha_per_batch",
   "runtime_policy": "offline_candidate_research_only",
   "shipping_policy": "human_license_quality_and_canon_approval_required",
@@ -42,6 +42,31 @@
       "adoption_status": "research_only",
       "source_url": "https://huggingface.co/artificialguybr/PixelArtRedmond",
       "notes": "Adapter research only; resolve and record an immutable revision for every batch."
+    },
+    {
+      "id": "Qwen/Qwen-Image-2512",
+      "role": "high-capacity base image model for CRIA pixel-art candidate generation",
+      "requested_ref": "ca98f15a127a0c732aec7e60ba6e783fb953d490",
+      "license": "apache-2.0",
+      "adoption_status": "candidate_generation_allowed",
+      "source_url": "https://huggingface.co/Qwen/Qwen-Image-2512",
+      "notes": "Audited as the declared base of the CRIA pixel-art LoRA. Large model footprint; offline authoring only. Base output never bypasses art-direction, provenance, QA or human approval."
+    },
+    {
+      "id": "prithivMLmods/Qwen-Image-2512-Pixel-Art-LoRA",
+      "role": "primary pixel-art candidate adapter for environments, props, icons and character concept passes",
+      "requested_ref": "e14eea588e8e4a9c753439e52a203d06288769c5",
+      "license": "apache-2.0",
+      "adoption_status": "candidate_generation_allowed",
+      "source_url": "https://huggingface.co/prithivMLmods/Qwen-Image-2512-Pixel-Art-LoRA",
+      "base_model": "Qwen/Qwen-Image-2512",
+      "trigger": "Pixel Art",
+      "weights_file": "Qwen-Image-2512-Master-Pixel-Art-LoRA.safetensors",
+      "weights_sha256": "2a2775ac823b3704eba2f72f3be65d7b0fe3262f1822e971c16818d0c923a4b6",
+      "weights_size_bytes": 1267015356,
+      "training_card_images": 50,
+      "training_dataset_provenance": "not_disclosed_in_model_card",
+      "notes": "Candidate generation is allowed, not shipping. Model card declares Apache-2.0, Qwen-Image-2512 base, trigger `Pixel Art`, 45–50 inference steps and 50 training images. Training-image provenance is not disclosed, so every output remains subject to rights review and human approval. This LoRA does not replace Sprite Forge, identity lock, paired-BJJ biomechanics or manual pixel cleanup."
     },
     {
       "id": "xinsir/controlnet-openpose-sdxl-1.0",

--- a/data/ai/model_registry_v02.json
+++ b/data/ai/model_registry_v02.json
@@ -63,7 +63,7 @@
       "trigger": "Pixel Art",
       "weights_file": "Qwen-Image-2512-Master-Pixel-Art-LoRA.safetensors",
       "weights_sha256": "2a2775ac823b3704eba2f72f3be65d7b0fe3262f1822e971c16818d0c923a4b6",
-      "weights_size_bytes": 1267015356,
+      "weights_size_hub_display": "1.18 GB",
       "training_card_images": 50,
       "training_dataset_provenance": "not_disclosed_in_model_card",
       "notes": "Candidate generation is allowed, not shipping. Model card declares Apache-2.0, Qwen-Image-2512 base, trigger `Pixel Art`, 45–50 inference steps and 50 training images. Training-image provenance is not disclosed, so every output remains subject to rights review and human approval. This LoRA does not replace Sprite Forge, identity lock, paired-BJJ biomechanics or manual pixel cleanup."

--- a/data/ai/qwen_pixel_art_profile_v1.json
+++ b/data/ai/qwen_pixel_art_profile_v1.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "cria.qwen_pixel_art_profile.v1",
+  "version": "1.0.0",
+  "status": "CANDIDATE_AUTHORING_PROFILE",
+  "runtime_authority": false,
+  "shipping": false,
+  "model_registry": "data/ai/model_registry_v02.json",
+  "base_model": {
+    "id": "Qwen/Qwen-Image-2512",
+    "revision": "ca98f15a127a0c732aec7e60ba6e783fb953d490",
+    "license_metadata": "apache-2.0"
+  },
+  "lora": {
+    "id": "prithivMLmods/Qwen-Image-2512-Pixel-Art-LoRA",
+    "revision": "e14eea588e8e4a9c753439e52a203d06288769c5",
+    "license_metadata": "apache-2.0",
+    "trigger": "Pixel Art",
+    "weights_file": "Qwen-Image-2512-Master-Pixel-Art-LoRA.safetensors",
+    "weights_sha256": "2a2775ac823b3704eba2f72f3be65d7b0fe3262f1822e971c16818d0c923a4b6",
+    "training_images_declared": 50,
+    "training_dataset_provenance": "NOT_DISCLOSED_IN_MODEL_CARD"
+  },
+  "acquisition": {
+    "metadata_clone": "GIT_LFS_SKIP_SMUDGE=1 git clone https://huggingface.co/prithivMLmods/Qwen-Image-2512-Pixel-Art-LoRA",
+    "metadata_clone_semantics": "CLONES_POINTERS_AND_METADATA_ONLY",
+    "weights_download_policy": "ON_DEMAND_PINNED_REVISION_ONLY",
+    "persistent_public_repo_cache": false,
+    "verify_sha256_before_inference": true
+  },
+  "inference": {
+    "dtype_preferred": "bfloat16",
+    "device_preferred": "cuda",
+    "steps_default": 48,
+    "steps_allowed": [45, 46, 47, 48, 49, 50],
+    "published_dimensions": [
+      {"width": 1024, "height": 1024, "use": "character_identity_concept_or_square_asset"},
+      {"width": 1280, "height": 832, "use": "arena_environment_concept"}
+    ],
+    "dimension_note": "The upstream card labels 1280x832 as 3:1, but 1280/832 is approximately 1.538; CRIA records the dimensions, not the incorrect ratio label."
+  },
+  "routing": {
+    "high_value": [
+      "arena_environment_concept",
+      "regional_props",
+      "collectable_concepts",
+      "icon_concepts",
+      "story_scene_concepts"
+    ],
+    "conditional": [
+      "character_turnaround_concept",
+      "character_combat_pose_concept",
+      "portrait_concept"
+    ],
+    "not_authoritative_alone": [
+      "fighter_core_spritesheet",
+      "fighter_clinch_spritesheet",
+      "fighter_ground_spritesheet",
+      "paired_bjj_technique",
+      "identity_from_real_person_reference",
+      "ui_with_baked_text"
+    ]
+  },
+  "prompt_contract": {
+    "prefix": "Pixel Art, CRIA DO TATAME Regional Premium 2D pixel art, Brazilian Baixo Sul Bahia, true square pixel grid, crisp manual pixel clusters, cel-shaded surfaces, grounded anatomy, no smooth vector, no photo, no 3D CGI,",
+    "must_append_from_skill": ".agents/skills/cria-art-direction/SKILL.md",
+    "forbid_baked_text_by_default": true,
+    "forbid_real_brand_marks": true,
+    "forbid_unapproved_faction_or_canon_changes": true
+  },
+  "postprocess_required": [
+    "human_visual_selection",
+    "identity_lock_when_character",
+    "palette_snap",
+    "manual_pixel_cleanup",
+    "nearest_neighbor_normalization",
+    "set_pivot_when_sprite",
+    "sprite_forge_qa_when_sprite",
+    "paired_sync_and_bjj_biomechanics_when_technique",
+    "provenance_sidecar",
+    "rights_review",
+    "human_approval",
+    "godot_integration_before_product_status"
+  ],
+  "promotion_guards": {
+    "generation_implies_approval": false,
+    "generation_implies_rights_clearance": false,
+    "generation_implies_shipping": false,
+    "model_license_implies_training_dataset_provenance": false
+  }
+}

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -23,7 +23,8 @@ Este arquivo é a porta de entrada da documentação ativa. Antes de criar um do
 - [`../production/coverage/asset_links_v1.json`](../production/coverage/asset_links_v1.json) — vínculo explícito requisito→binário para coverage e shipping;
 - [`../data/visual/sprite_forge_contract_v1.json`](../data/visual/sprite_forge_contract_v1.json) — consistência quantitativa de sprites sobre o Asset Pipeline v2;
 - [`../data/production/repository_governance_v01.json`](../data/production/repository_governance_v01.json) — governança validável por máquina;
-- [`../data/ai/cloud_drive_layout_v01.json`](../data/ai/cloud_drive_layout_v01.json) — árvore privada e política de promoção do adaptador Drive.
+- [`../data/ai/cloud_drive_layout_v01.json`](../data/ai/cloud_drive_layout_v01.json) — árvore privada e política de promoção do adaptador Drive;
+- [`../data/ai/qwen_pixel_art_profile_v1.json`](../data/ai/qwen_pixel_art_profile_v1.json) — perfil pinado do stack Qwen 2512 + Pixel Art LoRA para geração de candidatos.
 
 ## Produto e gameplay
 
@@ -51,6 +52,7 @@ Este arquivo é a porta de entrada da documentação ativa. Antes de criar um do
 - [`architecture/CRIA_SPRITE_FORGE_V1.md`](architecture/CRIA_SPRITE_FORGE_V1.md) — perfil mestre, anchor/scale QA e handoff de sprites para o pipeline existente;
 - [`production/APK_VISUAL_COMPLETION_PLAN_V09.md`](production/APK_VISUAL_COMPLETION_PLAN_V09.md) — gates de vertical slice e Android;
 - [`production/DRIVE_CLOUD_V1.md`](production/DRIVE_CLOUD_V1.md) — adaptador privado Google Drive, Colab, rclone e provenance Hugging Face;
+- [`production/QWEN_PIXEL_ART_AUTHORING_V1.md`](production/QWEN_PIXEL_ART_AUTHORING_V1.md) — uso auditado do Qwen Pixel Art LoRA como gerador de candidatos, com clone metadata-only e download pinado;
 - [`../data/ai/model_registry_v02.json`](../data/ai/model_registry_v02.json) — auditoria e gates atuais de modelos Hugging Face.
 
 ## Engenharia e QA
@@ -66,7 +68,8 @@ Este arquivo é a porta de entrada da documentação ativa. Antes de criar um do
 - [`../tools/ci/derive_production_manifest_v03.py`](../tools/ci/derive_production_manifest_v03.py) — derivador determinístico de requisitos de produção;
 - [`../tools/ci/validate_production_coverage_v03.py`](../tools/ci/validate_production_coverage_v03.py) — coverage normal + shipping fail-closed;
 - [`../tools/data/validate_bjj_reducer_v2_slice.py`](../tools/data/validate_bjj_reducer_v2_slice.py) — gate fail-closed do reducer v2 e do fixture Ruan × Davi;
-- [`../tools/ai_asset_pipeline/cloud/validate_cloud_pipeline.py`](../tools/ai_asset_pipeline/cloud/validate_cloud_pipeline.py) — gate offline do adaptador de nuvem.
+- [`../tools/ai_asset_pipeline/cloud/validate_cloud_pipeline.py`](../tools/ai_asset_pipeline/cloud/validate_cloud_pipeline.py) — gate offline do adaptador de nuvem;
+- [`../tools/ai_asset_pipeline/cloud/validate_qwen_pixel_art_profile.py`](../tools/ai_asset_pipeline/cloud/validate_qwen_pixel_art_profile.py) — gate fail-closed do stack Qwen Pixel Art.
 
 ## Status dos documentos
 

--- a/docs/production/QWEN_PIXEL_ART_AUTHORING_V1.md
+++ b/docs/production/QWEN_PIXEL_ART_AUTHORING_V1.md
@@ -1,0 +1,133 @@
+# Qwen Pixel Art Authoring v1
+
+**Status:** ACTIVE CANDIDATE TOOLING  
+**Runtime authority:** none  
+**Shipping default:** false
+
+## Purpose
+
+Use `prithivMLmods/Qwen-Image-2512-Pixel-Art-LoRA` as a high-capacity **candidate generator** inside CRIA's visual production pipeline. It is not the art-direction authority and it does not replace Sprite Forge, identity lock, paired BJJ animation review, provenance, rights review or human approval.
+
+The authoritative CRIA profile is:
+
+`data/ai/qwen_pixel_art_profile_v1.json`
+
+## Audited stack
+
+- base: `Qwen/Qwen-Image-2512`;
+- base revision: `ca98f15a127a0c732aec7e60ba6e783fb953d490`;
+- adapter: `prithivMLmods/Qwen-Image-2512-Pixel-Art-LoRA`;
+- adapter revision: `e14eea588e8e4a9c753439e52a203d06288769c5`;
+- license metadata observed on both: Apache-2.0;
+- LoRA trigger: `Pixel Art`;
+- weight: `Qwen-Image-2512-Master-Pixel-Art-LoRA.safetensors`;
+- weight SHA-256: `2a2775ac823b3704eba2f72f3be65d7b0fe3262f1822e971c16818d0c923a4b6`;
+- Hub-displayed weight size: 1.18 GB;
+- declared training images: 50;
+- training dataset provenance: not disclosed in the model card.
+
+The last item prevents any inference from model license -> dataset provenance -> shipping rights. Outputs remain candidate-only until reviewed.
+
+## Metadata-only audit clone
+
+Use the command supplied for lightweight inspection:
+
+```bash
+GIT_LFS_SKIP_SMUDGE=1 git clone https://huggingface.co/prithivMLmods/Qwen-Image-2512-Pixel-Art-LoRA
+```
+
+This intentionally avoids pulling the large LFS/Xet weight during metadata audit. It is not an inference install.
+
+## Production download rule
+
+Do not render from mutable `main`. Resolve/pin the audited revision and fetch only the required weight on the GPU worker/Colab session. One acceptable pattern is:
+
+```bash
+hf download prithivMLmods/Qwen-Image-2512-Pixel-Art-LoRA \
+  Qwen-Image-2512-Master-Pixel-Art-LoRA.safetensors \
+  --revision e14eea588e8e4a9c753439e52a203d06288769c5 \
+  --local-dir /content/cria-models/qwen-pixel-art
+```
+
+Then verify SHA-256 before inference. Large base-model caches should remain ephemeral where possible.
+
+## Routing
+
+### High-value uses
+
+- arena/environment concept passes;
+- regional props;
+- collectible concepts;
+- icon concepts;
+- story-scene concepts.
+
+### Conditional uses
+
+- character turnaround concepts;
+- combat-pose concepts;
+- portrait concepts.
+
+Character output must still pass identity lock and cannot be treated as a faithful likeness merely because a prompt mentions a reference person.
+
+### Not authoritative alone
+
+- fighter core/clinch/ground spritesheets;
+- paired BJJ techniques;
+- identity from real-person references;
+- UI containing baked text.
+
+Those need the project-specific motion, identity, UI and biomechanical pipelines.
+
+## Inference baseline
+
+The upstream model card publishes:
+
+- trigger `Pixel Art`;
+- 45–50 inference steps;
+- 1024×1024;
+- 1280×832.
+
+CRIA uses 48 steps as a middle baseline for candidate experiments. The upstream card labels 1280×832 as `3:1`; that label is mathematically inconsistent, so CRIA records the dimensions but not the ratio label.
+
+## CRIA prompt prefix
+
+Every request starts from the repository art-direction contract, not from a generic pixel-art prompt. The profile stores a baseline prefix that includes:
+
+- `Pixel Art` trigger;
+- CRIA Regional Premium 2D pixel art;
+- Baixo Sul da Bahia;
+- crisp square pixel clusters;
+- cel shading;
+- grounded anatomy;
+- no smooth vector/photo/3D CGI;
+- no unapproved brands/canon changes.
+
+The rest of the prompt is derived from `.agents/skills/cria-art-direction/SKILL.md` and the COMMAND source data.
+
+## Mandatory postprocess
+
+```text
+generated candidate
+    -> human visual selection
+    -> identity lock (characters)
+    -> palette snap
+    -> manual pixel cleanup
+    -> nearest-neighbor normalization
+    -> pivot normalization (sprites)
+    -> Sprite Forge QA (sprites)
+    -> paired sync + BJJ biomechanics (techniques)
+    -> provenance + rights sidecars
+    -> human approval
+    -> Godot integration
+    -> runtime evidence
+    -> shipping gate
+```
+
+Generation never implies approval, rights clearance, integration or shipping.
+
+## Validation
+
+```bash
+npm run validate:qwen-pixel-art
+python -m unittest discover -s tests/cloud -p 'test_qwen_pixel_art_profile.py'
+```

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "validate:node": "node tools/node/validate_json.mjs",
     "validate:data": "node tools/node/validate_game_data.mjs",
     "validate:cloud": "python tools/ai_asset_pipeline/cloud/validate_cloud_pipeline.py",
+    "validate:qwen-pixel-art": "python tools/ai_asset_pipeline/cloud/validate_qwen_pixel_art_profile.py",
     "test:cloud": "python -m unittest discover -s tests/cloud -p 'test_*.py'",
     "validate:repository": "python tools/validate_complete_game.py",
     "validate:runtime": "python tools/validate_runtime_contracts.py",
@@ -43,7 +44,7 @@
     "cloud:batch": "python tools/ai_asset_pipeline/cloud/prepare_batch.py --output-dir tools/ai_asset_pipeline/generated_outputs/candidate_batches",
     "animations:generate": "python tools/animation/generate_character_animation_pack.py",
     "validate:animations": "python tools/animation/generate_character_animation_pack.py --validate-only",
-    "quality": "npm run validate:governance && npm run validate:canon && npm run validate:factions-v4 && npm run validate:phase1-data && npm run validate:skill-tree-visual && npm run validate:python && npm run validate:node && npm run validate:data && npm run validate:cloud && npm run test:cloud && npm run validate:animations && npm run validate:asset-protocol && npm run validate:sprite-forge && npm run validate:sprite-forge-phase1 && npm run test:sprite-forge && npm run test:sprite-forge-phase1 && npm run validate:art-direction && npm run test:art-direction && npm run derive:production-v03 && npm run validate:production-v03 && npm run test:production-v03 && npm run validate:bjj-kg-authoring && npm run test:bjj-kg-authoring && npm run validate:bjj-reducer-v2 && npm run test:bjj-reducer-v2 && npm run validate:repository && npm run validate:runtime && npm run validate:release && npm run validate:supreme && npm run validate:deck",
+    "quality": "npm run validate:governance && npm run validate:canon && npm run validate:factions-v4 && npm run validate:phase1-data && npm run validate:skill-tree-visual && npm run validate:python && npm run validate:node && npm run validate:data && npm run validate:cloud && npm run validate:qwen-pixel-art && npm run test:cloud && npm run validate:animations && npm run validate:asset-protocol && npm run validate:sprite-forge && npm run validate:sprite-forge-phase1 && npm run test:sprite-forge && npm run test:sprite-forge-phase1 && npm run validate:art-direction && npm run test:art-direction && npm run derive:production-v03 && npm run validate:production-v03 && npm run test:production-v03 && npm run validate:bjj-kg-authoring && npm run test:bjj-kg-authoring && npm run validate:bjj-reducer-v2 && npm run test:bjj-reducer-v2 && npm run validate:repository && npm run validate:runtime && npm run validate:release && npm run validate:supreme && npm run validate:deck",
     "build:android:windows": "powershell -ExecutionPolicy Bypass -File tools/build/build_android_debug.ps1",
     "build:android:linux": "bash tools/build/build_android_debug.sh",
     "build:windows": "powershell -ExecutionPolicy Bypass -File tools/build/build_windows_debug.ps1"

--- a/tests/cloud/test_qwen_pixel_art_profile.py
+++ b/tests/cloud/test_qwen_pixel_art_profile.py
@@ -1,0 +1,56 @@
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+PROFILE = ROOT / "data/ai/qwen_pixel_art_profile_v1.json"
+REGISTRY = ROOT / "data/ai/model_registry_v02.json"
+VALIDATOR = ROOT / "tools/ai_asset_pipeline/cloud/validate_qwen_pixel_art_profile.py"
+
+
+class QwenPixelArtProfileTests(unittest.TestCase):
+    def test_validator_passes(self):
+        result = subprocess.run(
+            [sys.executable, str(VALIDATOR)],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertTrue(payload["ok"])
+        self.assertFalse(payload["shipping"])
+
+    def test_model_stack_is_registered_and_pinned(self):
+        profile = json.loads(PROFILE.read_text(encoding="utf-8"))
+        registry = json.loads(REGISTRY.read_text(encoding="utf-8"))
+        models = {row["id"]: row for row in registry["models"]}
+        for key in ("base_model", "lora"):
+            descriptor = profile[key]
+            entry = models[descriptor["id"]]
+            self.assertEqual(entry["requested_ref"], descriptor["revision"])
+            self.assertEqual(entry["license"], "apache-2.0")
+            self.assertEqual(entry["adoption_status"], "candidate_generation_allowed")
+
+    def test_training_data_provenance_risk_is_not_hidden(self):
+        profile = json.loads(PROFILE.read_text(encoding="utf-8"))
+        self.assertEqual(
+            profile["lora"]["training_dataset_provenance"],
+            "NOT_DISCLOSED_IN_MODEL_CARD",
+        )
+        self.assertFalse(profile["promotion_guards"]["model_license_implies_training_dataset_provenance"])
+        self.assertFalse(profile["promotion_guards"]["generation_implies_shipping"])
+
+    def test_bjj_and_runtime_sprite_roles_remain_non_authoritative(self):
+        profile = json.loads(PROFILE.read_text(encoding="utf-8"))
+        blocked = set(profile["routing"]["not_authoritative_alone"])
+        self.assertIn("paired_bjj_technique", blocked)
+        self.assertIn("fighter_ground_spritesheet", blocked)
+        self.assertIn("identity_from_real_person_reference", blocked)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/ai_asset_pipeline/cloud/validate_qwen_pixel_art_profile.py
+++ b/tools/ai_asset_pipeline/cloud/validate_qwen_pixel_art_profile.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Fail-closed offline gate for the CRIA Qwen-Image-2512 Pixel Art authoring profile."""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[3]
+PROFILE_PATH = ROOT / "data/ai/qwen_pixel_art_profile_v1.json"
+REGISTRY_PATH = ROOT / "data/ai/model_registry_v02.json"
+HEX40 = re.compile(r"^[0-9a-f]{40}$")
+HEX64 = re.compile(r"^[0-9a-f]{64}$")
+
+
+def load(path: Path, errors: list[str]) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        errors.append(f"invalid JSON {path.relative_to(ROOT)}: {exc}")
+        return {}
+    if not isinstance(value, dict):
+        errors.append(f"JSON root is not an object: {path.relative_to(ROOT)}")
+        return {}
+    return value
+
+
+def main() -> int:
+    errors: list[str] = []
+    profile = load(PROFILE_PATH, errors)
+    registry = load(REGISTRY_PATH, errors)
+    if errors:
+        print(json.dumps({"ok": False, "errors": errors}, ensure_ascii=False, indent=2))
+        return 1
+
+    if profile.get("status") != "CANDIDATE_AUTHORING_PROFILE":
+        errors.append("Qwen profile must remain CANDIDATE_AUTHORING_PROFILE")
+    if profile.get("runtime_authority") is not False:
+        errors.append("Qwen profile must never have runtime authority")
+    if profile.get("shipping") is not False:
+        errors.append("Qwen generation profile must default shipping=false")
+
+    base = profile.get("base_model", {})
+    lora = profile.get("lora", {})
+    if base.get("id") != "Qwen/Qwen-Image-2512":
+        errors.append("Unexpected Qwen base model")
+    if lora.get("id") != "prithivMLmods/Qwen-Image-2512-Pixel-Art-LoRA":
+        errors.append("Unexpected pixel-art LoRA")
+    for label, revision in (("base", base.get("revision")), ("lora", lora.get("revision"))):
+        if not isinstance(revision, str) or not HEX40.fullmatch(revision):
+            errors.append(f"{label} revision must be a full immutable 40-char SHA")
+    if base.get("license_metadata") != "apache-2.0" or lora.get("license_metadata") != "apache-2.0":
+        errors.append("Audited Qwen base/LoRA license metadata drifted")
+    if lora.get("trigger") != "Pixel Art":
+        errors.append("Pixel-art trigger must remain exactly `Pixel Art`")
+    if not isinstance(lora.get("weights_sha256"), str) or not HEX64.fullmatch(lora["weights_sha256"]):
+        errors.append("LoRA weights SHA256 must be pinned")
+    if lora.get("training_dataset_provenance") != "NOT_DISCLOSED_IN_MODEL_CARD":
+        errors.append("Training dataset provenance risk must remain explicit")
+
+    acquisition = profile.get("acquisition", {})
+    clone = str(acquisition.get("metadata_clone", ""))
+    if not clone.startswith("GIT_LFS_SKIP_SMUDGE=1 git clone "):
+        errors.append("Metadata audit clone must skip LFS smudge")
+    if "prithivMLmods/Qwen-Image-2512-Pixel-Art-LoRA" not in clone:
+        errors.append("Metadata clone points to the wrong LoRA repository")
+    if acquisition.get("weights_download_policy") != "ON_DEMAND_PINNED_REVISION_ONLY":
+        errors.append("Weights must be downloaded only on demand at a pinned revision")
+    if acquisition.get("verify_sha256_before_inference") is not True:
+        errors.append("LoRA SHA256 verification must remain mandatory")
+
+    inference = profile.get("inference", {})
+    if inference.get("steps_default") not in inference.get("steps_allowed", []):
+        errors.append("Default inference steps must be inside the audited range")
+    if inference.get("steps_allowed") != [45, 46, 47, 48, 49, 50]:
+        errors.append("Audited LoRA inference step range drifted")
+    dims = {(d.get("width"), d.get("height")) for d in inference.get("published_dimensions", []) if isinstance(d, dict)}
+    if {(1024, 1024), (1280, 832)} - dims:
+        errors.append("Published upstream dimensions are incomplete")
+    note = str(inference.get("dimension_note", ""))
+    if "1.538" not in note or "incorrect ratio label" not in note:
+        errors.append("Upstream 1280x832 ratio-label correction must remain documented")
+
+    routing = profile.get("routing", {})
+    forbidden_authority = set(routing.get("not_authoritative_alone", []))
+    required_non_authority = {
+        "fighter_core_spritesheet",
+        "fighter_clinch_spritesheet",
+        "fighter_ground_spritesheet",
+        "paired_bjj_technique",
+        "identity_from_real_person_reference",
+        "ui_with_baked_text",
+    }
+    if not required_non_authority.issubset(forbidden_authority):
+        errors.append("Qwen LoRA is being over-promoted beyond safe authoring roles")
+
+    post = set(profile.get("postprocess_required", []))
+    required_post = {
+        "human_visual_selection",
+        "palette_snap",
+        "manual_pixel_cleanup",
+        "sprite_forge_qa_when_sprite",
+        "provenance_sidecar",
+        "rights_review",
+        "human_approval",
+        "godot_integration_before_product_status",
+    }
+    if not required_post.issubset(post):
+        errors.append("Qwen profile lost mandatory post-processing/promotion gates")
+
+    guards = profile.get("promotion_guards", {})
+    for key in (
+        "generation_implies_approval",
+        "generation_implies_rights_clearance",
+        "generation_implies_shipping",
+        "model_license_implies_training_dataset_provenance",
+    ):
+        if guards.get(key) is not False:
+            errors.append(f"Promotion guard must remain false: {key}")
+
+    models = {item.get("id"): item for item in registry.get("models", []) if isinstance(item, dict)}
+    for descriptor in (base, lora):
+        model_id = descriptor.get("id")
+        entry = models.get(model_id)
+        if not entry:
+            errors.append(f"Qwen profile model missing from registry: {model_id}")
+            continue
+        if entry.get("adoption_status") != "candidate_generation_allowed":
+            errors.append(f"Qwen stack must be candidate_generation_allowed: {model_id}")
+        if entry.get("requested_ref") != descriptor.get("revision"):
+            errors.append(f"Profile/registry revision mismatch: {model_id}")
+        if entry.get("license") != descriptor.get("license_metadata"):
+            errors.append(f"Profile/registry license mismatch: {model_id}")
+
+    result = {
+        "ok": not errors,
+        "errors": errors,
+        "base": base.get("id"),
+        "lora": lora.get("id"),
+        "shipping": profile.get("shipping"),
+    }
+    print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0 if not errors else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Extends #103 with an audited Hugging Face candidate-generation stack for CRIA's Premium Pixel Art pipeline.

## Added
- registers `Qwen/Qwen-Image-2512` and `prithivMLmods/Qwen-Image-2512-Pixel-Art-LoRA` in `model_registry_v02`;
- pins the audited revisions instead of rendering from mutable `main`;
- records trigger `Pixel Art`, LoRA weight SHA-256 and upstream training-card facts;
- adds `data/ai/qwen_pixel_art_profile_v1.json` with routing, acquisition, inference and promotion guards;
- preserves the user's `GIT_LFS_SKIP_SMUDGE=1 git clone ...` as **metadata-only audit**;
- adds `validate_qwen_pixel_art_profile.py` + cloud tests + `npm run validate:qwen-pixel-art`;
- documents the authoring workflow.

## Important limits
- candidate generation only; no runtime authority and `shipping=false`;
- upstream model card declares only 50 training images and does not disclose training-dataset provenance, so model license does not imply output shipping clearance;
- the LoRA is useful for environments/props/icons/story concepts and conditional character concept passes;
- it is **not** authoritative alone for fighter spritesheets, paired BJJ techniques, real-person identity fidelity or UI with baked text;
- Sprite Forge, identity lock, palette/pivot normalization, manual pixel cleanup, provenance/rights and human approval remain mandatory.

## Audit correction
The upstream card labels 1280×832 as `3:1`; CRIA records the dimensions but rejects the ratio label because 1280/832 ≈ 1.538.

## Validation
- `npm run validate:qwen-pixel-art`
- `python -m unittest discover -s tests/cloud -p 'test_qwen_pixel_art_profile.py'`
- `npm run quality`

No model weights are committed to GitHub.