### PR TITLE
feat(production): audit external game-dev sources and gate reuse

### DIFF
--- a/.github/workflows/external-tool-intake-v1.yml
+++ b/.github/workflows/external-tool-intake-v1.yml
@@ -1,0 +1,30 @@
+name: External Tool Intake V1
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "data/production/external_tool_registry_v1.json"
+      - "tools/ci/validate_external_tool_registry_v1.py"
+      - "tests/test_external_tool_registry_v1.py"
+      - "docs/architecture/EXTERNAL_GAME_STUDIO_INTAKE_V1.md"
+      - "package.json"
+      - ".github/workflows/external-tool-intake-v1.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Validate registry policy
+        run: python tools/ci/validate_external_tool_registry_v1.py
+      - name: Run registry tests
+        run: python -m unittest discover -s tests -p 'test_external_tool_registry_v1.py'

--- a/data/production/external_tool_registry_v1.json
+++ b/data/production/external_tool_registry_v1.json
@@ -1,0 +1,151 @@
+{
+  "$schema": "cria.external_tool_registry.v1",
+  "version": "1.0.0",
+  "status": "ACTIVE_RESEARCH_REGISTRY",
+  "audited_at": "2026-09-09",
+  "default_policy": {
+    "runtime_dependency": false,
+    "shipping_default": false,
+    "pin_revision": true,
+    "copy_code_only_when_license_clear": true,
+    "copy_assets_only_when_asset_level_rights_clear": true,
+    "concept_reimplementation_allowed": true,
+    "canon_authority": false
+  },
+  "sources": [
+    {
+      "id": "qwen_2512_pixel_art_lora",
+      "kind": "hugging_face_model",
+      "source": "prithivMLmods/Qwen-Image-2512-Pixel-Art-LoRA",
+      "revision": "e14eea588e8e4a9c753439e52a203d06288769c5",
+      "license_status": "CLEAR_APACHE_2_0_METADATA",
+      "adoption": "ADOPTED_CANDIDATE_GENERATOR",
+      "direct_code_reuse": false,
+      "direct_asset_reuse": false,
+      "cria_roles": ["arena_concept", "prop_concept", "icon_concept", "story_scene_concept", "conditional_character_concept"],
+      "notes": "Already integrated through qwen_pixel_art_profile_v1. Training dataset provenance is not disclosed, therefore generation never implies shipping rights."
+    },
+    {
+      "id": "claude_code_game_studios",
+      "kind": "github_repo",
+      "source": "Donchitos/Claude-Code-Game-Studios",
+      "revision": "984023ddac0d5e27624f2baacde6105e45de375f",
+      "license_status": "CLEAR_MIT",
+      "adoption": "PORT_SELECTED_PATTERNS",
+      "direct_code_reuse": true,
+      "direct_asset_reuse": false,
+      "attribution_required": true,
+      "cria_roles": ["studio_orchestration", "godot_specialist_pattern", "asset_spec", "asset_audit", "art_bible_review", "team_combat", "team_ui", "team_qa", "release_gates", "accessibility", "performance_review"],
+      "notes": "High-value source for 49-agent/73-skill studio structure, path-scoped rules, hooks, vertical-slice gates and department review. Port only selected concepts/files after reconciliation with CRIA AGENTS, Production OS and Godot 4.3 authorities."
+    },
+    {
+      "id": "wolfcha",
+      "kind": "github_repo",
+      "source": "oil-oil/wolfcha",
+      "revision": "a4c246b09a5cdfdd88a07db8a0a6dbca403142ad",
+      "license_status": "CONFLICT_README_MIT_LICENSE_FILE_APACHE_2_0",
+      "adoption": "REIMPLEMENT_CONCEPTS_PENDING_LICENSE_REVIEW",
+      "direct_code_reuse": false,
+      "direct_asset_reuse": false,
+      "cria_roles": ["npc_personality", "memory_grounding", "private_public_knowledge_separation", "suspicion_state", "social_decision_intent", "conversation_resume", "vote_history_pattern"],
+      "notes": "README says MIT while repository LICENSE contains Apache-2.0. Technical concepts are highly valuable for living-world NPCs: stable personalities, memory, role goals, public/private knowledge separation and fact-grounded prompts. Do not copy code until license discrepancy is explicitly resolved."
+    },
+    {
+      "id": "cline_qwen_snes_engine",
+      "kind": "github_repo",
+      "source": "QuantumBitX/cline-qwen-snes-engine",
+      "revision": "f8c2c30ffb7dfb36ef4b4315585ab321ff9bd444",
+      "license_status": "NO_LICENSE_FOUND",
+      "adoption": "STUDY_AND_REIMPLEMENT_CONCEPTS_ONLY",
+      "direct_code_reuse": false,
+      "direct_asset_reuse": false,
+      "cria_roles": ["fixed_timestep_reference", "camera_bounds", "tile_collision_reference", "autotiling_reference", "sprite_atlas_baking", "parallax_reference", "particle_pooling", "headless_behavior_tests", "data_generated_levels"],
+      "notes": "Technically strong HTML/Canvas platformer with 182 documented checks and data-driven level/sprite tooling. No LICENSE file found at the audited revision. Its Mario-style assets/content are also unsuitable for CRIA production. Use ideas only."
+    },
+    {
+      "id": "pixel_life_simulator",
+      "kind": "github_repo",
+      "source": "LabibLikesChimken/Pixel-Life-Simulator",
+      "revision": "a84301a3597f00b5f267073eb163d4faea6cec57",
+      "license_status": "NO_LICENSE_FOUND",
+      "adoption": "LOW_PRIORITY_REFERENCE_ONLY",
+      "direct_code_reuse": false,
+      "direct_asset_reuse": false,
+      "cria_roles": ["mobile_virtual_joystick_reference", "pixelated_canvas_reference", "four_direction_sprite_reference"],
+      "notes": "Small browser prototype. Useful only as a simple mobile-control/pixel-rendering reference; CRIA's Godot systems are already substantially more mature."
+    },
+    {
+      "id": "sprite_animator",
+      "kind": "github_repo",
+      "source": "poirotw66/Sprite-Animator",
+      "revision": "f713c5ae8bdc6ffe78eb3e961bd18f724eda5cfe",
+      "license_status": "CC_BY_NC_SA_4_0_NONCOMMERCIAL",
+      "adoption": "REIMPLEMENT_CONCEPTS_ONLY",
+      "direct_code_reuse": false,
+      "direct_asset_reuse": false,
+      "cria_roles": ["sprite_sheet_generation_pattern", "integer_grid_slicing", "padding_shift_alignment", "chroma_key_cleanup", "background_color_normalization", "apng_gif_zip_export", "web_worker_processing", "batch_job_restore", "secret_scan_ci_pattern"],
+      "notes": "Technically excellent and active, but commercial use of the project is blocked without a separate commercial license. Reimplement algorithms/workflow concepts independently; never copy project code into commercial CRIA without permission."
+    },
+    {
+      "id": "pixelsrpg_forge",
+      "kind": "github_repo",
+      "source": "Huu-Yuu/PixelSRPG-Forge",
+      "revision": "5ff74c28ea96798d43e55cafbabbee80c8945a4f",
+      "license_status": "REPO_STRUCTURE_MIT_ASSET_RIGHTS_UNKNOWN",
+      "adoption": "TAXONOMY_AND_TOOL_REFERENCE_ONLY",
+      "direct_code_reuse": false,
+      "direct_asset_reuse": false,
+      "cria_roles": ["asset_taxonomy_reference", "coverage_checklist_reference", "atlas_packer_reference"],
+      "notes": "README states assets were collected from internet downloads and commercial purchases and that copyright status is not known for all materials; it even references Stardew Valley assets. No asset may enter CRIA shipping from this collection without item-level provenance."
+    },
+    {
+      "id": "mia_deepseek_v4_1_html_100",
+      "kind": "design_benchmark_repo",
+      "source": "MiaAI-Lab/DeepSeek-v4-1-Flash-100-HTML-Files",
+      "revision": "main",
+      "license_status": "NO_LICENSE_FOUND",
+      "adoption": "DESIGN_PATTERN_REFERENCE_ONLY",
+      "direct_code_reuse": false,
+      "direct_asset_reuse": false,
+      "cria_roles": ["ui_creativity_reference", "microinteraction_reference", "procedural_visual_reference", "accessibility_motion_reference"],
+      "favorite_patterns": {
+        "077_pixel_art_studio": ["draw", "erase", "fill", "color_pick", "undo_redo", "zoom", "preview"],
+        "006_editorial_spread": ["strong_hierarchy", "limited_accent_color", "responsive_layout", "reduced_motion"],
+        "098_domino_cascade": ["place_draw_chain", "slow_motion", "sound_toggle", "zoom"],
+        "004_rain_alley": ["multi_pass_weather", "reflections", "screen_shake", "pointer_light", "reduced_motion"],
+        "007_kinetic_clock": ["state_change_animation", "real_time_loop", "style_presets", "reduced_motion"],
+        "032_glitch_lab": ["controlled_post_fx", "presets", "freeze_frame"],
+        "033_soft_synth": ["direct_manipulation_controls", "keyboard_shortcuts", "procedural_audio"],
+        "034_kaleidoscope": ["mirrored_drawing", "brush_controls", "undo"],
+        "059_cursor_comet": ["velocity_driven_particles", "intensity_hold", "burst", "trail_length"],
+        "080_vinyl_deck": ["direct_manipulation", "procedural_audio", "pitch_control", "one_shots"],
+        "100_metamorphosis": ["swarm_states", "scatter", "swirl", "repel"]
+      },
+      "notes": "Useful as a creativity and interaction benchmark. No repository license was found, so CRIA may study and reimplement interaction ideas but should not copy the HTML/CSS/JS wholesale."
+    },
+    {
+      "id": "mia_gpt6_astra_html_100",
+      "kind": "design_benchmark_repo",
+      "source": "MiaAI-Lab/GPT-6-Astra-100-HTML-Files",
+      "revision": "main",
+      "license_status": "UNVERIFIED_FOR_CODE_REUSE",
+      "adoption": "COMPARATIVE_DESIGN_REFERENCE_ONLY",
+      "direct_code_reuse": false,
+      "direct_asset_reuse": false,
+      "cria_roles": ["ui_benchmark_comparison", "creative_diversity_reference"],
+      "notes": "Comparison corpus only. Model-ranking claims from social posts are subjective benchmark commentary, not engineering evidence for CRIA."
+    },
+    {
+      "id": "old_cria_android_repo",
+      "kind": "github_repo",
+      "source": "ringuemkt-rgb/Cria-do-tatame-",
+      "revision": "main",
+      "license_status": "INTERNAL_DEACTIVATED_REPO",
+      "adoption": "BLOCKED_DEACTIVATED",
+      "direct_code_reuse": false,
+      "direct_asset_reuse": false,
+      "cria_roles": [],
+      "notes": "README explicitly marks this old Android/Gradle prototype as deactivated and points all work to ringuemkt-rgb/cria-do-tatame."
+    }
+  ]
+}

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -18,6 +18,7 @@ Este arquivo é a porta de entrada da documentação ativa. Antes de criar um do
 - [`../data/production/supreme_build_contract_v01.json`](../data/production/supreme_build_contract_v01.json) — metas e release gates;
 - [`../data/production/release_gate_status_v01.json`](../data/production/release_gate_status_v01.json) — ledger único com evidências e pendências de release;
 - [`../data/production/game_build_matrix_v1.json`](../data/production/game_build_matrix_v1.json) — matriz machine-readable de completude do jogo inteiro, G0–G8;
+- [`../data/production/external_tool_registry_v1.json`](../data/production/external_tool_registry_v1.json) — intake auditado de repositórios/modelos/benchmarks externos e políticas de reuso;
 - [`../data/visual/production_manifest_v03.json`](../data/visual/production_manifest_v03.json) — contrato ativo de derivação audiovisual fail-closed;
 - [`../data/visual/production_manifest_v02.json`](../data/visual/production_manifest_v02.json) — inventário audiovisual histórico/compatível usado como entrada do v03;
 - [`../production/coverage/asset_links_v1.json`](../production/coverage/asset_links_v1.json) — vínculo explícito requisito→binário para coverage e shipping;
@@ -41,6 +42,7 @@ Este arquivo é a porta de entrada da documentação ativa. Antes de criar um do
 ## Arte e produção
 
 - [`architecture/CRIA_PRODUCTION_OS_V03.md`](architecture/CRIA_PRODUCTION_OS_V03.md) — derivação data-driven, coverage ledger e gates de promoção até shipping;
+- [`architecture/EXTERNAL_GAME_STUDIO_INTAKE_V1.md`](architecture/EXTERNAL_GAME_STUDIO_INTAKE_V1.md) — regras de ADOPT/PORT/REIMPLEMENT/REFERENCE/BLOCK para fontes externas;
 - [`../.agents/skills/cria-art-direction/SKILL.md`](../.agents/skills/cria-art-direction/SKILL.md) — skill mestre de direção visual; cânone, paleta, personagens, facções, arenas, mapas, UI, cartas, QA, rights e protocolo COMMAND;
 - [`../.agents/skills/cria-art-direction/references/anchors.md`](../.agents/skills/cria-art-direction/references/anchors.md) — hierarquia de âncoras e correções de cânone;
 - [`../.agents/skills/cria-art-direction/references/palette.md`](../.agents/skills/cria-art-direction/references/palette.md) — tokens de paleta e variantes cerimoniais;
@@ -67,6 +69,7 @@ Este arquivo é a porta de entrada da documentação ativa. Antes de criar um do
 - [`../.agents/skills/cria-art-direction/scripts/validate_skill.py`](../.agents/skills/cria-art-direction/scripts/validate_skill.py) — gate fail-closed da skill e da fila P1;
 - [`../tools/ci/derive_production_manifest_v03.py`](../tools/ci/derive_production_manifest_v03.py) — derivador determinístico de requisitos de produção;
 - [`../tools/ci/validate_production_coverage_v03.py`](../tools/ci/validate_production_coverage_v03.py) — coverage normal + shipping fail-closed;
+- [`../tools/ci/validate_external_tool_registry_v1.py`](../tools/ci/validate_external_tool_registry_v1.py) — bloqueia reuso direto de fontes sem licença clara, NC, conflitantes ou desativadas;
 - [`../tools/data/validate_bjj_reducer_v2_slice.py`](../tools/data/validate_bjj_reducer_v2_slice.py) — gate fail-closed do reducer v2 e do fixture Ruan × Davi;
 - [`../tools/ai_asset_pipeline/cloud/validate_cloud_pipeline.py`](../tools/ai_asset_pipeline/cloud/validate_cloud_pipeline.py) — gate offline do adaptador de nuvem;
 - [`../tools/ai_asset_pipeline/cloud/validate_qwen_pixel_art_profile.py`](../tools/ai_asset_pipeline/cloud/validate_qwen_pixel_art_profile.py) — gate fail-closed do stack Qwen Pixel Art.

--- a/docs/architecture/EXTERNAL_GAME_STUDIO_INTAKE_V1.md
+++ b/docs/architecture/EXTERNAL_GAME_STUDIO_INTAKE_V1.md
@@ -1,0 +1,183 @@
+# External Game Studio Intake v1
+
+**Status:** ACTIVE research/governance layer  
+**Runtime authority:** none  
+**Shipping authority:** none
+
+## Purpose
+
+CRIA can learn aggressively from open repositories, model hubs and design benchmarks without turning the game into an uncontrolled dependency bundle or contaminating commercial shipping with unclear licenses.
+
+Every external source enters through:
+
+```text
+source
+  -> repository/model inspection
+  -> immutable revision
+  -> license + asset-rights classification
+  -> role mapping
+  -> ADOPT / PORT / REIMPLEMENT / REFERENCE / BLOCK
+  -> CRIA-native tests and contracts
+  -> only then implementation
+```
+
+The machine-readable authority for this intake is:
+
+`data/production/external_tool_registry_v1.json`
+
+## Triage classes
+
+### ADOPTED_CANDIDATE_GENERATOR
+External model/tool may generate offline candidates, but output remains subject to CRIA art direction, provenance, rights, QA, human approval and Godot integration.
+
+Current example: pinned Qwen-Image-2512 Pixel Art LoRA.
+
+### PORT_SELECTED_PATTERNS
+License is clear enough for selected code/document patterns to be ported, with attribution where required. CRIA contracts and architecture still win on conflict.
+
+Current example: `Donchitos/Claude-Code-Game-Studios` (MIT).
+
+### REIMPLEMENT_CONCEPTS_ONLY / STUDY_AND_REIMPLEMENT_CONCEPTS_ONLY
+Technical ideas may be studied and independently implemented, but source code is not copied. This is required for non-commercial, no-license or otherwise unsuitable sources.
+
+### DESIGN_PATTERN_REFERENCE_ONLY / COMPARATIVE_DESIGN_REFERENCE_ONLY
+Visual/interaction benchmark only. No HTML/CSS/JS or assets are copied.
+
+### BLOCKED_DEACTIVATED
+Source must not receive new implementation work.
+
+## Highest-value transfers
+
+### 1. Claude Code Game Studios -> CRIA Studio Orchestrator
+
+The audited source provides a professional AI-studio structure with 49 agents, 73 skills, hooks, path-scoped rules, specialist roles and director gates. CRIA should not import the entire `.claude` tree blindly. The useful transfer is the **coordination model**:
+
+```text
+CRIA Producer/Orchestrator
+  ├── Creative/Canon
+  ├── Godot Technical Director
+  │    ├── GDScript/runtime
+  │    ├── tools/build
+  │    └── performance
+  ├── Combat/BJJ
+  ├── Art Director
+  │    ├── Sprite Forge
+  │    ├── Maps/Arenas
+  │    └── UI/technical art
+  ├── World/Narrative
+  ├── Audio
+  └── QA/Accessibility/Release
+```
+
+Existing CRIA authorities remain above this layer:
+
+`AGENTS.md -> canon/supreme contracts -> Production OS -> domain contracts -> orchestrator skill`.
+
+Priority patterns to port/rewrite:
+
+- project-stage detection;
+- art-bible review;
+- asset-spec and asset-audit workflows;
+- vertical-slice gate;
+- team-combat/team-ui/team-qa orchestration;
+- Godot specialist review;
+- performance/accessibility/release gates;
+- session state + gap detection;
+- path-scoped review rules.
+
+## 2. Wolfcha -> living NPC cognition, reimplemented
+
+Wolfcha demonstrates useful architecture for AI-controlled characters:
+
+- stable personality;
+- memory of observed events;
+- role/faction goals;
+- private vs public knowledge boundaries;
+- fact-grounded decisions;
+- suspicion/pressure state;
+- history-aware actions and resume behavior.
+
+CRIA should reimplement these ideas in a deterministic/offline-compatible **NPC Social Memory** layer. It must not allow NPC LLM context to become world truth.
+
+Proposed invariant:
+
+```text
+WorldState facts
+      ↓
+NPC perception filter
+      ↓
+known facts + beliefs + memories
+      ↓
+intent/utility decision
+      ↓
+action/dialogue
+      ↓
+event log
+
+belief ≠ fact
+claim ≠ canon
+private knowledge never leaks unless an explicit event reveals it
+```
+
+Wolfcha direct code remains disabled while its README/license-file metadata conflict is unresolved.
+
+## 3. Sprite Animator -> independent Sprite Forge improvements
+
+The project has excellent implementation ideas:
+
+- integer grid slicing;
+- padding/shift alignment;
+- chroma cleanup;
+- background color normalization;
+- APNG/GIF/ZIP preview/export;
+- worker-based processing;
+- persistent batch jobs;
+- CI including secret scanning and distribution budgets.
+
+Its CC BY-NC-SA 4.0 license blocks commercial reuse without separate authorization. CRIA may independently implement equivalent algorithms/patterns but must not copy the code.
+
+## 4. SNES engine -> engineering patterns only
+
+The audited platformer demonstrates fixed timestep, camera bounds, tile collision, autotiling, sprite atlas baking, parallax, particle pooling, generated levels and headless regression tests. No license was found, and Mario-style content is not suitable for CRIA. Reimplement only generally applicable engineering ideas in Godot where they actually improve the existing runtime.
+
+## 5. PixelSRPG Forge -> taxonomy only
+
+The collection is useful for checking coverage categories, but its README explicitly says asset rights are uncertain and mentions internet downloads/commercial purchases. No binary from the collection may be linked in `asset_links_v1.json` without independent item-level provenance.
+
+## 6. Mia HTML benchmark -> UI/microinteraction laboratory
+
+The DeepSeek v4.1 Flash corpus is useful as a creative-interaction benchmark. No repository license was found, therefore code is reference-only.
+
+CRIA-relevant experiments include:
+
+- Pixel Art Studio: draw/erase/fill/pick, undo/redo, zoom, preview;
+- Editorial Spread: visual hierarchy + reduced motion;
+- Rain Alley: layered weather, reflection, shake, local light;
+- Kinetic Clock: state-transition animation;
+- Glitch Lab: controlled post-processing presets;
+- Cursor Comet: velocity-driven particles;
+- Vinyl Deck/Soft Synth: direct manipulation + procedural audio;
+- Metamorphosis: swarm-state transitions.
+
+These are idea sources for editor tooling, map/weather presentation, CriaLive transitions and UI polish. They are not new runtime frameworks.
+
+## Low-priority/blocked sources
+
+- Pixel Life Simulator: only simple joystick/four-direction/pixel-canvas reference; CRIA already has a stronger Godot foundation.
+- old `ringuemkt-rgb/Cria-do-tatame-`: explicitly deactivated; never implement there.
+- GPT-6 Astra HTML corpus: comparative design benchmark only.
+
+## Validation
+
+```bash
+npm run validate:external-tools
+npm run test:external-tools
+```
+
+The validator rejects direct reuse from ambiguous, non-commercial, no-license or deactivated sources. It also requires immutable SHAs for GitHub repositories that are used beyond pure comparative design reference.
+
+## Shipping rule
+
+This registry never makes an asset or implementation shipping-ready. Any imported or independently reimplemented capability must enter the normal CRIA path:
+
+`proposal -> branch -> tests -> PR -> CI -> runtime evidence -> (asset: rights + human QA) -> shipping gate`.

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "validate:cloud": "python tools/ai_asset_pipeline/cloud/validate_cloud_pipeline.py",
     "validate:qwen-pixel-art": "python tools/ai_asset_pipeline/cloud/validate_qwen_pixel_art_profile.py",
     "test:cloud": "python -m unittest discover -s tests/cloud -p 'test_*.py'",
+    "validate:external-tools": "python tools/ci/validate_external_tool_registry_v1.py",
+    "test:external-tools": "python -m unittest discover -s tests -p 'test_external_tool_registry_v1.py'",
     "validate:repository": "python tools/validate_complete_game.py",
     "validate:runtime": "python tools/validate_runtime_contracts.py",
     "validate:release": "python tools/validate_release_readiness.py",
@@ -44,7 +46,7 @@
     "cloud:batch": "python tools/ai_asset_pipeline/cloud/prepare_batch.py --output-dir tools/ai_asset_pipeline/generated_outputs/candidate_batches",
     "animations:generate": "python tools/animation/generate_character_animation_pack.py",
     "validate:animations": "python tools/animation/generate_character_animation_pack.py --validate-only",
-    "quality": "npm run validate:governance && npm run validate:canon && npm run validate:factions-v4 && npm run validate:phase1-data && npm run validate:skill-tree-visual && npm run validate:python && npm run validate:node && npm run validate:data && npm run validate:cloud && npm run validate:qwen-pixel-art && npm run test:cloud && npm run validate:animations && npm run validate:asset-protocol && npm run validate:sprite-forge && npm run validate:sprite-forge-phase1 && npm run test:sprite-forge && npm run test:sprite-forge-phase1 && npm run validate:art-direction && npm run test:art-direction && npm run derive:production-v03 && npm run validate:production-v03 && npm run test:production-v03 && npm run validate:bjj-kg-authoring && npm run test:bjj-kg-authoring && npm run validate:bjj-reducer-v2 && npm run test:bjj-reducer-v2 && npm run validate:repository && npm run validate:runtime && npm run validate:release && npm run validate:supreme && npm run validate:deck",
+    "quality": "npm run validate:governance && npm run validate:canon && npm run validate:factions-v4 && npm run validate:phase1-data && npm run validate:skill-tree-visual && npm run validate:python && npm run validate:node && npm run validate:data && npm run validate:cloud && npm run validate:qwen-pixel-art && npm run test:cloud && npm run validate:external-tools && npm run test:external-tools && npm run validate:animations && npm run validate:asset-protocol && npm run validate:sprite-forge && npm run validate:sprite-forge-phase1 && npm run test:sprite-forge && npm run test:sprite-forge-phase1 && npm run validate:art-direction && npm run test:art-direction && npm run derive:production-v03 && npm run validate:production-v03 && npm run test:production-v03 && npm run validate:bjj-kg-authoring && npm run test:bjj-kg-authoring && npm run validate:bjj-reducer-v2 && npm run test:bjj-reducer-v2 && npm run validate:repository && npm run validate:runtime && npm run validate:release && npm run validate:supreme && npm run validate:deck",
     "build:android:windows": "powershell -ExecutionPolicy Bypass -File tools/build/build_android_debug.ps1",
     "build:android:linux": "bash tools/build/build_android_debug.sh",
     "build:windows": "powershell -ExecutionPolicy Bypass -File tools/build/build_windows_debug.ps1"

--- a/tests/test_external_tool_registry_v1.py
+++ b/tests/test_external_tool_registry_v1.py
@@ -1,0 +1,62 @@
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+REGISTRY = ROOT / "data/production/external_tool_registry_v1.json"
+VALIDATOR = ROOT / "tools/ci/validate_external_tool_registry_v1.py"
+
+
+class ExternalToolRegistryV1Tests(unittest.TestCase):
+    def setUp(self):
+        self.registry = json.loads(REGISTRY.read_text(encoding="utf-8"))
+        self.sources = {row["id"]: row for row in self.registry["sources"]}
+
+    def test_validator_passes(self):
+        result = subprocess.run(
+            [sys.executable, str(VALIDATOR)],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertTrue(json.loads(result.stdout)["ok"])
+
+    def test_only_clear_source_allows_direct_code_reuse(self):
+        direct = [row for row in self.registry["sources"] if row["direct_code_reuse"]]
+        self.assertEqual([row["id"] for row in direct], ["claude_code_game_studios"])
+        self.assertEqual(direct[0]["license_status"], "CLEAR_MIT")
+
+    def test_noncommercial_and_unknown_sources_are_no_copy(self):
+        for sid in (
+            "sprite_animator",
+            "cline_qwen_snes_engine",
+            "pixel_life_simulator",
+            "mia_deepseek_v4_1_html_100",
+            "mia_gpt6_astra_html_100",
+        ):
+            self.assertFalse(self.sources[sid]["direct_code_reuse"], sid)
+            self.assertFalse(self.sources[sid]["direct_asset_reuse"], sid)
+
+    def test_pixelsrpg_assets_never_enter_directly(self):
+        source = self.sources["pixelsrpg_forge"]
+        self.assertFalse(source["direct_asset_reuse"])
+        self.assertEqual(source["adoption"], "TAXONOMY_AND_TOOL_REFERENCE_ONLY")
+
+    def test_wolfcha_license_discrepancy_remains_explicit(self):
+        source = self.sources["wolfcha"]
+        self.assertEqual(source["license_status"], "CONFLICT_README_MIT_LICENSE_FILE_APACHE_2_0")
+        self.assertFalse(source["direct_code_reuse"])
+        self.assertEqual(source["adoption"], "REIMPLEMENT_CONCEPTS_PENDING_LICENSE_REVIEW")
+
+    def test_deactivated_old_repo_has_no_role(self):
+        source = self.sources["old_cria_android_repo"]
+        self.assertEqual(source["adoption"], "BLOCKED_DEACTIVATED")
+        self.assertEqual(source["cria_roles"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/ci/validate_external_tool_registry_v1.py
+++ b/tools/ci/validate_external_tool_registry_v1.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Validate external tool/source intake for CRIA DO TATAME.
+
+The registry is research metadata, not permission to copy. This gate blocks direct
+code/asset reuse when licensing is missing, non-commercial, conflicting, unknown,
+or when the source is explicitly deactivated.
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+REGISTRY = ROOT / "data/production/external_tool_registry_v1.json"
+HEX40 = re.compile(r"^[0-9a-f]{40}$")
+
+CLEAR_CODE_LICENSES = {
+    "CLEAR_MIT",
+    "CLEAR_APACHE_2_0",
+    "CLEAR_APACHE_2_0_METADATA",
+    "CLEAR_BSD_2_CLAUSE",
+    "CLEAR_BSD_3_CLAUSE",
+}
+
+NO_DIRECT_REUSE_PREFIXES = (
+    "NO_LICENSE",
+    "UNVERIFIED",
+    "CONFLICT_",
+    "CC_BY_NC",
+    "REPO_STRUCTURE_MIT_ASSET_RIGHTS_UNKNOWN",
+    "INTERNAL_DEACTIVATED",
+)
+
+ADOPTIONS_FORBID_DIRECT_REUSE = {
+    "STUDY_AND_REIMPLEMENT_CONCEPTS_ONLY",
+    "LOW_PRIORITY_REFERENCE_ONLY",
+    "REIMPLEMENT_CONCEPTS_ONLY",
+    "REIMPLEMENT_CONCEPTS_PENDING_LICENSE_REVIEW",
+    "TAXONOMY_AND_TOOL_REFERENCE_ONLY",
+    "DESIGN_PATTERN_REFERENCE_ONLY",
+    "COMPARATIVE_DESIGN_REFERENCE_ONLY",
+    "BLOCKED_DEACTIVATED",
+}
+
+
+def load() -> dict[str, Any]:
+    value = json.loads(REGISTRY.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError("external tool registry root must be object")
+    return value
+
+
+def main() -> int:
+    errors: list[str] = []
+    try:
+        registry = load()
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        print(json.dumps({"ok": False, "errors": [str(exc)]}, indent=2))
+        return 1
+
+    if registry.get("status") != "ACTIVE_RESEARCH_REGISTRY":
+        errors.append("registry must remain ACTIVE_RESEARCH_REGISTRY")
+    policy = registry.get("default_policy", {})
+    expected_false = ("runtime_dependency", "shipping_default", "canon_authority")
+    for key in expected_false:
+        if policy.get(key) is not False:
+            errors.append(f"default_policy.{key} must remain false")
+    for key in ("pin_revision", "copy_code_only_when_license_clear", "copy_assets_only_when_asset_level_rights_clear", "concept_reimplementation_allowed"):
+        if policy.get(key) is not True:
+            errors.append(f"default_policy.{key} must remain true")
+
+    sources = registry.get("sources")
+    if not isinstance(sources, list) or not sources:
+        errors.append("registry has no sources")
+        sources = []
+
+    seen: set[str] = set()
+    for entry in sources:
+        if not isinstance(entry, dict):
+            errors.append("source entry is not an object")
+            continue
+        sid = entry.get("id")
+        if not isinstance(sid, str) or not sid:
+            errors.append("source has invalid id")
+            continue
+        if sid in seen:
+            errors.append(f"duplicate source id: {sid}")
+        seen.add(sid)
+
+        for field in ("kind", "source", "revision", "license_status", "adoption", "direct_code_reuse", "direct_asset_reuse", "cria_roles", "notes"):
+            if field not in entry:
+                errors.append(f"{sid}: missing {field}")
+
+        license_status = str(entry.get("license_status", ""))
+        adoption = str(entry.get("adoption", ""))
+        direct_code = entry.get("direct_code_reuse") is True
+        direct_asset = entry.get("direct_asset_reuse") is True
+
+        if direct_code and license_status not in CLEAR_CODE_LICENSES:
+            errors.append(f"{sid}: direct_code_reuse=true without clear permissive license ({license_status})")
+        if license_status.startswith(NO_DIRECT_REUSE_PREFIXES) and (direct_code or direct_asset):
+            errors.append(f"{sid}: ambiguous/noncommercial/deactivated source cannot allow direct reuse")
+        if adoption in ADOPTIONS_FORBID_DIRECT_REUSE and (direct_code or direct_asset):
+            errors.append(f"{sid}: adoption={adoption} forbids direct reuse")
+
+        if adoption == "BLOCKED_DEACTIVATED" and entry.get("cria_roles"):
+            errors.append(f"{sid}: deactivated source must have no CRIA roles")
+
+        # Anything adopted/ported beyond pure design reference must be commit-pinned.
+        if entry.get("kind") == "github_repo" and adoption in {
+            "PORT_SELECTED_PATTERNS",
+            "REIMPLEMENT_CONCEPTS_PENDING_LICENSE_REVIEW",
+            "STUDY_AND_REIMPLEMENT_CONCEPTS_ONLY",
+            "LOW_PRIORITY_REFERENCE_ONLY",
+            "REIMPLEMENT_CONCEPTS_ONLY",
+            "TAXONOMY_AND_TOOL_REFERENCE_ONLY",
+        }:
+            revision = str(entry.get("revision", ""))
+            if not HEX40.fullmatch(revision):
+                errors.append(f"{sid}: GitHub source must be pinned to immutable 40-char commit SHA")
+
+        if sid == "claude_code_game_studios":
+            if license_status != "CLEAR_MIT" or adoption != "PORT_SELECTED_PATTERNS":
+                errors.append("Claude Code Game Studios must remain selected-pattern port only under MIT")
+        elif sid == "wolfcha":
+            if direct_code or license_status != "CONFLICT_README_MIT_LICENSE_FILE_APACHE_2_0":
+                errors.append("Wolfcha must remain no-copy while README/LICENSE discrepancy is unresolved")
+        elif sid == "sprite_animator":
+            if direct_code or adoption != "REIMPLEMENT_CONCEPTS_ONLY":
+                errors.append("Sprite Animator must remain concept-only without separate commercial license")
+        elif sid == "pixelsrpg_forge":
+            if direct_asset or adoption != "TAXONOMY_AND_TOOL_REFERENCE_ONLY":
+                errors.append("PixelSRPG Forge assets must remain blocked from direct CRIA use")
+        elif sid == "old_cria_android_repo":
+            if adoption != "BLOCKED_DEACTIVATED" or direct_code or direct_asset:
+                errors.append("old CRIA Android repository must remain deactivated")
+
+    required = {
+        "qwen_2512_pixel_art_lora",
+        "claude_code_game_studios",
+        "wolfcha",
+        "cline_qwen_snes_engine",
+        "pixel_life_simulator",
+        "sprite_animator",
+        "pixelsrpg_forge",
+        "mia_deepseek_v4_1_html_100",
+        "mia_gpt6_astra_html_100",
+        "old_cria_android_repo",
+    }
+    missing = sorted(required - seen)
+    if missing:
+        errors.append(f"required audited sources missing: {missing}")
+
+    result = {"ok": not errors, "sources": len(sources), "errors": errors}
+    print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0 if not errors else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds a fail-closed external-source intake layer for the repositories/models/benchmarks supplied for CRIA.

## Normalized and audited
- pinned Qwen 2512 Pixel Art LoRA (already adopted candidate generator);
- `Donchitos/Claude-Code-Game-Studios@984023d...` — MIT, selected patterns may be ported with reconciliation/attribution;
- `oil-oil/wolfcha@a4c246b...` — high-value NPC memory/knowledge patterns, but README says MIT while LICENSE file is Apache-2.0, so no direct code reuse pending resolution;
- `QuantumBitX/cline-qwen-snes-engine@f8c2c30...` — excellent engineering reference, no LICENSE found: concepts only;
- `LabibLikesChimken/Pixel-Life-Simulator@a84301a...` — low-priority mobile/pixel reference, no LICENSE found;
- `poirotw66/Sprite-Animator@f713c5a...` — technically strong, CC BY-NC-SA 4.0: reimplement concepts only without commercial license;
- `Huu-Yuu/PixelSRPG-Forge@5ff74c2...` — taxonomy/tool reference only; individual asset rights explicitly uncertain;
- Mia DeepSeek/GPT HTML corpora — UI/creative benchmark only; no direct code reuse;
- old `ringuemkt-rgb/Cria-do-tatame-` — deactivated and blocked.

## Added
- `data/production/external_tool_registry_v1.json`;
- `tools/ci/validate_external_tool_registry_v1.py`;
- tests and dedicated CI workflow;
- `docs/architecture/EXTERNAL_GAME_STUDIO_INTAKE_V1.md`;
- `npm run validate:external-tools` + `test:external-tools` in quality;
- docs index wiring.

## Safety guarantees
- no direct code reuse from no-license, NC, conflicting or deactivated sources;
- no direct PixelSRPG asset reuse;
- adopted GitHub sources are commit-pinned;
- external sources never become canon/runtime/shipping authority;
- concept reimplementation is allowed where useful.

## Follow-up epics
- #111 CRIA Game Studio Orchestrator — port selected MIT studio patterns;
- #112 Living NPC Social Memory — reimplement fact/belief/knowledge architecture from scratch.

No third-party code or binary assets are copied in this PR.