### PR TITLE
feat(narrative): canonize five narrative fixes

### DIFF
--- a/data/narrative/acts_v3.json
+++ b/data/narrative/acts_v3.json
@@ -1,84 +1,422 @@
 {
   "$schema": "cria_narrative_acts_v3",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "authority": "data/narrative/canon_v3.json",
   "acts": [
     {
       "id": "ato_1_o_chao",
       "title": "O CHAO",
-      "ages": [19, 20],
+      "ages": [
+        19,
+        20
+      ],
       "belt_range": "branca_para_azul",
       "premise": "Ruan aprende que forca sem base vira queda e que gentileza e disciplina, nao fraqueza.",
       "required_beats": [
-        {"id": "entrada_terreiro", "location": "terreiro_da_luta", "characters": ["ruan_macacao", "mestre_dende"], "result": "tese_ser_forte_e_ser_gentil"},
-        {"id": "conhecer_nucleo", "characters": ["biel", "dandara", "leoa"], "result": "pertencimento_inicial"},
-        {"id": "primeira_vitoria_mao_estendida", "result": "honra_como_acao"},
-        {"id": "ferida_origem", "duration_seconds": 5, "presentation": "eliptica", "result": "pai_desaparecido_terra_perdida_sem_vinganca"}
+        {
+          "id": "entrada_terreiro",
+          "location": "terreiro_da_luta",
+          "characters": [
+            "ruan_macacao",
+            "mestre_dende"
+          ],
+          "result": "tese_ser_forte_e_ser_gentil"
+        },
+        {
+          "id": "conhecer_nucleo",
+          "characters": [
+            "biel",
+            "dandara",
+            "leoa"
+          ],
+          "result": "pertencimento_inicial"
+        },
+        {
+          "id": "primeira_vitoria_mao_estendida",
+          "result": "honra_como_acao"
+        },
+        {
+          "id": "ferida_origem",
+          "duration_seconds": 5,
+          "presentation": "eliptica",
+          "result": "pai_desaparecido_terra_perdida_sem_vinganca"
+        }
       ],
       "causal_exit": "dividas + orgulho -> oferta de Cassio no Ato 2"
     },
     {
       "id": "ato_2_o_molde",
       "title": "O MOLDE",
-      "ages": [21, 22],
+      "ages": [
+        21,
+        22
+      ],
       "belt_range": "azul_para_roxa",
       "premise": "Ruan cresce em publico e confunde autonomia com orgulho.",
       "required_beats": [
-        {"id": "pratigi_hype", "location": "praia_de_pratigi", "result": "hype_cresce"},
-        {"id": "concha_davi", "location": "praia_da_concha", "opponent": "davi_relampago", "result": "davi_vence_de_modo_moralmente_sujo"},
-        {"id": "primeiro_clandestino", "location": "ferro_velho_da_lapa", "opponent": "oni_da_lapa", "result": "codigo_submundo_apresentado"},
-        {"id": "cassio_oferta_dinheiro", "characters": ["cassio_molho", "ruan_macacao"], "result": "ruan_recusa_por_orgulho"}
+        {
+          "id": "pratigi_hype",
+          "location": "praia_de_pratigi",
+          "result": "hype_cresce"
+        },
+        {
+          "id": "concha_davi",
+          "location": "praia_da_concha",
+          "opponent": "davi_relampago",
+          "result": "davi_vence_de_modo_moralmente_sujo"
+        },
+        {
+          "id": "primeiro_clandestino",
+          "location": "ferro_velho_da_lapa",
+          "opponent": "oni_da_lapa",
+          "result": "codigo_submundo_apresentado"
+        },
+        {
+          "id": "cassio_oferta_dinheiro",
+          "characters": [
+            "cassio_molho",
+            "ruan_macacao"
+          ],
+          "result": "ruan_recusa_por_orgulho"
+        }
       ],
       "causal_exit": "orgulho + necessidade -> Ruan entra pelas regras do submundo no Ato 3"
     },
     {
       "id": "ato_3_o_nome",
       "title": "O NOME",
-      "ages": [23, 24],
-      "belt_range": "roxa_para_marrom",
-      "premise": "Sobreviver e buscar a verdade passam a produzir culpa real.",
-      "required_beats": [
-        {"id": "infiltracao_tripla", "factions": ["ALE", "LEM", "NTM"], "double_purpose": ["sobrevivencia", "fragmentos_da_verdade"]},
-        {"id": "aprender_codigo", "result": "Ruan_entende_regras_morais_e_sociais_do_submundo"},
-        {"id": "vera_recruta", "optional": true, "characters": ["vera_salles", "ruan_macacao"]},
-        {"id": "byaku_primeira_aula", "characters": ["byaku", "ruan_macacao"], "style": "NO-GI"},
-        {"id": "o_barco", "scene_ref": "3.3a_o_barco", "result": "inocente_preso_maos_sujas_sobe"},
-        {"id": "biel_escorrega", "result": "prenuncio_da_queda"}
+      "ages": [
+        23,
+        24
       ],
-      "causal_exit": "culpa + Biel + Maos Sujas -> A Queda"
+      "belt_range": "roxa_para_marrom",
+      "premise": "Sobreviver e buscar a verdade passam a produzir culpa real, enquanto a cobertura cobra lealdade e identidade.",
+      "required_beats": [
+        {
+          "id": "infiltracao_tripla",
+          "factions": [
+            "ALE",
+            "LEM",
+            "NTM"
+          ],
+          "double_purpose": [
+            "sobrevivencia",
+            "fragmentos_da_verdade"
+          ]
+        },
+        {
+          "id": "aprender_codigo",
+          "result": "Ruan_entende_regras_morais_e_sociais_do_submundo"
+        },
+        {
+          "id": "o_gosto",
+          "scene_ref": "3.2b_o_gosto",
+          "result": [
+            "sombra_sobe",
+            "culpa_corporal",
+            "coro_marca_mudanca"
+          ]
+        },
+        {
+          "id": "o_que_e_forca",
+          "scene_ref": "3.5b_forca_primeiro",
+          "characters": [
+            "pipoca",
+            "ruan_macacao"
+          ],
+          "result": "Ruan_ensina_conter_antes_de_ferir"
+        },
+        {
+          "id": "bala_desconfia",
+          "scene_ref": "3.6_bala_desconfia",
+          "characters": [
+            "pedro_bala",
+            "ruan_macacao"
+          ],
+          "result": "capitaes_passam_a_cobrar_coerencia"
+        },
+        {
+          "id": "tu_luta_diferente",
+          "scene_ref": "3.6b_tu_luta_diferente",
+          "characters": [
+            "pipoca",
+            "ruan_macacao"
+          ],
+          "result": "Ruan_reconhece_mascara_da_infiltracao"
+        },
+        {
+          "id": "vera_recruta",
+          "optional": true,
+          "characters": [
+            "vera_salles",
+            "ruan_macacao"
+          ]
+        },
+        {
+          "id": "a_isca",
+          "scene_ref": "3.8_a_isca",
+          "characters": [
+            "pipoca",
+            "george_chupeta",
+            "ruan_macacao"
+          ],
+          "result": "Pipoca_deixa_de_ser_pano_de_fundo"
+        },
+        {
+          "id": "ordem_impossivel",
+          "scene_ref": "3.9b_ordem_impossivel",
+          "characters": [
+            "vera_salles",
+            "ruan_macacao"
+          ],
+          "result": "criancas_nao_sao_ativos_operacionais"
+        },
+        {
+          "id": "byaku_primeira_aula",
+          "characters": [
+            "byaku",
+            "ruan_macacao"
+          ],
+          "style": "NO-GI"
+        },
+        {
+          "id": "o_barco",
+          "scene_ref": "3.3a_o_barco",
+          "result": "inocente_preso_maos_sujas_sobe"
+        },
+        {
+          "id": "biel_escorrega",
+          "result": "prenuncio_da_queda"
+        }
+      ],
+      "causal_exit": "culpa + cobertura rachada + molecada em risco + Biel + Maos Sujas -> A Queda"
     },
     {
       "id": "ato_4_a_queda",
       "title": "A QUEDA",
-      "ages": [25, 26],
-      "belt_range": "marrom_para_preta",
-      "premise": "Ruan precisa atravessar luto e culpa sem transformar ambos em licenca para crueldade.",
-      "required_beats": [
-        {"id": "morte_biel", "presentation": "eliptica", "silence_seconds": 8, "revenge_payoff_forbidden": true},
-        {"id": "dende_colapsa", "key_line_id": "dende_promete_merecer"},
-        {"id": "o_contrato", "branches": ["cassio", "vera", "nenhum"]},
-        {"id": "chie_acolhe", "characters": ["dona_chie", "ruan_macacao"]},
-        {"id": "pratigi_do_avesso", "opponent": "ruan_do_avesso", "scaling": "save_stats + maos_sujas*0.3", "integration_condition": "vencer_sem_furia"},
-        {"id": "cost_montage", "scene_ref": "4.5_cost_montage"}
+      "ages": [
+        25,
+        26
       ],
-      "causal_exit": "luto integrado + responsabilidade -> restituicao e legado"
+      "belt_range": "marrom_para_preta",
+      "premise": "Ruan precisa atravessar luto, culpa e o espelho de Chupeta sem transformar dor em licença para crueldade.",
+      "required_beats": [
+        {
+          "id": "morte_biel",
+          "presentation": "eliptica",
+          "silence_seconds": 8,
+          "revenge_payoff_forbidden": true
+        },
+        {
+          "id": "dende_colapsa",
+          "key_line_id": "dende_promete_merecer"
+        },
+        {
+          "id": "bala_quem_volta",
+          "scene_ref": "4.1b_quem_volta",
+          "characters": [
+            "pedro_bala",
+            "ruan_macacao"
+          ],
+          "resolution": "sem_bater"
+        },
+        {
+          "id": "foguete_volta",
+          "scene_ref": "4.1c_foguete_volta",
+          "characters": [
+            "foguete",
+            "ruan_macacao"
+          ],
+          "result": "acolhimento_com_limite"
+        },
+        {
+          "id": "rastro_do_aluno",
+          "scene_ref": "4.2a_rastro_do_aluno",
+          "characters": [
+            "byaku",
+            "kenzo_kuroi",
+            "ruan_macacao"
+          ],
+          "result": "Ruan_descobre_que_Chupeta_veio_do_Terreiro_antes_de_Dende_confirmar"
+        },
+        {
+          "id": "aluno_que_ficou",
+          "scene_ref": "4.2b_o_aluno_que_ficou",
+          "characters": [
+            "mestre_dende",
+            "ruan_macacao",
+            "george_chupeta"
+          ],
+          "result": "Chupeta_ligado_ao_Terreiro"
+        },
+        {
+          "id": "aula_dos_capitaes",
+          "scene_ref": "4.2c_a_aula_dos_capitaes",
+          "characters": [
+            "ruan_macacao",
+            "mestre_dende",
+            "degodo",
+            "pedro_bala",
+            "pipoca",
+            "foguete"
+          ],
+          "result": "Terreiro_vira_estrutura_de_protecao"
+        },
+        {
+          "id": "tinker_confronta",
+          "scene_ref": "4.3b_mentindo_pra_quem",
+          "characters": [
+            "tinker_bell",
+            "ruan_macacao"
+          ],
+          "result": "Tinker_coarquiteto_por_escolha"
+        },
+        {
+          "id": "pipoca_cicatriz",
+          "scene_ref": "4.3c_mao_marcada",
+          "characters": [
+            "pipoca",
+            "ruan_macacao"
+          ],
+          "result": "aula_em_vez_de_vinganca"
+        },
+        {
+          "id": "o_contrato",
+          "branches": [
+            "cassio",
+            "vera",
+            "nenhum"
+          ]
+        },
+        {
+          "id": "chie_acolhe",
+          "characters": [
+            "dona_chie",
+            "ruan_macacao"
+          ]
+        },
+        {
+          "id": "pratigi_do_avesso",
+          "scene_ref": "4.4_pratigi_do_avesso",
+          "opponent": "ruan_do_avesso",
+          "scaling": "save_stats + maos_sujas*0.3",
+          "trigger": "sombra>=50 + cobertura_rachada + lua_cheia + mare_baixa",
+          "integration_condition": "aceitar_sem_finalizar"
+        },
+        {
+          "id": "o_hospital",
+          "scene_ref": "4.5b_o_hospital",
+          "characters": [
+            "george_chupeta",
+            "dona_zefa",
+            "ruan_macacao"
+          ],
+          "result": "antagonista_humanizado_sem_absolvicao"
+        },
+        {
+          "id": "bala_escudo",
+          "scene_ref": "4.6_escudo_da_molecada",
+          "characters": [
+            "pedro_bala"
+          ],
+          "result": "capitaes_param_de_fazer_recados_para_rede"
+        },
+        {
+          "id": "cost_montage",
+          "scene_ref": "4.5_cost_montage"
+        }
+      ],
+      "causal_exit": "luto integrado + molecada protegida + Tinker aliado consciente + Chupeta compreendido sem ser absolvido -> confronto e legado"
     },
     {
       "id": "ato_5_o_legado",
       "title": "O LEGADO",
-      "ages": [27, 28],
+      "ages": [
+        27,
+        28
+      ],
       "belt_range": "preta",
       "premise": "A faixa preta mede o que Ruan devolve ao mundo, nao o que consegue arrancar dele.",
       "required_beats": [
-        {"id": "restituicao", "scene_ref": "5.4a_restituicao", "optional_scenes": 4},
-        {"id": "davi_revanche", "opponent": "davi_relampago", "resolution": ["domina", "solta", "estende_a_mao"]},
-        {"id": "byaku_rematch", "opponent": "byaku", "condition": "vencer_sem_cortar_a_faixa", "unlock": "NO-GI_completo"},
-        {"id": "operacao_raiz_forte", "result": ["montenegro_exposto", "cassio_exposto"]},
-        {"id": "tinker_revela", "result": "revelacao_PF_e_motivo_do_sumiço_Ato4"},
-        {"id": "dandara_abraco", "result": "fecho_afetivo"},
-        {"id": "instituto_cria", "result": "legado_material"}
+        {
+          "id": "confronto_chupeta",
+          "scene_ref": "5.2_confronto_chupeta",
+          "opponent": "george_chupeta",
+          "resolution": [
+            "domina",
+            "segura_finalizacao",
+            "nao_quebra"
+          ],
+          "result": "tese_do_tatame_provada_em_acao"
+        },
+        {
+          "id": "restituicao",
+          "scene_ref": "5.4a_restituicao",
+          "optional_scenes": 4
+        },
+        {
+          "id": "davi_revanche",
+          "opponent": "davi_relampago",
+          "resolution": [
+            "domina",
+            "solta",
+            "estende_a_mao"
+          ]
+        },
+        {
+          "id": "byaku_rematch",
+          "opponent": "byaku",
+          "condition": "vencer_sem_cortar_a_faixa",
+          "unlock": "NO-GI_completo"
+        },
+        {
+          "id": "operacao_raiz_forte",
+          "result": [
+            "chupeta_exposto",
+            "montenegro_exposto",
+            "cassio_exposto"
+          ]
+        },
+        {
+          "id": "tinker_revela",
+          "result": "tinker_assume_coautoria_e_explica_sumiço;_Vera_permanece_eixo_federal"
+        },
+        {
+          "id": "pipoca_primeira_faixa",
+          "scene_ref": "5.5h_primeira_faixa",
+          "ending": "heroi_duas_aguas",
+          "result": "transmissao_da_tese"
+        },
+        {
+          "id": "dandara_abraco",
+          "result": "fecho_afetivo"
+        },
+        {
+          "id": "instituto_cria",
+          "result": "legado_material"
+        }
       ],
-      "causal_exit": "calculo_final + epilogos + camada A Verdade"
+      "causal_exit": "calculo_final + epilogos + camada A Verdade",
+      "branch_scenes": {
+        "sombras": [
+          {
+            "scene_ref": "5.5s_o_dinheiro_que_nao_lava",
+            "result": "riqueza_externa_corroi_sono_e_vinculos"
+          },
+          {
+            "scene_ref": "5.6s_a_volta",
+            "result": "faixa_branca_oferecida_como_recomeco"
+          },
+          {
+            "choice": "aceitar_faixa_branca",
+            "result": "ngplus_redencao_do_zero"
+          },
+          {
+            "choice": "recusar_e_seguir_estrada",
+            "result": "tragedia_assumida_sem_impunidade"
+          }
+        ]
+      }
     }
   ],
   "adult_scenes": [
@@ -88,9 +426,28 @@
       "title": "A Cobranca",
       "purpose": "mostrar que sobreviver pode empurrar Ruan a instrumentalizar gente sem transformar o jogo em manual de crime",
       "choices": [
-        {"id": "limpa", "effects": {"honra": 3, "maos_sujas": -2}},
-        {"id": "ambigua", "effects": {"hype": 2, "maos_sujas": 4}},
-        {"id": "suja", "effects": {"criacoin": 1, "maos_sujas": 12, "sombra": 5}}
+        {
+          "id": "limpa",
+          "effects": {
+            "honra": 3,
+            "maos_sujas": -2
+          }
+        },
+        {
+          "id": "ambigua",
+          "effects": {
+            "hype": 2,
+            "maos_sujas": 4
+          }
+        },
+        {
+          "id": "suja",
+          "effects": {
+            "criacoin": 1,
+            "maos_sujas": 12,
+            "sombra": 5
+          }
+        }
       ]
     },
     {
@@ -106,9 +463,28 @@
         "O silencio de Ruan pesa mais que qualquer celebracao."
       ],
       "confrontation_choices": [
-        {"id": "assumir_parte", "effects": {"verdade": 8, "honra": 4, "maos_sujas": 6}},
-        {"id": "culpar_terceiros", "effects": {"faca": 8, "maos_sujas": 14}},
-        {"id": "reparar_em_silencio", "effects": {"verdade": 4, "maos_sujas": 8}}
+        {
+          "id": "assumir_parte",
+          "effects": {
+            "verdade": 8,
+            "honra": 4,
+            "maos_sujas": 6
+          }
+        },
+        {
+          "id": "culpar_terceiros",
+          "effects": {
+            "faca": 8,
+            "maos_sujas": 14
+          }
+        },
+        {
+          "id": "reparar_em_silencio",
+          "effects": {
+            "verdade": 4,
+            "maos_sujas": 8
+          }
+        }
       ]
     },
     {
@@ -116,13 +492,19 @@
       "act": 3,
       "title": "O Palco",
       "result": "luta_suja_viraliza_e_comunidade_rejeita",
-      "effects": {"hype": 12, "maos_sujas": 10}
+      "effects": {
+        "hype": 12,
+        "maos_sujas": 10
+      }
     },
     {
       "id": "4.0a_maos_tremem",
       "act": 4,
       "title": "Maos Tremem",
-      "mechanic": {"temporary_grip_penalty": true, "recurring_silence": true},
+      "mechanic": {
+        "temporary_grip_penalty": true,
+        "recurring_silence": true
+      },
       "meaning": "culpa aparece no corpo sem diagnostico romantizado"
     },
     {
@@ -130,15 +512,194 @@
       "act": 4,
       "title": "Cost Montage",
       "dialogue": false,
-      "images": ["tatame_vazio", "mensagem_nao_respondida", "gi_remendado", "cadeira_vazia", "chuva_no_metal"]
+      "images": [
+        "tatame_vazio",
+        "mensagem_nao_respondida",
+        "gi_remendado",
+        "cadeira_vazia",
+        "chuva_no_metal"
+      ]
     },
     {
       "id": "5.4a_restituicao",
       "act": 5,
       "title": "Restituicao",
-      "optional_scenes": ["familia_do_inocente", "terreiro", "comunidade_pratigi", "pessoa_traida"],
+      "optional_scenes": [
+        "familia_do_inocente",
+        "terreiro",
+        "comunidade_pratigi",
+        "pessoa_traida"
+      ],
       "effect_rule": "atenua Maos Sujas sem apagar cicatriz",
-      "unlocks": ["epilogos_de_responsabilidade"]
+      "unlocks": [
+        "epilogos_de_responsabilidade"
+      ]
+    },
+    {
+      "id": "3.2b_o_gosto",
+      "act": 3,
+      "title": "O Gosto",
+      "placement": "apos_primeira_clandestina_em_que_Ruan_vai_alem_do_necessario",
+      "purpose": "fazer a infiltracao doer psicologicamente",
+      "effects": {
+        "sombra": 1
+      },
+      "presentation": [
+        "Ruan encara as proprias maos no vestiario.",
+        "Tinker entra e nao filma.",
+        "O Coro fecha a cena sem explicar o sentimento."
+      ]
+    },
+    {
+      "id": "3.5b_forca_primeiro",
+      "act": 3,
+      "title": "Forca Primeiro",
+      "purpose": "plantar o arco de Pipoca antes de ele virar isca",
+      "lesson": "forca primeiro e nao machucar"
+    },
+    {
+      "id": "3.6_bala_desconfia",
+      "act": 3,
+      "title": "Capitao que Some",
+      "purpose": "dar agencia a Pedro Bala e tornar confianca algo conquistado"
+    },
+    {
+      "id": "3.6b_tu_luta_diferente",
+      "act": 3,
+      "title": "Tu Luta Diferente",
+      "purpose": "Pipoca percebe a erosao moral antes dos adultos"
+    },
+    {
+      "id": "3.8_a_isca",
+      "act": 3,
+      "title": "A Isca",
+      "purpose": "Chupeta usa Pipoca para atrair Ruan; dano e consequencia, nunca espetaculo",
+      "child_harm_presentation": "nao_grafica"
+    },
+    {
+      "id": "3.9b_ordem_impossivel",
+      "act": 3,
+      "title": "A Ordem Impossivel",
+      "purpose": "Ruan recusa transformar criancas em ativos de operacao",
+      "choice_locked": "nao_entregar_rota_da_molecada"
+    },
+    {
+      "id": "4.1b_quem_volta",
+      "act": 4,
+      "title": "Quem Volta",
+      "purpose": "Ruan protege Bala sem bater, usando presenca e o nome do Terreiro"
+    },
+    {
+      "id": "4.1c_foguete_volta",
+      "act": 4,
+      "title": "Foguete Volta",
+      "purpose": "acolher erro sem normalizar cooptacao",
+      "result": "proteção + limite + corte_de_contato_com_rede"
+    },
+    {
+      "id": "4.2b_o_aluno_que_ficou",
+      "act": 4,
+      "title": "O Aluno que Ficou",
+      "purpose": "revelar Chupeta como tragedia do tatame que perdeu um aluno"
+    },
+    {
+      "id": "4.2c_a_aula_dos_capitaes",
+      "act": 4,
+      "title": "A Aula dos Capitaes",
+      "purpose": "transformar o Terreiro em mecanismo de prevencao e pertencimento"
+    },
+    {
+      "id": "4.3b_mentindo_pra_quem",
+      "act": 4,
+      "title": "Tu Ta Mentindo Pra Mim ou Pra Ti?",
+      "purpose": "Tinker recupera agencia e entra na queda de Chupeta por escolha"
+    },
+    {
+      "id": "4.3c_mao_marcada",
+      "act": 4,
+      "title": "A Mao Marcada",
+      "purpose": "substituir promessa de vinganca por promessa de ensino"
+    },
+    {
+      "id": "4.4_pratigi_do_avesso",
+      "act": 4,
+      "title": "Pratigi do Avesso",
+      "purpose": "materializar a divida moral sob regras claras",
+      "trigger_all": {
+        "sombra_min": 50,
+        "story_flag": "cobertura_rachada",
+        "lunar_state": "lua_cheia",
+        "tide_state": "mare_baixa"
+      },
+      "lose": {
+        "honra": -1,
+        "permanent": true,
+        "grant": "tecnica_de_sombra",
+        "avesso_debt": 1
+      },
+      "win": {
+        "required": "aceitar_sem_finalizar",
+        "grant": "visao_do_avesso"
+      },
+      "recurrence": "retorna_quando_Ruan_mente_de_novo"
+    },
+    {
+      "id": "4.5b_o_hospital",
+      "act": 4,
+      "title": "O Hospital",
+      "purpose": "humanizar Chupeta sem absolve-lo",
+      "presentation": "Ruan observa Chupeta cuidando da mae Dona Zefa; nao ha chantagem nem uso dela como alvo"
+    },
+    {
+      "id": "4.6_escudo_da_molecada",
+      "act": 4,
+      "title": "Escudo da Molecada",
+      "purpose": "fechar arco de Bala como organizador dos Capitaes"
+    },
+    {
+      "id": "5.2_confronto_chupeta",
+      "act": 5,
+      "title": "O Preco da Rua",
+      "purpose": "confronto final trágico; Ruan domina e escolhe nao quebrar",
+      "finisher_forbidden": true
+    },
+    {
+      "id": "5.5h_primeira_faixa",
+      "act": 5,
+      "title": "Primeira Faixa",
+      "ending": "heroi_duas_aguas",
+      "purpose": "Ruan amarra a primeira faixa de Pipoca e transmite a tese"
+    },
+    {
+      "id": "5.5s_o_dinheiro_que_nao_lava",
+      "act": 5,
+      "title": "O Dinheiro que Nao Lava",
+      "ending": "rei_dos_atalhos",
+      "purpose": "mostrar corrosao do dinheiro da rede; riqueza nao funciona como premio"
+    },
+    {
+      "id": "5.6s_a_volta",
+      "act": 5,
+      "title": "A Volta",
+      "ending": "rei_dos_atalhos",
+      "purpose": "Dende oferece recomeço sem perdao barato",
+      "choices": [
+        {
+          "id": "aceitar_faixa_branca",
+          "unlock": "ngplus_recomeco"
+        },
+        {
+          "id": "recusar_e_seguir_estrada",
+          "result": "tragedia_assumida"
+        }
+      ]
+    },
+    {
+      "id": "4.2a_rastro_do_aluno",
+      "act": 4,
+      "title": "O Rastro do Aluno",
+      "purpose": "Byaku e Kenzo revelam que a tecnica de Chupeta tem raiz no Terreiro; Dende confirma a historia na cena seguinte",
+      "result": "backstory_em_duas_fontes_antes_da_confissao_do_mentor"
     }
   ],
   "compliance": {

--- a/data/narrative/canon_v3.json
+++ b/data/narrative/canon_v3.json
@@ -1,6 +1,6 @@
 {
   "$schema": "cria_narrative_canon_v3",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "status": "canonical_authority",
   "project": "CRIA DO TATAME: PRESSAO",
   "authority": {
@@ -15,7 +15,19 @@
       "data/finais_adultos.json"
     ],
     "migration_scope": "narrative_and_character_data_only",
-    "runtime_logic_changes_forbidden": true
+    "runtime_logic_changes_forbidden": true,
+    "canonical_companions": [
+      "data/narrative/acts_v3.json",
+      "data/narrative/dialogues.json",
+      "data/narrative/endings_v2.json",
+      "data/narrative/narrative_v3_fixes_characters.json"
+    ],
+    "data_precedence": [
+      "canon_v3.json define fatos e papeis",
+      "narrative_v3_fixes_characters.json pode sobrescrever campos da character_bible_v1 quando explicitamente listado em character_overrides",
+      "acts_v3.json define ordem e consequencia das cenas",
+      "dialogues.json define fala canonica"
+    ]
   },
   "thesis": {
     "phrase": "Ser forte e ser gentil.",
@@ -26,15 +38,52 @@
   "setting": {
     "region": "Baixo Sul da Bahia",
     "main_hub": "Itubera",
-    "forbidden_setting_drift": ["Rio de Janeiro"],
+    "forbidden_setting_drift": [
+      "Rio de Janeiro"
+    ],
     "cultural_rule": "referencias regionais com respeito, sem caricatura e sem retrato de pessoa real"
   },
   "timeline": {
-    "act_1": {"title": "O CHAO", "ages": [19, 20], "belt": "branca_para_azul"},
-    "act_2": {"title": "O MOLDE", "ages": [21, 22], "belt": "azul_para_roxa"},
-    "act_3": {"title": "O NOME", "ages": [23, 24], "belt": "roxa_para_marrom"},
-    "act_4": {"title": "A QUEDA", "ages": [25, 26], "belt": "marrom_para_preta"},
-    "act_5": {"title": "O LEGADO", "ages": [27, 28], "belt": "preta"}
+    "act_1": {
+      "title": "O CHAO",
+      "ages": [
+        19,
+        20
+      ],
+      "belt": "branca_para_azul"
+    },
+    "act_2": {
+      "title": "O MOLDE",
+      "ages": [
+        21,
+        22
+      ],
+      "belt": "azul_para_roxa"
+    },
+    "act_3": {
+      "title": "O NOME",
+      "ages": [
+        23,
+        24
+      ],
+      "belt": "roxa_para_marrom"
+    },
+    "act_4": {
+      "title": "A QUEDA",
+      "ages": [
+        25,
+        26
+      ],
+      "belt": "marrom_para_preta"
+    },
+    "act_5": {
+      "title": "O LEGADO",
+      "ages": [
+        27,
+        28
+      ],
+      "belt": "preta"
+    }
   },
   "acts": [
     {
@@ -63,64 +112,135 @@
     },
     {
       "id": "ato_3_o_nome",
-      "theme": "infiltracao, sobrevivencia, verdade parcial e culpa",
+      "theme": "infiltracao, sobrevivencia, verdade parcial, culpa e lealdade",
       "beats": [
         "Ruan circula por ALE, LEM e NTM com duplo proposito: sobreviver e juntar fragmentos da verdade.",
-        "Aprende o Codigo.",
-        "Vera pode recruta-lo opcionalmente.",
+        "Depois de uma clandestina em que continua alem do necessario, O Gosto torna explicito o custo psicologico da infiltracao.",
+        "Pipoca e Bala percebem que Ruan esta mudando; a molecada deixa de ser pano de fundo e passa a cobrar coerencia.",
+        "Vera pode recruta-lo, mas Ruan recusa usar criancas como rota operacional, mesmo que isso dificulte chegar a Chupeta.",
         "Byaku oferece a primeira aula NO-GI.",
         "Em O Barco, informacao fornecida por Ruan derruba uma operacao da faccao infiltrada e um inocente e preso.",
-        "Maos Sujas sobe e Biel comeca a escorregar."
+        "Maos Sujas sobe, Biel comeca a escorregar e a cobertura de Ruan racha."
       ],
-      "causes_next": "a culpa, a morte futura de Biel e o custo acumulado tornam inevitavel a queda"
+      "causes_next": "culpa + lealdade testada + Biel + Maos Sujas + cobertura rachada -> A Queda"
     },
     {
       "id": "ato_4_a_queda",
-      "theme": "luto, culpa, contrato, integracao da sombra",
+      "theme": "luto, culpa, Chupeta, molecada, lealdade e integracao da sombra",
       "beats": [
         "Biel morre em cena eliptica, seguida por oito segundos de silencio.",
         "Dende colapsa e pede que Ruan prometa merecer o que ainda pode salvar.",
+        "Bala, Pipoca e Foguete ganham arcos proprios; o Terreiro se torna abrigo ativo, nao cenario.",
+        "Dende revela que George Chupeta foi seu melhor aluno e abandonou o tatame quando confundiu limite com fraqueza.",
+        "Tinker confronta as mentiras de Ruan e escolhe tornar-se co-arquiteto da queda de Chupeta, preservando agencia propria.",
         "O Contrato bifurca Cassio, Vera ou nenhum.",
         "Dona Chie acolhe Ruan.",
-        "Pratigi do Avesso materializa a sombra de Ruan a partir de Maos Sujas.",
-        "Vencer sem Furia integra a sombra em vez de derrota-la por odio.",
-        "Montagem de perdas fecha o ato sem dialogo."
+        "Pratigi do Avesso materializa o recibo moral das mentiras de Ruan sob regras observaveis e custo persistente.",
+        "Ruan encontra Chupeta cuidando de Dona Zefa no hospital; o antagonista permanece responsavel por seus atos sem deixar de ser humano.",
+        "Montagem de perdas fecha o ato sem glamour de violencia."
       ],
-      "causes_next": "Ruan precisa restituir, revelar e decidir o que a faixa preta significara"
+      "causes_next": "luto integrado + responsabilidade com a molecada + prova contra a rede -> confronto, restituicao e legado"
     },
     {
       "id": "ato_5_o_legado",
-      "theme": "restituicao, verdade, tecnica madura e continuidade",
+      "theme": "restituicao, confronto sem crueldade, verdade, tecnica madura e continuidade",
       "beats": [
+        "Ruan confronta Chupeta e vence sem quebrar a finalizacao, provando na pratica a tese do tatame.",
         "Ruan procura pessoas que feriu e executa cenas opcionais de restituicao.",
         "Na revanche com Davi, domina, solta e estende a mao.",
         "No rematch com Byaku, vence sem cortar a faixa e conclui o arco NO-GI.",
-        "Operacao Raiz Forte expoe Montenegro e Cassio.",
-        "Tinker revela sua funcao e o motivo do desaparecimento no Ato 4.",
+        "Operacao Raiz Forte expoe Chupeta, Montenegro e Cassio como partes distintas da mesma rede.",
+        "Tinker assume a coautoria do plano e explica o desaparecimento no Ato 4; a cadeia federal permanece com Vera, nao com ele.",
+        "No caminho Heroi, Ruan amarra a primeira faixa de Pipoca e transforma a tese em transmissao.",
         "Dandara encerra o arco afetivo com um abraco.",
-        "O legado concreto e o Instituto CRIA."
+        "O legado concreto e o Instituto CRIA.",
+        "No caminho Sombras, dinheiro de origem criminosa corrói sono, vinculos e identidade; anos depois, Dende oferece faixa branca como recomeço, nao absolvição."
       ],
-      "causes_next": "final e epilogos dependem de contrato, Verdade, Faca, honra e cicatrizes"
+      "causes_next": "calculo final + epilogos de responsabilidade ou recomeço + camada A Verdade"
     }
   ],
   "meters": {
-    "honra": {"range": [0, 100], "meaning": "coerencia entre poder e responsabilidade"},
-    "hype": {"range": [0, 100], "meaning": "visibilidade e pressao publica"},
-    "sombra": {"alias": "Faca", "range": [0, 100], "meaning": "atalhos, frieza e disposicao para instrumentalizar pessoas"},
-    "verdade": {"range": [0, 100], "meaning": "compromisso com fatos, reparacao e revelacao"},
-    "dupla_face": {"formula": "max(0, Faca - Verdade)", "range": [0, 100]},
+    "honra": {
+      "range": [
+        0,
+        100
+      ],
+      "meaning": "coerencia entre poder e responsabilidade"
+    },
+    "hype": {
+      "range": [
+        0,
+        100
+      ],
+      "meaning": "visibilidade e pressao publica"
+    },
+    "sombra": {
+      "alias": "Faca",
+      "range": [
+        0,
+        100
+      ],
+      "meaning": "atalhos, frieza e disposicao para instrumentalizar pessoas"
+    },
+    "verdade": {
+      "range": [
+        0,
+        100
+      ],
+      "meaning": "compromisso com fatos, reparacao e revelacao"
+    },
+    "dupla_face": {
+      "formula": "max(0, Faca - Verdade)",
+      "range": [
+        0,
+        100
+      ]
+    },
     "maos_sujas": {
-      "range": [0, 100],
+      "range": [
+        0,
+        100
+      ],
       "persistent": true,
       "never_resets": true,
-      "scar_floor": {"if_ever_above": 60, "minimum_afterwards": 20},
+      "scar_floor": {
+        "if_ever_above": 60,
+        "minimum_afterwards": 20
+      },
       "avesso_multiplier": 0.3,
       "dende_refuses_training_above": 70
+    },
+    "avesso_debt": {
+      "range": [
+        0,
+        99
+      ],
+      "persistent": true,
+      "meaning": "divida moral acumulada quando o Avesso concede tecnica apos derrota"
     }
   },
   "finals": {
-    "heroi_duas_aguas": {"requires": ["contrato != cassio", "Verdade >= Faca", "honra >= 25"]},
-    "rei_dos_atalhos": {"requires_any": ["contrato == cassio", "Faca > Verdade"]}
+    "heroi_duas_aguas": {
+      "requires": [
+        "contrato != cassio",
+        "Verdade >= Faca",
+        "honra >= 25"
+      ]
+    },
+    "rei_dos_atalhos": {
+      "requires_any": [
+        "contrato == cassio",
+        "Faca > Verdade"
+      ],
+      "shadow_epilogue": {
+        "id": "sombras_a_volta",
+        "requires": "caminho_sombras + dinheiro_da_rede_aceito",
+        "choice": [
+          "aceitar_faixa_branca",
+          "recusar_e_seguir_estrada"
+        ]
+      }
+    }
   },
   "truth_layer": {
     "id": "a_verdade",
@@ -134,6 +254,61 @@
     "no_real_organization_defamation": true,
     "hidden_mystery_never_named_in_dialogue": true,
     "violence_has_consequence": true,
-    "revenge_arc_forbidden": true
+    "revenge_arc_forbidden": true,
+    "children_are_never_operational_assets": true,
+    "humanize_antagonist_without_absolution": true
+  },
+  "avesso_rules": {
+    "ontology": "realidade_magica_com_efeitos_persistentes",
+    "visible_to": [
+      "ruan_macacao"
+    ],
+    "effects_visible_to_world": true,
+    "trigger_all": {
+      "sombra_min": 50,
+      "sombra_min_is_tuning_constant": true,
+      "story_flag": "cobertura_rachada",
+      "lunar_state": "lua_cheia",
+      "tide_state": "mare_baixa"
+    },
+    "lose": {
+      "death": false,
+      "honra_delta": -1,
+      "honra_loss_permanent": true,
+      "grant": "uma_tecnica_de_sombra",
+      "avesso_debt_delta": 1
+    },
+    "win": {
+      "required_resolution": "aceitar_sem_finalizar",
+      "grant": "visao_do_avesso",
+      "effect": "counters_legiveis",
+      "avesso_kneels": true
+    },
+    "recurrence": "retorna quando Ruan mente de novo depois da primeira integracao",
+    "cosmology": "O Pratigi do Avesso e a margem espelhada onde Exu cruza; a travessia e um limiar de realidade magica, nao um sonho.",
+    "cultural_safeguard": "Exu nao e o Avesso, nao e vilao e nao e demonio; o Avesso e o recibo moral de Ruan. A referencia deve evitar caricatura e demonizacao."
+  },
+  "antagonist_network": {
+    "chupeta": {
+      "id": "george_chupeta",
+      "role": "antagonista_humano_da_rede",
+      "backstory": "ex-melhor aluno de Dende; saiu ao interpretar limite moral como fraqueza e converteu forca em poder de rua",
+      "soft_point": "cuida da mae Dona Zefa",
+      "accountability_rule": "humanizacao nunca reduz responsabilidade pelos danos causados"
+    },
+    "operation_raiz_forte": {
+      "targets": [
+        "george_chupeta",
+        "delegado_montenegro",
+        "cassio_molho"
+      ],
+      "design_rule": "nenhum alvo substitui os demais; representam camadas humana, institucional falsa e economica/de_hype da rede"
+    }
+  },
+  "youth_arcs": {
+    "pedro_bala": "desconfianca -> confronto -> Ruan retorna -> escudo dos Capitaes",
+    "pipoca": "idolo -> isca -> cicatriz -> primeira faixa",
+    "foguete": "cooptado -> assustado -> acolhido -> protegido sem impunidade",
+    "anchor_scene": "4.2c_a_aula_dos_capitaes"
   }
 }

--- a/data/narrative/dialogues.json
+++ b/data/narrative/dialogues.json
@@ -1,6 +1,6 @@
 {
   "$schema": "cria_dialogues_v3",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "authority": "data/narrative/canon_v3.json",
   "rules": {
     "language": "pt-BR",
@@ -10,133 +10,573 @@
   },
   "clue_dialogues": [
     {
-      "id":"clue_seu_neco_01",
-      "speaker":"seu_neco",
-      "context":"margem do rio, depois do Ato 2",
-      "lines":["Teu pai conhecia correnteza que nao aparece no mapa.","Tem gente que some do papel antes de sumir da memoria."]
+      "id": "clue_seu_neco_01",
+      "speaker": "seu_neco",
+      "context": "margem do rio, depois do Ato 2",
+      "lines": [
+        "Teu pai conhecia correnteza que nao aparece no mapa.",
+        "Tem gente que some do papel antes de sumir da memoria."
+      ]
     },
     {
-      "id":"clue_iara_01",
-      "speaker":"cigana_iara",
-      "context":"feira, opcional",
-      "lines":["Tem nome que some do papel e continua crescendo na raiz.","Quando a flor volta, pergunta quem ficou regando."]
+      "id": "clue_iara_01",
+      "speaker": "cigana_iara",
+      "context": "feira, opcional",
+      "lines": [
+        "Tem nome que some do papel e continua crescendo na raiz.",
+        "Quando a flor volta, pergunta quem ficou regando."
+      ]
     },
     {
-      "id":"clue_chie_01",
-      "speaker":"dona_chie",
-      "context":"Ato 4, acolhimento",
-      "lines":["Tem coisa que a gente guarda ate a pessoa aprender a segurar.","Verdade na mao errada vira faca. Aprende primeiro a nao cortar ninguem com ela."]
+      "id": "clue_chie_01",
+      "speaker": "dona_chie",
+      "context": "Ato 4, acolhimento",
+      "lines": [
+        "Tem coisa que a gente guarda ate a pessoa aprender a segurar.",
+        "Verdade na mao errada vira faca. Aprende primeiro a nao cortar ninguem com ela."
+      ]
     },
     {
-      "id":"clue_dende_01",
-      "speaker":"mestre_dende",
-      "context":"Ato 4, depois da morte de Biel",
-      "lines":["Eu sabia mais do que te contei.","Nao calei pra te fazer fraco. Calei porque achei que silencio era protecao. Talvez eu tenha errado."]
+      "id": "clue_dende_01",
+      "speaker": "mestre_dende",
+      "context": "Ato 4, depois da morte de Biel",
+      "lines": [
+        "Eu sabia mais do que te contei.",
+        "Nao calei pra te fazer fraco. Calei porque achei que silencio era protecao. Talvez eu tenha errado."
+      ]
     }
   ],
   "act_dialogues": [
     {
-      "act":1,
-      "scene":"entrada_terreiro",
-      "beats":[
-        {"speaker":"mestre_dende","line":"Ser forte e ser gentil. Se uma coisa mata a outra, voce ainda nao entendeu nenhuma das duas."},
-        {"speaker":"ruan_macacao","line":"Eu vim aprender a vencer."},
-        {"speaker":"mestre_dende","line":"Entao aprende primeiro a cair sem procurar culpado."}
+      "act": 1,
+      "scene": "entrada_terreiro",
+      "beats": [
+        {
+          "speaker": "mestre_dende",
+          "line": "Ser forte e ser gentil. Se uma coisa mata a outra, voce ainda nao entendeu nenhuma das duas."
+        },
+        {
+          "speaker": "ruan_macacao",
+          "line": "Eu vim aprender a vencer."
+        },
+        {
+          "speaker": "mestre_dende",
+          "line": "Entao aprende primeiro a cair sem procurar culpado."
+        }
       ]
     },
     {
-      "act":1,
-      "scene":"primeira_vitoria_mao_estendida",
-      "beats":[
-        {"speaker":"davi_relampago","line":"Vai comemorar ou vai me deixar levantar?"},
-        {"speaker":"ruan_macacao","line":"Levanta."}
+      "act": 1,
+      "scene": "primeira_vitoria_mao_estendida",
+      "beats": [
+        {
+          "speaker": "davi_relampago",
+          "line": "Vai comemorar ou vai me deixar levantar?"
+        },
+        {
+          "speaker": "ruan_macacao",
+          "line": "Levanta."
+        }
       ]
     },
     {
-      "act":2,
-      "scene":"cassio_primeira_oferta",
-      "beats":[
-        {"speaker":"cassio_molho","line":"Voce tem conta, familia e talento. Orgulho nao paga nenhum dos tres."},
-        {"speaker":"ruan_macacao","line":"Eu nao preciso de favor."},
-        {"speaker":"cassio_molho","line":"Esse e o problema. Voce acha que aceitar ajuda e o mesmo que dever a alma."}
+      "act": 2,
+      "scene": "cassio_primeira_oferta",
+      "beats": [
+        {
+          "speaker": "cassio_molho",
+          "line": "Voce tem conta, familia e talento. Orgulho nao paga nenhum dos tres."
+        },
+        {
+          "speaker": "ruan_macacao",
+          "line": "Eu nao preciso de favor."
+        },
+        {
+          "speaker": "cassio_molho",
+          "line": "Esse e o problema. Voce acha que aceitar ajuda e o mesmo que dever a alma."
+        }
       ]
     },
     {
-      "act":3,
-      "scene":"o_barco_pos_consequencia",
-      "beats":[
-        {"speaker":"vera_salles","line":"A informacao era incompleta. Eu agi mesmo assim."},
-        {"speaker":"ruan_macacao","line":"E quem pagou nao fui eu nem voce."},
-        {"speaker":"vera_salles","line":"Entao para de contar essa historia como se alguem aqui tivesse a mao limpa."}
+      "act": 3,
+      "scene": "o_barco_pos_consequencia",
+      "beats": [
+        {
+          "speaker": "vera_salles",
+          "line": "A informacao era incompleta. Eu agi mesmo assim."
+        },
+        {
+          "speaker": "ruan_macacao",
+          "line": "E quem pagou nao fui eu nem voce."
+        },
+        {
+          "speaker": "vera_salles",
+          "line": "Entao para de contar essa historia como se alguem aqui tivesse a mao limpa."
+        }
       ]
     },
     {
-      "act":3,
-      "scene":"o_palco",
-      "beats":[
-        {"speaker":"leoa","line":"Hype vai embora. Quem mora aqui fica com o que sobrou."},
-        {"speaker":"ruan_macacao","line":"Eu achei que vencer ia proteger meu nome."},
-        {"speaker":"leoa","line":"Nome nao precisa de protecao. Gente precisa."}
+      "act": 3,
+      "scene": "o_palco",
+      "beats": [
+        {
+          "speaker": "leoa",
+          "line": "Hype vai embora. Quem mora aqui fica com o que sobrou."
+        },
+        {
+          "speaker": "ruan_macacao",
+          "line": "Eu achei que vencer ia proteger meu nome."
+        },
+        {
+          "speaker": "leoa",
+          "line": "Nome nao precisa de protecao. Gente precisa."
+        }
       ]
     },
     {
-      "act":4,
-      "scene":"dende_promete_merecer",
-      "beats":[
-        {"speaker":"mestre_dende","line":"Eu nao vou te pedir pra esquecer.","delivery":"quebrada"},
-        {"speaker":"mestre_dende","line":"Promete que vai merecer o que ainda da pra salvar.","delivery":"baixo"},
-        {"speaker":"ruan_macacao","line":"Eu prometo tentar sem transformar ele em desculpa."}
+      "act": 4,
+      "scene": "dende_promete_merecer",
+      "beats": [
+        {
+          "speaker": "mestre_dende",
+          "line": "Eu nao vou te pedir pra esquecer.",
+          "delivery": "quebrada"
+        },
+        {
+          "speaker": "mestre_dende",
+          "line": "Promete que vai merecer o que ainda da pra salvar.",
+          "delivery": "baixo"
+        },
+        {
+          "speaker": "ruan_macacao",
+          "line": "Eu prometo tentar sem transformar ele em desculpa."
+        }
       ]
     },
     {
-      "act":4,
-      "scene":"o_contrato",
-      "beats":[
-        {"speaker":"cassio_molho","line":"Eu nao inventei tua fome. So estou dizendo que sei vender o prato."},
-        {"speaker":"vera_salles","line":"Contrato tambem e escolha. E escolha deixa rastro."},
-        {"speaker":"tinker_bell","line":"Escolhe o que voce consegue sustentar quando nao tiver ninguem olhando."}
+      "act": 4,
+      "scene": "o_contrato",
+      "beats": [
+        {
+          "speaker": "cassio_molho",
+          "line": "Eu nao inventei tua fome. So estou dizendo que sei vender o prato."
+        },
+        {
+          "speaker": "vera_salles",
+          "line": "Contrato tambem e escolha. E escolha deixa rastro."
+        },
+        {
+          "speaker": "tinker_bell",
+          "line": "Escolhe o que voce consegue sustentar quando nao tiver ninguem olhando."
+        }
       ]
     },
     {
-      "act":4,
-      "scene":"pratigi_do_avesso",
-      "beats":[
-        {"speaker":"ruan_do_avesso","line":"Eu sou o que sobra quando voce chama medo de necessidade."},
-        {"speaker":"ruan_macacao","line":"Voce nao e meu inimigo."},
-        {"speaker":"ruan_do_avesso","line":"Entao prova que consegue me carregar sem me obedecer."}
+      "act": 5,
+      "scene": "revanche_davi",
+      "beats": [
+        {
+          "speaker": "davi_relampago",
+          "line": "Vai apertar?"
+        },
+        {
+          "speaker": "ruan_macacao",
+          "line": "Ja acabou."
+        },
+        {
+          "speaker": "davi_relampago",
+          "line": "Agora voce entendeu timing."
+        }
       ]
     },
     {
-      "act":5,
-      "scene":"revanche_davi",
-      "beats":[
-        {"speaker":"davi_relampago","line":"Vai apertar?"},
-        {"speaker":"ruan_macacao","line":"Ja acabou."},
-        {"speaker":"davi_relampago","line":"Agora voce entendeu timing."}
+      "act": 5,
+      "scene": "tinker_revela",
+      "beats": [
+        {
+          "speaker": "tinker_bell",
+          "line": "Eu sumi porque ficar perto de tu naquele momento colocava mais gente em risco."
+        },
+        {
+          "speaker": "ruan_macacao",
+          "line": "E tu esperava que eu entendesse sozinho?"
+        },
+        {
+          "speaker": "tinker_bell",
+          "line": "Não. Eu esperava voltar vivo pra explicar. Mas polícia eu nunca fui. Quem responde por essa parte é Vera."
+        }
       ]
     },
     {
-      "act":5,
-      "scene":"tinker_revela",
-      "beats":[
-        {"speaker":"tinker_bell","line":"Eu sumi porque ficar perto de voce naquele momento colocava mais gente em risco."},
-        {"speaker":"ruan_macacao","line":"E voce esperava que eu entendesse sozinho?"},
-        {"speaker":"tinker_bell","line":"Nao. Eu esperava voltar vivo pra explicar."}
+      "act": 5,
+      "scene": "instituto_cria",
+      "beats": [
+        {
+          "speaker": "dandara",
+          "line": "Agora vai ter timer?"
+        },
+        {
+          "speaker": "ruan_macacao",
+          "line": "So pra quem quiser."
+        },
+        {
+          "speaker": "dandara",
+          "line": "Entao eu fico."
+        }
       ]
     },
     {
-      "act":5,
-      "scene":"instituto_cria",
-      "beats":[
-        {"speaker":"dandara","line":"Agora vai ter timer?"},
-        {"speaker":"ruan_macacao","line":"So pra quem quiser."},
-        {"speaker":"dandara","line":"Entao eu fico."}
+      "act": 3,
+      "scene": "3.2b_o_gosto",
+      "beats": [
+        {
+          "speaker": "tinker_bell",
+          "line": "Tu ganhou. Limpo, até."
+        },
+        {
+          "speaker": "ruan_macacao",
+          "line": "Eu ouvi o ombro dele estalar, Tinker. E eu continuei."
+        },
+        {
+          "speaker": "tinker_bell",
+          "line": "Tu gostou?",
+          "delivery": "pausa_antes"
+        },
+        {
+          "speaker": "coro",
+          "line": "Diz que naquela noite o Macacão lavou a mão três vez. Diz que na quarta, ele parou de lavar.",
+          "delivery": "v.o."
+        }
+      ]
+    },
+    {
+      "act": 3,
+      "scene": "3.5b_forca_primeiro",
+      "beats": [
+        {
+          "speaker": "pipoca",
+          "line": "Me ensina a ser forte igual tu?"
+        },
+        {
+          "speaker": "ruan_macacao",
+          "line": "Força primeiro é não machucar. Aprende a segurar antes de aprender a bater."
+        }
+      ]
+    },
+    {
+      "act": 3,
+      "scene": "3.6_bala_desconfia",
+      "beats": [
+        {
+          "speaker": "pedro_bala",
+          "line": "Tu some de dia, luta de noite pra bandido, e quer que eu confie? Capitão que some não é capitão."
+        },
+        {
+          "speaker": "ruan_macacao",
+          "line": "Então não confia na fala. Me cobra na volta."
+        }
+      ]
+    },
+    {
+      "act": 3,
+      "scene": "3.6b_tu_luta_diferente",
+      "beats": [
+        {
+          "speaker": "pipoca",
+          "line": "Macacão… tu luta diferente agora. Antes tu ganhava segurando. Agora tu ganha machucando. Tu tá lutando como eles."
+        },
+        {
+          "speaker": "ruan_macacao",
+          "line": "Eu tô lutando como eles por fora. Por dentro eu ainda sou teu mestre. Me cobra se eu esquecer."
+        }
+      ]
+    },
+    {
+      "act": 3,
+      "scene": "3.9b_ordem_impossivel",
+      "beats": [
+        {
+          "speaker": "vera_salles",
+          "line": "É matemática, Macacão. Cinco menino por um banqueiro."
+        },
+        {
+          "speaker": "ruan_macacao",
+          "line": "Matemática não. É gente. Eu não te dou menino. Tu quer o Chupeta? Pega ele sem passar por cima de criança. Senão tu é igual ele de farda."
+        }
+      ]
+    },
+    {
+      "act": 4,
+      "scene": "4.1b_quem_volta",
+      "beats": [
+        {
+          "speaker": "ruan_macacao",
+          "line": "Aqui não. Ele tá comigo. E o Terreiro sabe o nome dele."
+        },
+        {
+          "speaker": "pedro_bala",
+          "line": "Eu não confio em quem some. Mas eu confio em quem volta. Tu voltou. Tá bom."
+        }
+      ]
+    },
+    {
+      "act": 4,
+      "scene": "4.1c_foguete_volta",
+      "beats": [
+        {
+          "speaker": "foguete",
+          "line": "Eu fiz recado pra eles. Eu achei que era só dinheiro."
+        },
+        {
+          "speaker": "ruan_macacao",
+          "line": "Aqui dentro tu é menino. Lá fora eu cuido. Mas tu não volta lá."
+        }
+      ]
+    },
+    {
+      "act": 4,
+      "scene": "4.2b_o_aluno_que_ficou",
+      "beats": [
+        {
+          "speaker": "mestre_dende",
+          "line": "George foi meu melhor aluno. Melhor que tu, melhor que eu fui. Mas quando a milícia veio comprar o braço dele, eu disse não. Ele disse que eu escolhi a fraqueza. Foi embora jurando que a rua ia ensinar o que o tatame não ensina."
+        },
+        {
+          "speaker": "ruan_macacao",
+          "line": "E o que a rua ensinou, mestre?"
+        },
+        {
+          "speaker": "mestre_dende",
+          "line": "Que dinheiro compra tudo, menos o que ele deixou aqui dentro.",
+          "stage_direction": "aponta_o_peito"
+        }
+      ]
+    },
+    {
+      "act": 4,
+      "scene": "4.2c_a_aula_dos_capitaes",
+      "beats": [
+        {
+          "speaker": "degodo",
+          "line": "Eu não treino menino pra lutar. Treino menino pra não precisar lutar."
+        },
+        {
+          "speaker": "mestre_dende",
+          "line": "É a mesma coisa, Adriano. Só muda o dia que tu percebe."
+        }
+      ]
+    },
+    {
+      "act": 4,
+      "scene": "4.3b_mentindo_pra_quem",
+      "beats": [
+        {
+          "speaker": "tinker_bell",
+          "line": "Eu não sou polícia, irmão. Eu sou teu empresário. E teu melhor amigo. E os dois tão te lendo diferente."
+        },
+        {
+          "speaker": "ruan_macacao",
+          "line": "Eu não podia te contar. Era pra te proteger."
+        },
+        {
+          "speaker": "tinker_bell",
+          "line": "Proteger é contar. Mentir é usar. Eu não sou teu handler, Ruan. Eu sou teu irmão. Daqui pra frente, eu sei de tudo — e eu decido comigo, não por ti."
+        }
+      ]
+    },
+    {
+      "act": 4,
+      "scene": "4.3c_mao_marcada",
+      "beats": [
+        {
+          "speaker": "ruan_macacao",
+          "line": "Tu vai aprender comigo. Todo dia. Até tua mão ficar mais forte que o medo."
+        },
+        {
+          "speaker": "pipoca",
+          "line": "Pra bater mais forte?"
+        },
+        {
+          "speaker": "ruan_macacao",
+          "line": "Pra não precisar."
+        }
+      ]
+    },
+    {
+      "act": 4,
+      "scene": "4.4_pratigi_do_avesso",
+      "beats": [
+        {
+          "speaker": "ruan_do_avesso",
+          "line": "Eu não sou teu sonho, Macacão. Eu sou teu recibo. Toda mentira tua tá escrita em mim."
+        },
+        {
+          "speaker": "ruan_do_avesso",
+          "line": "Me mata e tu vira eu. Me aceita e eu te ensino o que tu esconde. Mas lembra: eu volto quando tu mentir de novo."
+        },
+        {
+          "speaker": "ruan_macacao",
+          "line": "Então ajoelha. Eu vou carregar o que é meu sem te obedecer.",
+          "resolution": "aceitar_sem_finalizar"
+        }
+      ]
+    },
+    {
+      "act": 4,
+      "scene": "4.5b_o_hospital",
+      "beats": [
+        {
+          "speaker": "coro",
+          "line": "Diz que o Chupeta paga o remédio da mãe com o dinheiro que suja a mão de todo mundo. Diz que ele beija a testa dela e depois assina ordem pra quebrar osso de menino. Diz que é o mesmo homem. É.",
+          "delivery": "v.o."
+        }
+      ]
+    },
+    {
+      "act": 4,
+      "scene": "4.6_escudo_da_molecada",
+      "beats": [
+        {
+          "speaker": "pedro_bala",
+          "line": "Eu não confio em quem some. Mas eu confio em quem volta. Tu voltou. Tá bom."
+        },
+        {
+          "speaker": "pedro_bala",
+          "line": "Daqui pra frente nenhum Capitão faz recado pra Chupeta. Se apertar, chama o Terreiro."
+        }
+      ]
+    },
+    {
+      "act": 5,
+      "scene": "5.2_confronto_chupeta",
+      "beats": [
+        {
+          "speaker": "george_chupeta",
+          "line": "Dendê escolheu tu. O lento. O gentil. Eu provei que a rua é mais forte."
+        },
+        {
+          "speaker": "ruan_macacao",
+          "line": "Tu provou que a rua é mais cara. Custou tua mãe te ver assim. Custou menino que nem eu fui. Tu não é forte, George. Tu é caro."
+        },
+        {
+          "speaker": "ruan_macacao",
+          "line": "Eu podia. Eu não vou. É isso que o tatame ensinou e tu não quis aprender.",
+          "stage_direction": "segura_a_finalizacao_e_soltar"
+        }
+      ]
+    },
+    {
+      "act": 5,
+      "scene": "5.5s_o_dinheiro_que_nao_lava",
+      "beats": [
+        {
+          "speaker": "coro",
+          "line": "Diz que o Macacão ficou rico. Diz que ninguém viu ele rir de novo. Diz que dinheiro sujo não compra sono. Diz que é verdade.",
+          "delivery": "v.o."
+        }
+      ]
+    },
+    {
+      "act": 5,
+      "scene": "5.6s_a_volta",
+      "beats": [
+        {
+          "speaker": "mestre_dende",
+          "line": "O tatame não fecha pra quem volta. Mas tu não volta pra ser perdoado. Tu volta pra recomeçar."
+        },
+        {
+          "speaker": "mestre_dende",
+          "line": "Todo mundo que entra aqui, entra assim. Até tu. Principalmente tu.",
+          "stage_direction": "estende_uma_faixa_branca"
+        }
+      ],
+      "choices": [
+        {
+          "id": "aceitar_faixa_branca",
+          "label": "Aceitar a faixa branca",
+          "result": "Ruan ajoelha, amarra e recomeça do zero."
+        },
+        {
+          "id": "recusar_e_seguir_estrada",
+          "label": "Recusar e andar",
+          "result": "Ruan olha o tatame uma ultima vez e segue a estrada."
+        }
+      ]
+    },
+    {
+      "act": 3,
+      "scene": "3.8_a_isca",
+      "beats": [
+        {
+          "speaker": "pipoca",
+          "line": "Mestre… disseram que tu vinha se eu mandasse mensagem."
+        },
+        {
+          "speaker": "ruan_macacao",
+          "line": "Tu fez certo em me chamar. Agora fica atrás de mim."
+        },
+        {
+          "speaker": "george_chupeta",
+          "line": "O menino só abriu a porta. Quem escolheu entrar foi tu."
+        }
+      ]
+    },
+    {
+      "act": 4,
+      "scene": "4.2a_rastro_do_aluno",
+      "beats": [
+        {
+          "speaker": "byaku",
+          "line": "Antes de ser Chupeta, George era do Terreiro."
+        },
+        {
+          "speaker": "kenzo_kuroi",
+          "line": "O padrão dele não nasceu na rua. A rua comprou uma técnica que já vinha treinada."
+        },
+        {
+          "speaker": "ruan_macacao",
+          "line": "Então Dendê vai me contar o resto."
+        }
+      ]
+    },
+    {
+      "act": 5,
+      "scene": "5.5h_primeira_faixa",
+      "beats": [
+        {
+          "speaker": "pipoca",
+          "line": "Agora eu sou forte?"
+        },
+        {
+          "speaker": "ruan_macacao",
+          "line": "Agora tu começou. Forte a gente prova no jeito que segura."
+        }
       ]
     }
   ],
   "ending_lines": {
-    "heroi_duas_aguas":["Ganhar foi a parte curta.","E a parte longa?","Ficar."],
-    "rei_dos_atalhos":["Todo mundo sabe teu nome.","E voce?","Ainda estou tentando lembrar."],
-    "a_verdade":["Vo... eu aprendi a plantar."]
+    "heroi_duas_aguas": [
+      "Ganhar foi a parte curta.",
+      "E a parte longa?",
+      "Ficar."
+    ],
+    "rei_dos_atalhos": [
+      "Todo mundo sabe teu nome.",
+      "E voce?",
+      "Ainda estou tentando lembrar."
+    ],
+    "a_verdade": [
+      "Vo... eu aprendi a plantar."
+    ],
+    "sombras_recomeco": [
+      "Todo mundo entra assim.",
+      "Até eu?",
+      "Principalmente tu."
+    ],
+    "sombras_estrada": [
+      "A porta ficou aberta.",
+      "E ele?",
+      "Escolheu a estrada."
+    ]
   }
 }

--- a/data/narrative/endings_v2.json
+++ b/data/narrative/endings_v2.json
@@ -1,12 +1,16 @@
 {
   "$schema": "cria_endings_v2",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "authority": "data/narrative/canon_v3.json",
   "main_endings": [
     {
       "id": "heroi_duas_aguas",
       "title": "Heroi das Duas Aguas",
-      "conditions": {"contract_not": "cassio", "verdade_gte_faca": true, "honra_min": 25},
+      "conditions": {
+        "contract_not": "cassio",
+        "verdade_gte_faca": true,
+        "honra_min": 25
+      },
       "resolution": "Ruan transforma a faixa preta em responsabilidade comunitaria e ajuda a erguer o Instituto CRIA.",
       "tone": "esperancoso sem santificacao",
       "core_image": "Ruan abre o Terreiro e divide o centro do quadro com outras crias, nao acima delas."
@@ -14,66 +18,130 @@
     {
       "id": "rei_dos_atalhos",
       "title": "Rei dos Atalhos",
-      "conditions_any": [{"contract": "cassio"}, {"faca_gt_verdade": true}],
-      "resolution": "Ruan vence externamente, mas sua forca passa a depender de controle, medo e imagem.",
+      "conditions_any": [
+        {
+          "contract": "cassio"
+        },
+        {
+          "faca_gt_verdade": true
+        }
+      ],
+      "resolution": "Ruan vence externamente, mas o dinheiro e o controle corroem sono, intimidade e identidade; a consequencia continua depois dos creditos.",
       "tone": "vitoria externa, perda interna",
-      "core_image": "Ruan cercado de sinais de sucesso, com distancia humana crescente."
+      "core_image": "Ruan cercado de sinais de sucesso enquanto o Coro desaparece; no epilogo Sombras, a faixa branca permanece como porta de recomeço."
     }
   ],
   "epilogues": [
     {
-      "id":"casal_do_tatame",
-      "parent_ending":"heroi_duas_aguas",
-      "conditions":{"honra_min":55,"maos_sujas_max":45},
-      "resolution":"Ruan constrói uma vida afetiva sustentada por rotina, cuidado e tatame, sem transformar relacionamento em premio por vencer.",
-      "compatibility":"optional"
+      "id": "casal_do_tatame",
+      "parent_ending": "heroi_duas_aguas",
+      "conditions": {
+        "honra_min": 55,
+        "maos_sujas_max": 45
+      },
+      "resolution": "Ruan constrói uma vida afetiva sustentada por rotina, cuidado e tatame, sem transformar relacionamento em premio por vencer.",
+      "compatibility": "optional"
     },
     {
-      "id":"veterano_cicatriz",
-      "parent_ending":"heroi_duas_aguas",
-      "conditions":{"maos_sujas_ever_above":60,"restituicao_min":2},
-      "resolution":"Ruan ensina carregando a cicatriz de escolhas antigas. A reparacao melhora o futuro sem apagar o passado.",
-      "compatibility":"optional"
+      "id": "veterano_cicatriz",
+      "parent_ending": "heroi_duas_aguas",
+      "conditions": {
+        "maos_sujas_ever_above": 60,
+        "restituicao_min": 2
+      },
+      "resolution": "Ruan ensina carregando a cicatriz de escolhas antigas. A reparacao melhora o futuro sem apagar o passado.",
+      "compatibility": "optional"
     },
     {
-      "id":"estrela_vazia",
-      "parent_ending":"rei_dos_atalhos",
-      "conditions":{"hype_min":70,"verdade_max":45},
-      "resolution":"Dinheiro, seguidores e contratos crescem enquanto intimidade e confianca desaparecem.",
-      "compatibility":"optional"
+      "id": "estrela_vazia",
+      "parent_ending": "rei_dos_atalhos",
+      "conditions": {
+        "hype_min": 70,
+        "verdade_max": 45
+      },
+      "resolution": "Dinheiro, seguidores e contratos crescem enquanto intimidade e confianca desaparecem.",
+      "compatibility": "optional"
     },
     {
-      "id":"traidor_silencioso",
-      "parent_ending":"rei_dos_atalhos",
-      "conditions":{"dupla_face_min":25,"tinker_state":"RETORNO_DIFICIL"},
-      "resolution":"Tinker retorna, mas a relacao permanece fria; o futuro depende de prova continuada, nao de uma fala de perdao.",
-      "compatibility":"optional"
+      "id": "traidor_silencioso",
+      "parent_ending": "rei_dos_atalhos",
+      "conditions": {
+        "dupla_face_min": 25,
+        "tinker_state": "RETORNO_DIFICIL"
+      },
+      "resolution": "Tinker retorna, mas a relacao permanece fria; o futuro depende de prova continuada, nao de uma fala de perdao.",
+      "compatibility": "optional"
     },
     {
-      "id":"o_informante",
-      "parent_ending":"rei_dos_atalhos",
-      "conditions":{"faca_min":60,"truth_fragments_min":4},
-      "resolution":"Ruan aprende a negociar informacao como poder e termina preso a uma logica de utilidade que antes dizia combater.",
-      "compatibility":"optional"
+      "id": "o_informante",
+      "parent_ending": "rei_dos_atalhos",
+      "conditions": {
+        "faca_min": 60,
+        "truth_fragments_min": 4
+      },
+      "resolution": "Ruan aprende a negociar informacao como poder e termina preso a uma logica de utilidade que antes dizia combater.",
+      "compatibility": "optional"
+    },
+    {
+      "id": "dinheiro_que_nao_lava",
+      "parent_ending": "rei_dos_atalhos",
+      "conditions": {
+        "shadow_money_taken": true
+      },
+      "resolution": "Ruan parte com dinheiro da rede, mas nao consegue transforma-lo em vida limpa; o Coro some e o sono quebra.",
+      "compatibility": "optional",
+      "scene_ref": "5.5s_o_dinheiro_que_nao_lava"
+    },
+    {
+      "id": "sombras_a_volta",
+      "parent_ending": "rei_dos_atalhos",
+      "conditions": {
+        "shadow_money_taken": true,
+        "years_later_return": true
+      },
+      "resolution": "Ruan volta ao Terreiro quebrado; Dende oferece faixa branca como recomeço, nao absolvição.",
+      "compatibility": "optional",
+      "scene_ref": "5.6s_a_volta",
+      "micro_choice": [
+        {
+          "id": "aceitar_faixa_branca",
+          "result": "recomeco_do_zero",
+          "ngplus_hook": true
+        },
+        {
+          "id": "recusar_e_seguir_estrada",
+          "result": "tragedia_assumida",
+          "ngplus_hook": false
+        }
+      ]
     }
   ],
   "truth_layer": {
-    "id":"a_verdade",
-    "independent":true,
-    "required_fragments":8,
-    "can_overlay":["heroi_duas_aguas","rei_dos_atalhos"],
+    "id": "a_verdade",
+    "independent": true,
+    "required_fragments": 8,
+    "can_overlay": [
+      "heroi_duas_aguas",
+      "rei_dos_atalhos"
+    ],
     "scene": {
-      "location":"terreiro_quintal",
-      "image":"Ruan planta uma camelia em silencio.",
-      "spoken_line":"Vo... eu aprendi a plantar.",
-      "rule":"nenhum nome oculto e pronunciado"
+      "location": "terreiro_quintal",
+      "image": "Ruan planta uma camelia em silencio.",
+      "spoken_line": "Vo... eu aprendi a plantar.",
+      "rule": "nenhum nome oculto e pronunciado"
     }
   },
-  "selection_order": ["main_ending", "compatible_epilogues", "truth_layer"],
+  "selection_order": [
+    "main_ending",
+    "compatible_epilogues",
+    "truth_layer"
+  ],
   "design_rules": {
     "truth_layer_is_not_a_third_main_ending": true,
     "multiple_compatible_epilogues_allowed": true,
     "maos_sujas_scar_is_never_erased": true,
-    "ending_must_reflect_choices_not_score_only": true
+    "ending_must_reflect_choices_not_score_only": true,
+    "shadow_ending_is_not_impunity": true,
+    "restarting_is_not_automatic_forgiveness": true
   }
 }

--- a/data/narrative/narrative_v3_fixes_characters.json
+++ b/data/narrative/narrative_v3_fixes_characters.json
@@ -1,0 +1,339 @@
+{
+  "$schema": "cria_character_addendum_v3_fixes",
+  "version": "1.0.0",
+  "authority": "data/narrative/canon_v3.json",
+  "purpose": "Registrar personagens introduzidos pelos cinco fixes narrativos sem reescrever retroativamente a bible v1.",
+  "rules": {
+    "all_characters_are_fictional": true,
+    "no_real_person_likeness": true,
+    "children_are_never_operational_assets": true,
+    "antagonist_humanization_is_not_absolution": true
+  },
+  "characters": [
+    {
+      "id": "george_chupeta",
+      "nome": "George 'Chupeta'",
+      "papel": "antagonista humano da rede e ex-aluno de Dende",
+      "arquetipo_jung": "Filho Perdido / Sombra do Discipulo",
+      "identidade": {
+        "idade": "adulto",
+        "origem": "Baixo Sul ficcional"
+      },
+      "visual": {
+        "silhueta": "elegante, compacta, contida",
+        "cor": "grafite, vinho e dourado gasto",
+        "acessorio": "terno simples; nenhum simbolo real",
+        "cabelo": "curto",
+        "roupa": "social discreta"
+      },
+      "psique": {
+        "want": "provar que a rua e mais forte que o limite moral do tatame",
+        "need": "reconhecer que poder comprado cobra pessoas",
+        "fear": "voltar a ser o aluno rejeitado",
+        "flaw": "confunde custo imposto aos outros com força propria"
+      },
+      "voz": {
+        "estilo": "baixa, segura, sem caricatura",
+        "fala": "Eu provei que a rua é mais forte."
+      },
+      "combate": {
+        "estilo": "pressao madura e finalizacoes controladoras",
+        "assinatura": "Preco da Rua"
+      },
+      "arco": "melhor aluno -> ruptura com Dende -> banqueiro da rede -> ponto mole com Dona Zefa -> confronto sem quebra",
+      "relacoes": [
+        "Dende ex-mestre",
+        "Ruan espelho moral",
+        "Dona Zefa mae",
+        "Cassio/Montenegro rede de interesse"
+      ],
+      "segredo": "cuida da mae com ternura enquanto sustenta uma rede que fere outras familias",
+      "papel_no_jogo": "antagonista tragico do eixo humano; boss moral A5"
+    },
+    {
+      "id": "dona_zefa",
+      "nome": "Dona Zefa",
+      "papel": "mae de Chupeta e ponto de humanidade, nunca refem",
+      "arquetipo_jung": "Grande Mae",
+      "identidade": {
+        "idade": "idosa",
+        "origem": "Baixo Sul ficcional"
+      },
+      "visual": {
+        "silhueta": "fragil sem ser infantilizada",
+        "cor": "azul claro e off-white",
+        "acessorio": "livro",
+        "cabelo": "grisalho",
+        "roupa": "hospitalar simples"
+      },
+      "psique": {
+        "want": "presenca do filho",
+        "need": "nenhuma funcao de expiar crimes alheios",
+        "fear": "adoecimento e abandono",
+        "flaw": "nao usada como falha moral"
+      },
+      "voz": {
+        "estilo": "pouca fala",
+        "fala": ""
+      },
+      "combate": {
+        "estilo": "nao combatente",
+        "assinatura": "nenhuma"
+      },
+      "arco": "presenca breve no hospital humaniza sem absolver",
+      "relacoes": [
+        "George Chupeta filho"
+      ],
+      "segredo": "nenhum",
+      "papel_no_jogo": "cena 4.5b; proibido usa-la como alvo, chantagem ou moeda"
+    },
+    {
+      "id": "pedro_bala",
+      "nome": "Pedro 'Bala'",
+      "papel": "Capitao da molecada e fiscal de confianca",
+      "arquetipo_jung": "Guardiao Jovem",
+      "identidade": {
+        "idade": "adolescente",
+        "origem": "Itubera ficcional"
+      },
+      "visual": {
+        "silhueta": "magro, firme",
+        "cor": "azul gasto e amarelo",
+        "acessorio": "cordao do Terreiro",
+        "cabelo": "curto",
+        "roupa": "treino simples"
+      },
+      "psique": {
+        "want": "proteger os menores",
+        "need": "ver adultos voltarem quando prometem",
+        "fear": "ser abandonado por mais um capitão",
+        "flaw": "desconfiança defensiva"
+      },
+      "voz": {
+        "estilo": "direta, desconfiada",
+        "fala": "Capitão que some não é capitão."
+      },
+      "combate": {
+        "estilo": "iniciante; sem glorificacao de luta de rua",
+        "assinatura": "nenhuma"
+      },
+      "arco": "desconfiança -> confronto -> retorno comprovado -> escudo dos Capitaes",
+      "relacoes": [
+        "Ruan referencia sob prova",
+        "Pipoca e Foguete protegidos"
+      ],
+      "segredo": "nenhum",
+      "papel_no_jogo": "mede confiança por ações e organiza proteção da molecada"
+    },
+    {
+      "id": "pipoca",
+      "nome": "Pipoca",
+      "papel": "crianca do Terreiro e arco de transmissao",
+      "arquetipo_jung": "Crianca / Aprendiz",
+      "identidade": {
+        "idade": "crianca",
+        "origem": "Itubera ficcional"
+      },
+      "visual": {
+        "silhueta": "pequena, energetica",
+        "cor": "off-white, azul e amarelo",
+        "acessorio": "faixa branca no final Heroi",
+        "cabelo": "curto",
+        "roupa": "treino confortável"
+      },
+      "psique": {
+        "want": "ser forte como Ruan",
+        "need": "aprender que força primeiro e conter",
+        "fear": "ser impotente",
+        "flaw": "imita sem compreender"
+      },
+      "voz": {
+        "estilo": "franca e literal",
+        "fala": "Tu luta diferente agora."
+      },
+      "combate": {
+        "estilo": "aprendizagem segura; sem foco competitivo infantil",
+        "assinatura": "segurar_antes_de_bater"
+      },
+      "arco": "idolo -> isca -> cicatriz -> primeira faixa",
+      "relacoes": [
+        "Ruan mestre",
+        "Bala protetor",
+        "Foguete colega"
+      ],
+      "segredo": "nenhum",
+      "papel_no_jogo": "torna a tese observavel e fecha o Heroi com primeira faixa"
+    },
+    {
+      "id": "foguete",
+      "nome": "Foguete",
+      "papel": "Capitao cooptado que retorna",
+      "arquetipo_jung": "Filho Prodigo",
+      "identidade": {
+        "idade": "adolescente",
+        "origem": "Itubera ficcional"
+      },
+      "visual": {
+        "silhueta": "leve e inquieta",
+        "cor": "verde gasto e grafite",
+        "acessorio": "mochila",
+        "cabelo": "curto",
+        "roupa": "casual"
+      },
+      "psique": {
+        "want": "dinheiro rapido e pertencimento",
+        "need": "limite sem humilhacao",
+        "fear": "retaliacao e expulsao",
+        "flaw": "impulsividade"
+      },
+      "voz": {
+        "estilo": "rapida, envergonhada quando retorna",
+        "fala": "Eu achei que era só dinheiro."
+      },
+      "combate": {
+        "estilo": "nao foco",
+        "assinatura": "nenhuma"
+      },
+      "arco": "cooptado -> assustado -> acolhido -> protegido com limite",
+      "relacoes": [
+        "Ruan protetor",
+        "Bala capitao",
+        "Pipoca colega"
+      ],
+      "segredo": "viu algo que nao devia enquanto fazia recado",
+      "papel_no_jogo": "prova que o Terreiro acolhe erro sem normalizar risco"
+    },
+    {
+      "id": "degodo",
+      "nome": "Adriano 'Degodo'",
+      "papel": "adulto do Terreiro e instrutor relutante da molecada",
+      "arquetipo_jung": "Guardiao",
+      "identidade": {
+        "idade": "adulto",
+        "origem": "Baixo Sul ficcional"
+      },
+      "visual": {
+        "silhueta": "larga e cansada",
+        "cor": "terra e grafite",
+        "acessorio": "toalha de treino",
+        "cabelo": "curto",
+        "roupa": "gi gasto"
+      },
+      "psique": {
+        "want": "evitar que menino precise lutar na rua",
+        "need": "admitir que ensinar tambem e proteger",
+        "fear": "repetir ciclos de violencia",
+        "flaw": "dureza verbal"
+      },
+      "voz": {
+        "estilo": "seca, old school",
+        "fala": "Eu não treino menino pra lutar. Treino menino pra não precisar lutar."
+      },
+      "combate": {
+        "estilo": "BJJ raiz defensivo",
+        "assinatura": "Base de Porteira"
+      },
+      "arco": "reclama da aula infantil -> ensina junto -> assume papel protetivo",
+      "relacoes": [
+        "Dende mestre",
+        "Ruan parceiro de tatame",
+        "Capitaes alunos"
+      ],
+      "segredo": "nenhum",
+      "papel_no_jogo": "cena ancora Aula dos Capitaes"
+    },
+    {
+      "id": "coro",
+      "nome": "Coro",
+      "papel": "voz comunitaria extradiegética de realidade magica",
+      "arquetipo_jung": "Coro Grego",
+      "identidade": {
+        "idade": "atemporal",
+        "origem": "voz coletiva ficcional do Baixo Sul"
+      },
+      "visual": {
+        "silhueta": "nao possui corpo fixo",
+        "cor": "n/a",
+        "acessorio": "n/a",
+        "cabelo": "n/a",
+        "roupa": "n/a"
+      },
+      "psique": {
+        "want": "registrar consequencia sem explicar demais",
+        "need": "preservar ambiguidade",
+        "fear": "virar narrador moralista",
+        "flaw": "nenhuma pessoa individual responde por suas falas"
+      },
+      "voz": {
+        "estilo": "oral, curta, 'Diz que...'",
+        "fala": "Diz que dinheiro sujo não compra sono. Diz que é verdade."
+      },
+      "combate": {
+        "estilo": "nao aplicavel",
+        "assinatura": "nenhuma"
+      },
+      "arco": "aparece quando comunidade, culpa ou mito precisam deixar marca",
+      "relacoes": [
+        "Ruan como objeto de memoria coletiva"
+      ],
+      "segredo": "nao e fonte factual onisciente; e dispositivo de memoria e mito",
+      "papel_no_jogo": "voz off, transicoes e consequencia"
+    }
+  ],
+  "character_overrides": [
+    {
+      "id": "tinker_bell",
+      "supersedes_fields": [
+        "papel",
+        "segredo",
+        "arco",
+        "relacoes",
+        "papel_no_jogo"
+      ],
+      "papel": "irmao, empresario e co-arquiteto civil da queda de Chupeta; nao e policial",
+      "segredo": "Ruan omite dele a infiltracao durante parte do Ato 3; Tinker descobre padroes e exige agencia propria",
+      "arco": "companheiro/empresario -> percebe incoerencias -> confronta Ruan -> escolhe saber de tudo -> co-arquiteto civil -> afastamento operacional A4 -> retorno",
+      "relacoes": [
+        "Ruan irmao e amigo",
+        "Vera interlocutora institucional depois da verdade",
+        "Dende confianca conquistada"
+      ],
+      "papel_no_jogo": "vinculo dinamico, leitura tatica civil, contrapeso de lealdade; nunca handler"
+    },
+    {
+      "id": "vera_salles",
+      "supersedes_fields": [
+        "papel",
+        "arco",
+        "relacoes",
+        "papel_no_jogo"
+      ],
+      "papel": "agente federal ficcional e eixo institucional da infiltracao",
+      "arco": "recruta Ruan opcionalmente -> utilitarismo tensionado em A3 -> Ruan recusa usar criancas -> aprende limite operacional -> Operacao Raiz Forte",
+      "relacoes": [
+        "Ruan fonte/aliado com agencia",
+        "Tinker civil informado depois",
+        "Montenegro e Chupeta alvos"
+      ],
+      "papel_no_jogo": "rota Verdade, pressao institucional e infiltracao PF; nao controla moralmente Ruan"
+    },
+    {
+      "id": "ruan_do_avesso",
+      "supersedes_fields": [
+        "papel",
+        "identidade",
+        "segredo",
+        "arco",
+        "papel_no_jogo"
+      ],
+      "papel": "manifestacao de realidade magica da divida moral de Ruan; espelho, nunca demonio",
+      "identidade": {
+        "idade": "igual ao save de Ruan",
+        "origem": "Pratigi do Avesso; somente Ruan o ve, mas marcas e efeitos persistem no mundo"
+      },
+      "segredo": "nao e sonho nem simples alucinacao; sua ontologia permanece poetica, mas seus efeitos de jogo sao reais e persistentes",
+      "arco": "surge quando sombra, cobertura rachada, lua cheia e mare baixa coincidem -> cobra mentira -> integra sem finalizacao -> retorna quando Ruan mente de novo",
+      "papel_no_jogo": "boss moral recorrente; perder cobra honra e aumenta a divida, vencer por aceitacao concede Visao do Avesso"
+    }
+  ]
+}


### PR DESCRIPTION
## Objetivo
Canoniza os cinco fixes narrativos aprovados para os Atos 3–5 sem romper o eixo existente da Operação Raiz Forte.

## Mudanças canônicas
- **Infiltração com custo:** adiciona `O Gosto`, `Tu Luta Diferente`, `A Ordem Impossível` e o confronto de Tinker.
- **George "Chupeta":** entra como ex-aluno de Dendê e antagonista humano/trágico da rede, preservando Cássio e Montenegro como camadas distintas.
- **Pratigi do Avesso:** passa a realidade mágica com gatilhos, custos persistentes, `avesso_debt` e recorrência moral.
- **Molecada:** Pedro Bala, Pipoca e Foguete ganham arcos próprios; `A Aula dos Capitães` transforma o Terreiro em estrutura ativa de proteção.
- **Sombras:** deixa de premiar impunidade; `O Dinheiro que Não Lava` e `A Volta` acrescentam corrosão + micro-escolha de faixa branca/estrada.

## Migração de papel
- **Vera Salles** é o eixo federal da infiltração.
- **Tinker Bell** passa a irmão/empresário/co-arquiteto civil, nunca policial nem handler.
- O override fica explícito em `narrative_v3_fixes_characters.json` e na precedência definida pelo cânone.

## Arquivos
- `data/narrative/canon_v3.json` → 3.1.0
- `data/narrative/acts_v3.json` → 3.1.0
- `data/narrative/dialogues.json` → 3.1.0
- `data/narrative/endings_v2.json` → 2.1.0
- novo `data/narrative/narrative_v3_fixes_characters.json` → 1.0.0

## QA executado
Gate estrutural local: **PASS**
- 23 `scene_ref` verificados
- 26 cenas adultas indexadas
- 30 cenas de diálogo
- 7 personagens novos
- 7 epílogos
- zero IDs duplicados
- zero `scene_ref` órfãos
- zero cenas novas sem diálogo esperado
- escolhas do final Sombras consistentes entre acts/dialogues/endings
- regra PF/Tinker consistente
- regra do Avesso consistente entre cânone e atos
- proteção da molecada explícita no cânone e no addendum

Nenhuma lógica de runtime foi alterada neste PR; trata-se de canonização e dados narrativos.