### PR TITLE
feat(art): evaluate God Mode AI as Sprite Forge candidate

### DIFF
--- a/.github/workflows/godmode-sprite-candidate.yml
+++ b/.github/workflows/godmode-sprite-candidate.yml
@@ -1,0 +1,34 @@
+name: God Mode Sprite Candidate
+
+on:
+  pull_request:
+    paths:
+      - 'data/production/external_tool_registry_v1.json'
+      - 'data/visual/godmode_sprite_adapter_v1.json'
+      - 'tools/art/validate_godmode_sprite_adapter_v1.py'
+      - 'tests/test_godmode_sprite_adapter_v1.py'
+      - '.github/workflows/godmode-sprite-candidate.yml'
+  push:
+    branches:
+      - visual/godmode-sprite-candidate
+
+jobs:
+  validate-godmode-sprite-candidate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Validate external-tool registry
+        run: python tools/ci/validate_external_tool_registry_v1.py
+
+      - name: Validate God Mode adapter
+        run: python tools/art/validate_godmode_sprite_adapter_v1.py
+
+      - name: Run adapter invariants
+        run: python -m unittest discover -s tests -p 'test_godmode_sprite_adapter_v1.py'

--- a/data/production/external_tool_registry_v1.json
+++ b/data/production/external_tool_registry_v1.json
@@ -161,6 +161,31 @@
       "notes": "Comparison corpus only. Model-ranking claims from social posts are subjective benchmark commentary, not engineering evidence for CRIA."
     },
     {
+      "id": "godmodeai_sprite_service",
+      "kind": "external_service",
+      "source": "https://www.godmodeai.co",
+      "revision": "terms_2026-04-21_api_observed_2026-09-12",
+      "license_status": "SERVICE_TERMS_COMMERCIAL_OUTPUT_ALLOWED_REVIEW_REQUIRED",
+      "adoption": "ADOPTED_CANDIDATE_GENERATOR",
+      "direct_code_reuse": false,
+      "direct_asset_reuse": false,
+      "cria_roles": ["sprite_candidate_generation", "action_generation", "background_removal", "animation_upscale", "mcp_authoring_adapter"],
+      "notes": "Provider terms observed 2026-09-12 expressly allow commercial use of Generated Output and assign provider-held rights in Generated Output to the user, but do not guarantee uniqueness or non-infringement. CRIA therefore treats every result as CANDIDATE, preserves input/output provenance, keeps private sharing off, requires human rights review, and never creates a runtime dependency on this service."
+    },
+    {
+      "id": "godmodeai_sprites_skill",
+      "kind": "github_repo",
+      "source": "lyogavin/godmodeai-sprites-skill",
+      "revision": "98199ec3432d670793b6464b3e77c513db902992",
+      "license_status": "CLEAR_MIT",
+      "adoption": "REFERENCE_PINNED_MIT",
+      "direct_code_reuse": false,
+      "direct_asset_reuse": false,
+      "attribution_required": true,
+      "cria_roles": ["provider_action_discovery", "mcp_rest_authoring_workflow_reference"],
+      "notes": "Official God Mode sprite Agent Skill v1.0.0 pinned for workflow/reference only. CRIA does not need to copy it into the repository to use the provider adapter; if code is ever ported later, preserve MIT attribution and review the diff separately."
+    },
+    {
       "id": "old_cria_android_repo",
       "kind": "github_repo",
       "source": "ringuemkt-rgb/Cria-do-tatame-",

--- a/data/visual/godmode_sprite_adapter_v1.json
+++ b/data/visual/godmode_sprite_adapter_v1.json
@@ -1,0 +1,120 @@
+{
+  "$schema": "cria.godmode_sprite_adapter.v1",
+  "version": "1.0.0",
+  "status": "CANDIDATE_AUTHORING_ADAPTER",
+  "shipping": false,
+  "runtime_dependency": false,
+  "canon_authority": false,
+  "combat_authority": false,
+  "purpose": "Use God Mode AI only as an optional external authoring provider for CRIA Sprite Forge candidate sprites and animations. Every output remains a candidate until CRIA normalization, provenance, rights, technical QA and human approval pass.",
+  "authority": {
+    "sprite_forge": "data/visual/sprite_forge_contract_v2.json",
+    "visual": ".agents/skills/cria-art-direction/SKILL.md",
+    "external_tools": "data/production/external_tool_registry_v1.json",
+    "bjj": "authoritative BJJ graph/rules/reducer",
+    "runtime": "Godot"
+  },
+  "provider": {
+    "id": "godmodeai_sprite_service",
+    "service": "God Mode AI",
+    "terms_snapshot": "2026-04-21",
+    "api_observed": "2026-09-12",
+    "official_skill_repo": "lyogavin/godmodeai-sprites-skill",
+    "official_skill_revision": "98199ec3432d670793b6464b3e77c513db902992",
+    "official_skill_license": "MIT",
+    "interfaces": {
+      "rest_api": "https://www.godmodeai.co/get-api",
+      "mcp_endpoint": "https://www.godmodeai.co/api/mcp"
+    },
+    "authentication": {
+      "type": "bearer_token",
+      "environment_variable": "GODMODEAI_API_TOKEN",
+      "must_not_be_committed": true,
+      "must_not_be_written_to_sidecars": true
+    }
+  },
+  "supported_authoring_tools": [
+    "list_actions",
+    "list_models",
+    "upload_image",
+    "generate_sprite",
+    "get_sprite_result",
+    "remove_background",
+    "get_bg_removal_result",
+    "upscale_animation",
+    "get_upscale_result"
+  ],
+  "input_gate": {
+    "approved_identity_master_required_for_character_animation": true,
+    "input_rights_must_be_known": true,
+    "real_person_reference_requires_separate_consent_and_rights_review": true,
+    "production_requirement_id_required": true,
+    "bjj_transition_id_required_for_bjj_animation": true,
+    "generic_attack_prompt_may_define_bjj_motion": false,
+    "paired_bjj_spec_must_define_attacker_defender_sync": true
+  },
+  "generation_policy": {
+    "one_approved_character_seed_is_preferred": true,
+    "whole_action_strip_preferred_over_independent_frame_generation": true,
+    "exact_action_and_camera_view_must_be_recorded": true,
+    "raw_provider_output_status": "CANDIDATE",
+    "raw_provider_output_may_enter_runtime_paths": false,
+    "provider_may_choose_shipping": false,
+    "provider_may_define_canon": false,
+    "provider_may_define_bjj_legality_or_scoring": false,
+    "remote_service_required_for_gameplay": false
+  },
+  "normalization_handoff": {
+    "frame_px": [128, 128],
+    "upright_pivot_px": [64, 96],
+    "resampling": "nearest",
+    "integer_scale_only": true,
+    "binary_alpha_after_normalization": true,
+    "shared_scale_per_strip": true,
+    "shared_anchor_per_strip": true,
+    "identity_comparison_required": true,
+    "preview_harness_required": true,
+    "godot_runtime_evidence_required_before_promotion": true
+  },
+  "rights_policy": {
+    "provider_terms_allow_commercial_generated_output_as_of_snapshot": true,
+    "provider_terms_guarantee_output_uniqueness": false,
+    "provider_terms_guarantee_non_infringement": false,
+    "cria_rights_review_still_required": true,
+    "public_share_opt_in_must_remain_false_for_private_cria_assets": true,
+    "unknown_or_disputed_input_rights_block_generation_for_shipping_use": true
+  },
+  "required_provenance_fields": [
+    "asset_id",
+    "source_requirement_id",
+    "provider_id",
+    "provider_interface",
+    "provider_action",
+    "provider_model_or_tool",
+    "provider_revision_or_observation_date",
+    "identity_master_id",
+    "source_references",
+    "input_rights_status",
+    "terms_snapshot",
+    "raw_output_hash",
+    "normalization_evidence",
+    "qa_evidence",
+    "human_editor",
+    "human_approval",
+    "rights_status",
+    "shipping"
+  ],
+  "promotion_gate": {
+    "default_shipping": false,
+    "requires_sprite_forge_v2_pass": true,
+    "requires_human_visual_review": true,
+    "requires_human_rights_review": true,
+    "requires_biomechanical_review_for_bjj": true,
+    "requires_godot_import_and_runtime_visual_evidence": true,
+    "secret_presence_is_hard_fail": true
+  },
+  "rollback": {
+    "remove_adapter_without_touching_runtime": true,
+    "existing_assets_require_independent_provenance_to_survive_provider_removal": true
+  }
+}

--- a/tests/test_godmode_sprite_adapter_v1.py
+++ b/tests/test_godmode_sprite_adapter_v1.py
@@ -1,0 +1,65 @@
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ADAPTER = ROOT / "data/visual/godmode_sprite_adapter_v1.json"
+VALIDATOR = ROOT / "tools/art/validate_godmode_sprite_adapter_v1.py"
+
+
+class GodModeSpriteAdapterV1Tests(unittest.TestCase):
+    def setUp(self):
+        self.adapter = json.loads(ADAPTER.read_text(encoding="utf-8"))
+
+    def test_validator_passes(self):
+        result = subprocess.run(
+            [sys.executable, str(VALIDATOR)],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertTrue(json.loads(result.stdout)["ok"])
+
+    def test_provider_is_authoring_only(self):
+        self.assertFalse(self.adapter["runtime_dependency"])
+        self.assertFalse(self.adapter["shipping"])
+        self.assertFalse(self.adapter["canon_authority"])
+        self.assertFalse(self.adapter["combat_authority"])
+        self.assertFalse(self.adapter["generation_policy"]["remote_service_required_for_gameplay"])
+
+    def test_bjj_cannot_be_defined_by_generic_generation(self):
+        gate = self.adapter["input_gate"]
+        self.assertFalse(gate["generic_attack_prompt_may_define_bjj_motion"])
+        self.assertTrue(gate["bjj_transition_id_required_for_bjj_animation"])
+        self.assertTrue(gate["paired_bjj_spec_must_define_attacker_defender_sync"])
+
+    def test_raw_outputs_never_ship_directly(self):
+        generation = self.adapter["generation_policy"]
+        promotion = self.adapter["promotion_gate"]
+        self.assertEqual(generation["raw_provider_output_status"], "CANDIDATE")
+        self.assertFalse(generation["raw_provider_output_may_enter_runtime_paths"])
+        self.assertFalse(promotion["default_shipping"])
+        self.assertTrue(promotion["requires_sprite_forge_v2_pass"])
+        self.assertTrue(promotion["requires_human_rights_review"])
+
+    def test_cria_normalization_contract_is_preserved(self):
+        handoff = self.adapter["normalization_handoff"]
+        self.assertEqual(handoff["frame_px"], [128, 128])
+        self.assertEqual(handoff["upright_pivot_px"], [64, 96])
+        self.assertEqual(handoff["resampling"], "nearest")
+        self.assertTrue(handoff["shared_scale_per_strip"])
+        self.assertTrue(handoff["shared_anchor_per_strip"])
+
+    def test_secret_name_is_reference_only(self):
+        auth = self.adapter["provider"]["authentication"]
+        self.assertEqual(auth["environment_variable"], "GODMODEAI_API_TOKEN")
+        self.assertTrue(auth["must_not_be_committed"])
+        self.assertTrue(auth["must_not_be_written_to_sidecars"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/art/validate_godmode_sprite_adapter_v1.py
+++ b/tools/art/validate_godmode_sprite_adapter_v1.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Fail-closed validator for the optional God Mode AI Sprite Forge adapter."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+ADAPTER = ROOT / "data/visual/godmode_sprite_adapter_v1.json"
+REGISTRY = ROOT / "data/production/external_tool_registry_v1.json"
+
+REQUIRED_TOOLS = {
+    "list_actions",
+    "list_models",
+    "upload_image",
+    "generate_sprite",
+    "get_sprite_result",
+    "remove_background",
+    "get_bg_removal_result",
+    "upscale_animation",
+    "get_upscale_result",
+}
+
+REQUIRED_PROVENANCE = {
+    "asset_id",
+    "source_requirement_id",
+    "provider_id",
+    "provider_interface",
+    "provider_action",
+    "provider_model_or_tool",
+    "provider_revision_or_observation_date",
+    "identity_master_id",
+    "source_references",
+    "input_rights_status",
+    "terms_snapshot",
+    "raw_output_hash",
+    "normalization_evidence",
+    "qa_evidence",
+    "human_editor",
+    "human_approval",
+    "rights_status",
+    "shipping",
+}
+
+
+def load(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"{path.name} root must be object")
+    return value
+
+
+def main() -> int:
+    errors: list[str] = []
+    try:
+        adapter = load(ADAPTER)
+        registry = load(REGISTRY)
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        print(json.dumps({"ok": False, "errors": [str(exc)]}, indent=2))
+        return 1
+
+    if adapter.get("status") != "CANDIDATE_AUTHORING_ADAPTER":
+        errors.append("adapter status must remain CANDIDATE_AUTHORING_ADAPTER")
+    for field in ("shipping", "runtime_dependency", "canon_authority", "combat_authority"):
+        if adapter.get(field) is not False:
+            errors.append(f"{field} must remain false")
+
+    provider = adapter.get("provider", {})
+    if provider.get("id") != "godmodeai_sprite_service":
+        errors.append("provider.id must be godmodeai_sprite_service")
+    auth = provider.get("authentication", {})
+    if auth.get("environment_variable") != "GODMODEAI_API_TOKEN":
+        errors.append("auth must use GODMODEAI_API_TOKEN")
+    if auth.get("must_not_be_committed") is not True or auth.get("must_not_be_written_to_sidecars") is not True:
+        errors.append("token secrecy gates must remain true")
+    interfaces = provider.get("interfaces", {})
+    if interfaces.get("mcp_endpoint") != "https://www.godmodeai.co/api/mcp":
+        errors.append("unexpected God Mode MCP endpoint")
+
+    tools = set(adapter.get("supported_authoring_tools", []))
+    missing_tools = sorted(REQUIRED_TOOLS - tools)
+    if missing_tools:
+        errors.append(f"missing provider tools: {missing_tools}")
+
+    input_gate = adapter.get("input_gate", {})
+    if input_gate.get("approved_identity_master_required_for_character_animation") is not True:
+        errors.append("identity master must be required")
+    if input_gate.get("input_rights_must_be_known") is not True:
+        errors.append("input rights must be known")
+    if input_gate.get("generic_attack_prompt_may_define_bjj_motion") is not False:
+        errors.append("generic attack prompts must never define BJJ motion")
+    if input_gate.get("bjj_transition_id_required_for_bjj_animation") is not True:
+        errors.append("BJJ animation must require transition id")
+
+    generation = adapter.get("generation_policy", {})
+    for key in (
+        "raw_provider_output_may_enter_runtime_paths",
+        "provider_may_choose_shipping",
+        "provider_may_define_canon",
+        "provider_may_define_bjj_legality_or_scoring",
+        "remote_service_required_for_gameplay",
+    ):
+        if generation.get(key) is not False:
+            errors.append(f"generation_policy.{key} must remain false")
+    if generation.get("raw_provider_output_status") != "CANDIDATE":
+        errors.append("raw provider output must remain CANDIDATE")
+    if generation.get("whole_action_strip_preferred_over_independent_frame_generation") is not True:
+        errors.append("whole-strip generation preference must remain enabled")
+
+    normalization = adapter.get("normalization_handoff", {})
+    if normalization.get("frame_px") != [128, 128]:
+        errors.append("normalized frame must remain 128x128")
+    if normalization.get("upright_pivot_px") != [64, 96]:
+        errors.append("upright pivot must remain [64, 96]")
+    if normalization.get("resampling") != "nearest":
+        errors.append("resampling must remain nearest")
+    for key in (
+        "integer_scale_only",
+        "binary_alpha_after_normalization",
+        "shared_scale_per_strip",
+        "shared_anchor_per_strip",
+        "identity_comparison_required",
+        "preview_harness_required",
+        "godot_runtime_evidence_required_before_promotion",
+    ):
+        if normalization.get(key) is not True:
+            errors.append(f"normalization_handoff.{key} must remain true")
+
+    rights = adapter.get("rights_policy", {})
+    if rights.get("provider_terms_guarantee_output_uniqueness") is not False:
+        errors.append("provider uniqueness must not be assumed")
+    if rights.get("provider_terms_guarantee_non_infringement") is not False:
+        errors.append("provider non-infringement must not be assumed")
+    if rights.get("cria_rights_review_still_required") is not True:
+        errors.append("CRIA rights review must remain required")
+    if rights.get("public_share_opt_in_must_remain_false_for_private_cria_assets") is not True:
+        errors.append("private CRIA assets must not be public-shared by default")
+
+    provenance = set(adapter.get("required_provenance_fields", []))
+    missing_provenance = sorted(REQUIRED_PROVENANCE - provenance)
+    if missing_provenance:
+        errors.append(f"missing provenance fields: {missing_provenance}")
+
+    promotion = adapter.get("promotion_gate", {})
+    if promotion.get("default_shipping") is not False:
+        errors.append("default shipping must remain false")
+    for key in (
+        "requires_sprite_forge_v2_pass",
+        "requires_human_visual_review",
+        "requires_human_rights_review",
+        "requires_biomechanical_review_for_bjj",
+        "requires_godot_import_and_runtime_visual_evidence",
+        "secret_presence_is_hard_fail",
+    ):
+        if promotion.get(key) is not True:
+            errors.append(f"promotion_gate.{key} must remain true")
+
+    sources = {row.get("id"): row for row in registry.get("sources", []) if isinstance(row, dict)}
+    service = sources.get("godmodeai_sprite_service")
+    skill = sources.get("godmodeai_sprites_skill")
+    if not service:
+        errors.append("external tool registry missing godmodeai_sprite_service")
+    elif service.get("direct_code_reuse") is not False or service.get("direct_asset_reuse") is not False:
+        errors.append("God Mode service must not grant direct code/asset reuse")
+    if not skill:
+        errors.append("external tool registry missing godmodeai_sprites_skill")
+    elif skill.get("revision") != provider.get("official_skill_revision"):
+        errors.append("official skill revision drift between adapter and registry")
+
+    result = {"ok": not errors, "errors": errors}
+    print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0 if not errors else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Objetivo
Incorporar **God Mode AI** como ferramenta externa candidata do CRIA Sprite Forge, sem criar dependência de runtime e sem promover automaticamente nenhum output para shipping.

## O que este PR faz
- registra o serviço God Mode AI no `external_tool_registry_v1.json` como **candidate generator**;
- registra o Agent Skill oficial MIT (`lyogavin/godmodeai-sprites-skill`) pinado no commit `98199ec3432d670793b6464b3e77c513db902992`;
- adiciona `data/visual/godmode_sprite_adapter_v1.json` como contrato fail-closed;
- exige identity master, provenance e direitos de entrada conhecidos;
- exige `transition_id` e sincronização atacante/defensor para BJJ;
- preserva o contrato CRIA de 128×128, pivot `[64,96]`, nearest-neighbor, escala/anchor compartilhados por strip;
- mantém output bruto como `CANDIDATE`, `shipping=false`;
- impede o provider de definir cânone, legalidade/pontuação de BJJ ou shipping;
- mantém token apenas em `GODMODEAI_API_TOKEN`, proibido em Git e sidecars;
- adiciona validator, unit tests e workflow dedicado.

## Direitos e segurança
Os termos do fornecedor observados em 2026-09-12 permitem uso comercial do Generated Output e atribuem ao usuário os direitos que o fornecedor detiver sobre esse output, mas não garantem unicidade nem ausência de infração. Por isso, **CRIA rights review continua obrigatório** e compartilhar publicamente assets privados permanece desativado por política.

## Integração real
Este PR integra apenas o **adapter de authoring e seus gates**. Ele não chama a API, não gera sprite final, não adiciona token e não coloca binário gerado em runtime.

O próximo passo, após CI verde, é produzir um lote candidato controlado a partir de um identity master aprovado de Ruan/Davi, normalizar no Sprite Forge e inspecionar no preview/Godot antes de qualquer promoção.

## Rollback
Remover o adapter, registry entries e workflow. Nenhum runtime depende deles.

## Validação esperada
- `python tools/ci/validate_external_tool_registry_v1.py`
- `python tools/art/validate_godmode_sprite_adapter_v1.py`
- `python -m unittest discover -s tests -p 'test_godmode_sprite_adapter_v1.py'`
- checks existentes relevantes do `npm run quality`

**Status:** draft/candidate-only. Nenhum claim de arte final ou shipping.