### PR TITLE
build(tooling): isolate Godot AI MCP and qualify Godot 4.7

### DIFF
--- a/.github/workflows/godot-ai-mcp-eval.yml
+++ b/.github/workflows/godot-ai-mcp-eval.yml
@@ -1,0 +1,35 @@
+name: Godot AI MCP Evaluation
+
+on:
+  pull_request:
+    paths:
+      - 'data/production/godot_ai_mcp_eval_v1.json'
+      - 'tools/experiments/validate_godot_ai_mcp_eval_v1.py'
+      - 'tools/experiments/install_godot_ai_v4.py'
+      - 'tests/test_godot_ai_mcp_eval_v1.py'
+      - '.gitignore'
+      - '.github/workflows/godot-ai-mcp-eval.yml'
+  push:
+    branches:
+      - build/godot-ai-mcp-eval
+
+jobs:
+  validate-experiment-contract:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Validate experiment contract
+        run: python tools/experiments/validate_godot_ai_mcp_eval_v1.py
+
+      - name: Run experiment invariants
+        run: python -m unittest discover -s tests -p 'test_godot_ai_mcp_eval_v1.py'
+
+      - name: Verify installer is syntactically valid
+        run: python -m py_compile tools/experiments/install_godot_ai_v4.py

--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,8 @@ builds/android/*.idsig
 builds/android/*.sha256.txt
 reports/build/
 reports/runtime_audit/
+reports/godot_ai_eval/local/
+addons/godot_ai/
+addons/.godot_ai_update/
 *.translation
 .android/

--- a/data/production/godot_ai_mcp_eval_v1.json
+++ b/data/production/godot_ai_mcp_eval_v1.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "cria.godot_ai_mcp_eval.v1",
+  "version": "1.0.0",
+  "status": "EXPERIMENT_ONLY",
+  "shipping": false,
+  "runtime_dependency": false,
+  "main_engine_version_change_authorized": false,
+  "purpose": "Evaluate Godot AI MCP against CRIA DO TATAME on an isolated branch and a Godot 4.7 toolchain. No result may change the production engine version until every migration gate has explicit evidence.",
+  "baseline": {
+    "repository_branch": "main",
+    "engine_production_version": "4.3+",
+    "engine_minimum_audited": "4.2.2",
+    "mandatory_flow": ["main_menu", "terreiro", "combat", "result", "save", "career_week_advance", "return_to_terreiro"]
+  },
+  "candidate": {
+    "branch": "build/godot-ai-mcp-eval",
+    "engine_version": "4.7",
+    "godot_ai_version": "4.1.0",
+    "godot_ai_source": "hi-godot/godot-ai",
+    "godot_ai_release_tag": "v4.1.0",
+    "godot_ai_release_commit": "7968ada03044473372a8ab4beadd975c60b9d94a",
+    "godot_ai_archive": "godot-ai-v4-plugin.zip",
+    "godot_ai_archive_sha256": "535d8a7541871af8d991b07fe5031550dd6121a31b844400476b334a70612831",
+    "godot_ai_license": "MIT",
+    "godot_ai_v4_minimum_engine": "4.7",
+    "godot_ai_v3_2_5_minimum_engine": "4.5",
+    "plugin_is_local_experiment_dependency": true,
+    "plugin_may_be_required_by_shipping_runtime": false
+  },
+  "isolation": {
+    "do_not_modify_main_during_experiment": true,
+    "do_not_commit_provider_credentials": true,
+    "do_not_commit_local_mcp_client_config": true,
+    "do_not_make_new_gameplay_manager": true,
+    "do_not_change_combat_authority": true,
+    "do_not_change_save_schema_only_for_plugin": true,
+    "plugin_path": "addons/godot_ai",
+    "update_staging_path": "addons/.godot_ai_update",
+    "telemetry_opt_out_recommended_for_private_project_work": true,
+    "telemetry_opt_out_environment_variable": "GODOT_AI_DISABLE_TELEMETRY"
+  },
+  "evaluation_protocol": {
+    "baseline_first": true,
+    "candidate_uses_same_repository_commit_content_except_experiment_files": true,
+    "record_engine_version": true,
+    "record_godot_ai_version": true,
+    "record_commands_and_exit_codes": true,
+    "record_failure_logs": true,
+    "record_android_device_model_and_os_for_physical_gate": true,
+    "performance_comparison_required": true,
+    "rollback_is_branch_deletion_or_plugin_removal": true
+  },
+  "gates": [
+    {"id": "G47-01", "name": "npm_run_quality", "class": "automated", "status": "PENDING"},
+    {"id": "G47-02", "name": "godot_4_7_headless_import_and_parser", "class": "automated", "status": "PENDING"},
+    {"id": "G47-03", "name": "mandatory_flow_runtime_smoke", "class": "automated", "status": "PENDING"},
+    {"id": "G47-04", "name": "forty_mission_data_and_reference_regression", "class": "automated", "status": "PENDING"},
+    {"id": "G47-05", "name": "world_map_routes_nodes_and_travel_regression", "class": "automated", "status": "PENDING"},
+    {"id": "G47-06", "name": "save_load_roundtrip_and_migration_regression", "class": "automated", "status": "PENDING"},
+    {"id": "G47-07", "name": "ruan_davi_combat_determinism_regression", "class": "automated", "status": "PENDING"},
+    {"id": "G47-08", "name": "godot_ai_read_only_scene_and_resource_inspection", "class": "editor_mcp", "status": "PENDING"},
+    {"id": "G47-09", "name": "godot_ai_reversible_test_scene_edit", "class": "editor_mcp", "status": "PENDING"},
+    {"id": "G47-10", "name": "android_arm64_export", "class": "automated_or_local", "status": "PENDING"},
+    {"id": "G47-11", "name": "android_physical_install_touch_full_flow_save_restart", "class": "human_device", "status": "PENDING"},
+    {"id": "G47-12", "name": "windows_export_smoke", "class": "automated_or_local", "status": "PENDING"},
+    {"id": "G47-13", "name": "performance_fps_memory_temperature_battery_comparison", "class": "human_device", "status": "PENDING"},
+    {"id": "G47-14", "name": "plugin_removal_restores_clean_project", "class": "rollback", "status": "PENDING"}
+  ],
+  "decision_rule": {
+    "allowed_statuses": ["PENDING", "PASS", "FAIL", "BLOCKED"],
+    "adopt_engine_4_7_only_if_all_gates_pass": true,
+    "any_fail_blocks_main_migration": true,
+    "blocked_human_device_gate_blocks_release_claim": true,
+    "godot_ai_success_does_not_require_godot_ai_in_shipping": true,
+    "preferred_outcome_if_tooling_is_useful": "keep Godot AI as optional developer tooling, not runtime dependency"
+  },
+  "evidence": {
+    "report_path": "reports/godot_ai_eval/godot_4_7_evidence.json",
+    "human_device_report_path": "reports/godot_ai_eval/android_physical_evidence.md",
+    "current_state": "NOT_EXECUTED_IN_THIS_ENVIRONMENT"
+  }
+}

--- a/tests/test_godot_ai_mcp_eval_v1.py
+++ b/tests/test_godot_ai_mcp_eval_v1.py
@@ -1,0 +1,62 @@
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTRACT = ROOT / "data/production/godot_ai_mcp_eval_v1.json"
+VALIDATOR = ROOT / "tools/experiments/validate_godot_ai_mcp_eval_v1.py"
+
+
+class GodotAiMcpEvalV1Tests(unittest.TestCase):
+    def setUp(self):
+        self.contract = json.loads(CONTRACT.read_text(encoding="utf-8"))
+
+    def test_validator_passes(self):
+        result = subprocess.run(
+            [sys.executable, str(VALIDATOR)],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertTrue(json.loads(result.stdout)["ok"])
+
+    def test_experiment_cannot_authorize_main_migration(self):
+        self.assertEqual(self.contract["status"], "EXPERIMENT_ONLY")
+        self.assertFalse(self.contract["main_engine_version_change_authorized"])
+        self.assertFalse(self.contract["runtime_dependency"])
+        self.assertFalse(self.contract["shipping"])
+
+    def test_candidate_is_pinned_to_godot_4_7_and_godot_ai_4_1(self):
+        candidate = self.contract["candidate"]
+        self.assertEqual(candidate["engine_version"], "4.7")
+        self.assertEqual(candidate["godot_ai_version"], "4.1.0")
+        self.assertEqual(candidate["godot_ai_release_tag"], "v4.1.0")
+        self.assertEqual(candidate["godot_ai_archive_sha256"], "535d8a7541871af8d991b07fe5031550dd6121a31b844400476b334a70612831")
+
+    def test_current_v3_does_not_claim_4_3_compatibility(self):
+        candidate = self.contract["candidate"]
+        self.assertEqual(candidate["godot_ai_v3_2_5_minimum_engine"], "4.5")
+        self.assertNotEqual(candidate["godot_ai_v3_2_5_minimum_engine"], "4.3")
+
+    def test_critical_regressions_are_explicit_gates(self):
+        names = {gate["name"] for gate in self.contract["gates"]}
+        for name in (
+            "forty_mission_data_and_reference_regression",
+            "world_map_routes_nodes_and_travel_regression",
+            "save_load_roundtrip_and_migration_regression",
+            "ruan_davi_combat_determinism_regression",
+            "android_physical_install_touch_full_flow_save_restart",
+            "plugin_removal_restores_clean_project",
+        ):
+            self.assertIn(name, names)
+
+    def test_every_gate_starts_pending(self):
+        self.assertTrue(all(gate["status"] == "PENDING" for gate in self.contract["gates"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/experiments/install_godot_ai_v4.py
+++ b/tools/experiments/install_godot_ai_v4.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Install the pinned Godot AI v4 plugin for the isolated CRIA experiment.
+
+This is developer tooling only. It refuses to install unless the selected Godot
+binary reports 4.7+ and the downloaded official release archive matches the
+pinned SHA-256 from the reviewed release.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import re
+import shutil
+import subprocess
+import tempfile
+import urllib.request
+import zipfile
+from pathlib import Path, PurePosixPath
+
+VERSION = "4.1.0"
+TAG = "v4.1.0"
+ARCHIVE_NAME = "godot-ai-v4-plugin.zip"
+ARCHIVE_URL = f"https://github.com/hi-godot/godot-ai/releases/download/{TAG}/{ARCHIVE_NAME}"
+ARCHIVE_SHA256 = "535d8a7541871af8d991b07fe5031550dd6121a31b844400476b334a70612831"
+MIN_GODOT = (4, 7)
+
+
+def parse_version(text: str) -> tuple[int, int]:
+    match = re.search(r"(\d+)\.(\d+)", text)
+    if not match:
+        raise RuntimeError(f"could not parse Godot version from: {text!r}")
+    return int(match.group(1)), int(match.group(2))
+
+
+def godot_version(godot_bin: str) -> tuple[int, int, str]:
+    result = subprocess.run(
+        [godot_bin, "--version"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    output = (result.stdout or result.stderr).strip()
+    if result.returncode != 0:
+        raise RuntimeError(f"{godot_bin} --version failed ({result.returncode}): {output}")
+    major_minor = parse_version(output)
+    return major_minor[0], major_minor[1], output
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def safe_member(member: str) -> bool:
+    path = PurePosixPath(member)
+    return not path.is_absolute() and ".." not in path.parts
+
+
+def install_archive(archive: Path, project_root: Path, replace: bool) -> Path:
+    target = project_root / "addons" / "godot_ai"
+    if target.exists():
+        if not replace:
+            raise RuntimeError(f"{target} already exists; pass --replace to overwrite the local experiment plugin")
+        shutil.rmtree(target)
+
+    with zipfile.ZipFile(archive) as zf:
+        members = [name for name in zf.namelist() if name and not name.endswith("/")]
+        if any(not safe_member(name) for name in members):
+            raise RuntimeError("archive contains unsafe path traversal entry")
+
+        plugin_candidates = [name for name in members if name.endswith("addons/godot_ai/plugin.cfg")]
+        if len(plugin_candidates) != 1:
+            raise RuntimeError(f"expected exactly one addons/godot_ai/plugin.cfg, found {plugin_candidates}")
+
+        plugin_cfg = PurePosixPath(plugin_candidates[0])
+        prefix_parts = plugin_cfg.parts[:-3]
+        prefix = "/".join(prefix_parts)
+        source_prefix = f"{prefix}/addons/godot_ai/" if prefix else "addons/godot_ai/"
+
+        target.mkdir(parents=True, exist_ok=True)
+        extracted = 0
+        for name in members:
+            if not name.startswith(source_prefix):
+                continue
+            relative = name[len(source_prefix):]
+            if not relative:
+                continue
+            out = target / PurePosixPath(relative)
+            out.parent.mkdir(parents=True, exist_ok=True)
+            with zf.open(name) as src, out.open("wb") as dst:
+                shutil.copyfileobj(src, dst)
+            extracted += 1
+
+    if extracted == 0 or not (target / "plugin.cfg").exists():
+        raise RuntimeError("plugin extraction produced no valid Godot AI tree")
+    return target
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--godot-bin", default="godot")
+    parser.add_argument("--project-root", default=str(Path(__file__).resolve().parents[2]))
+    parser.add_argument("--replace", action="store_true")
+    parser.add_argument("--archive", help="Use an already downloaded official archive instead of network download")
+    parser.add_argument("--check-only", action="store_true", help="Validate Godot version and pin metadata without downloading")
+    args = parser.parse_args()
+
+    major, minor, raw = godot_version(args.godot_bin)
+    if (major, minor) < MIN_GODOT:
+        raise SystemExit(f"BLOCKED: Godot AI v4 requires Godot {MIN_GODOT[0]}.{MIN_GODOT[1]}+; found {raw}")
+
+    print(f"Godot OK: {raw}")
+    print(f"Godot AI pin: {TAG} ({ARCHIVE_SHA256})")
+    if args.check_only:
+        return 0
+
+    project_root = Path(args.project_root).resolve()
+    if not (project_root / "project.godot").exists():
+        raise SystemExit(f"BLOCKED: no project.godot under {project_root}")
+
+    if args.archive:
+        archive = Path(args.archive).resolve()
+        if not archive.exists():
+            raise SystemExit(f"BLOCKED: archive not found: {archive}")
+        actual = sha256(archive)
+        if actual != ARCHIVE_SHA256:
+            raise SystemExit(f"BLOCKED: archive SHA-256 mismatch: {actual}")
+        installed = install_archive(archive, project_root, args.replace)
+    else:
+        with tempfile.TemporaryDirectory(prefix="cria-godot-ai-") as temp_dir:
+            archive = Path(temp_dir) / ARCHIVE_NAME
+            print(f"Downloading pinned official release: {ARCHIVE_URL}")
+            urllib.request.urlretrieve(ARCHIVE_URL, archive)
+            actual = sha256(archive)
+            if actual != ARCHIVE_SHA256:
+                raise SystemExit(f"BLOCKED: downloaded archive SHA-256 mismatch: {actual}")
+            installed = install_archive(archive, project_root, args.replace)
+
+    print(f"Installed developer-only plugin at {installed}")
+    print("Next: open this branch with Godot 4.7+, enable Godot AI, keep MCP configuration local, and execute G47-01..G47-14.")
+    print("Recommended privacy setting for local private project work: GODOT_AI_DISABLE_TELEMETRY=true")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/experiments/validate_godot_ai_mcp_eval_v1.py
+++ b/tools/experiments/validate_godot_ai_mcp_eval_v1.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Validate the isolated Godot AI / Godot 4.7 evaluation contract."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+CONTRACT = ROOT / "data/production/godot_ai_mcp_eval_v1.json"
+
+REQUIRED_GATES = {
+    "npm_run_quality",
+    "godot_4_7_headless_import_and_parser",
+    "mandatory_flow_runtime_smoke",
+    "forty_mission_data_and_reference_regression",
+    "world_map_routes_nodes_and_travel_regression",
+    "save_load_roundtrip_and_migration_regression",
+    "ruan_davi_combat_determinism_regression",
+    "godot_ai_read_only_scene_and_resource_inspection",
+    "godot_ai_reversible_test_scene_edit",
+    "android_arm64_export",
+    "android_physical_install_touch_full_flow_save_restart",
+    "windows_export_smoke",
+    "performance_fps_memory_temperature_battery_comparison",
+    "plugin_removal_restores_clean_project",
+}
+
+
+def load() -> dict[str, Any]:
+    value = json.loads(CONTRACT.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError("Godot AI eval contract root must be object")
+    return value
+
+
+def main() -> int:
+    errors: list[str] = []
+    try:
+        contract = load()
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        print(json.dumps({"ok": False, "errors": [str(exc)]}, indent=2))
+        return 1
+
+    if contract.get("status") != "EXPERIMENT_ONLY":
+        errors.append("status must remain EXPERIMENT_ONLY")
+    for key in ("shipping", "runtime_dependency", "main_engine_version_change_authorized"):
+        if contract.get(key) is not False:
+            errors.append(f"{key} must remain false before migration approval")
+
+    baseline = contract.get("baseline", {})
+    if baseline.get("engine_production_version") != "4.3+":
+        errors.append("baseline engine production version must remain 4.3+")
+    if baseline.get("engine_minimum_audited") != "4.2.2":
+        errors.append("minimum audited baseline must remain 4.2.2")
+
+    candidate = contract.get("candidate", {})
+    if candidate.get("branch") != "build/godot-ai-mcp-eval":
+        errors.append("candidate branch drift")
+    if candidate.get("engine_version") != "4.7":
+        errors.append("Godot AI v4 experiment must use Godot 4.7")
+    if candidate.get("godot_ai_version") != "4.1.0":
+        errors.append("Godot AI experiment must remain pinned to reviewed v4.1.0")
+    if candidate.get("godot_ai_release_tag") != "v4.1.0":
+        errors.append("release tag must remain v4.1.0")
+    if candidate.get("godot_ai_release_commit") != "7968ada03044473372a8ab4beadd975c60b9d94a":
+        errors.append("release commit drift")
+    if candidate.get("godot_ai_archive_sha256") != "535d8a7541871af8d991b07fe5031550dd6121a31b844400476b334a70612831":
+        errors.append("reviewed archive hash drift")
+    if candidate.get("godot_ai_v4_minimum_engine") != "4.7":
+        errors.append("v4 minimum engine must remain 4.7")
+    if candidate.get("godot_ai_v3_2_5_minimum_engine") != "4.5":
+        errors.append("v3.2.5 compatibility fact must remain 4.5")
+    if candidate.get("plugin_may_be_required_by_shipping_runtime") is not False:
+        errors.append("Godot AI may not become a shipping runtime dependency")
+
+    isolation = contract.get("isolation", {})
+    for key in (
+        "do_not_modify_main_during_experiment",
+        "do_not_commit_provider_credentials",
+        "do_not_commit_local_mcp_client_config",
+        "do_not_make_new_gameplay_manager",
+        "do_not_change_combat_authority",
+        "do_not_change_save_schema_only_for_plugin",
+    ):
+        if isolation.get(key) is not True:
+            errors.append(f"isolation.{key} must remain true")
+
+    gates = contract.get("gates")
+    if not isinstance(gates, list) or not gates:
+        errors.append("evaluation gates missing")
+        gates = []
+    names: set[str] = set()
+    ids: set[str] = set()
+    allowed_statuses = set(contract.get("decision_rule", {}).get("allowed_statuses", []))
+    for row in gates:
+        if not isinstance(row, dict):
+            errors.append("gate entry must be object")
+            continue
+        gid = row.get("id")
+        name = row.get("name")
+        status = row.get("status")
+        if not isinstance(gid, str) or not gid:
+            errors.append("gate missing id")
+        elif gid in ids:
+            errors.append(f"duplicate gate id: {gid}")
+        else:
+            ids.add(gid)
+        if not isinstance(name, str) or not name:
+            errors.append(f"{gid}: gate missing name")
+        else:
+            names.add(name)
+        if status not in allowed_statuses:
+            errors.append(f"{gid}: invalid gate status {status}")
+
+    missing = sorted(REQUIRED_GATES - names)
+    if missing:
+        errors.append(f"required migration gates missing: {missing}")
+
+    decision = contract.get("decision_rule", {})
+    if decision.get("adopt_engine_4_7_only_if_all_gates_pass") is not True:
+        errors.append("4.7 adoption must require every gate PASS")
+    if decision.get("any_fail_blocks_main_migration") is not True:
+        errors.append("any FAIL must block main migration")
+    if decision.get("blocked_human_device_gate_blocks_release_claim") is not True:
+        errors.append("blocked device gate must block release claim")
+    if decision.get("godot_ai_success_does_not_require_godot_ai_in_shipping") is not True:
+        errors.append("tooling success must stay decoupled from shipping dependency")
+
+    evidence = contract.get("evidence", {})
+    if evidence.get("current_state") not in {"NOT_EXECUTED_IN_THIS_ENVIRONMENT", "PARTIAL", "COMPLETE"}:
+        errors.append("invalid evidence.current_state")
+
+    result = {"ok": not errors, "gates": len(gates), "errors": errors}
+    print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0 if not errors else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Objetivo
Avaliar **Godot AI MCP** sem alterar a versão de produção do CRIA DO TATAME. O experimento roda somente na branch `build/godot-ai-mcp-eval`; a `main` continua em Godot `4.3+` com mínimo auditado `4.2.2`.

## Fato de compatibilidade que orienta este PR
- Godot AI **v4** é breaking e exige **Godot 4.7+**.
- A linha atual **v3.2.5** já exige **Godot 4.5+**; portanto ela também não é uma solução suportada para a base 4.3.
- O experimento é pinado em Godot AI **v4.1.0**, release commit `7968ada03044473372a8ab4beadd975c60b9d94a`, archive `godot-ai-v4-plugin.zip`, SHA-256 `535d8a7541871af8d991b07fe5031550dd6121a31b844400476b334a70612831`.

## O que este PR adiciona
- contrato machine-readable `godot_ai_mcp_eval_v1.json`;
- **14 gates G47-01..G47-14**, todos inicialmente `PENDING`;
- validator e testes fail-closed;
- instalador experimental pinado que recusa Godot <4.7, valida SHA-256 do release oficial e protege contra path traversal;
- exclusão de `addons/godot_ai/`, staging do updater e evidências locais no `.gitignore`;
- CI apenas para validar contrato/invariantes e sintaxe do instalador.

## Gates obrigatórios antes de qualquer proposta 4.3 → 4.7
1. `npm run quality`;
2. import/parser headless no Godot 4.7;
3. smoke do fluxo obrigatório;
4. regressão das **40 missões**;
5. mapa, rotas, nós e viagem;
6. save/load + migração;
7. determinismo do combate Ruan × Davi;
8. leitura MCP de cena/resources;
9. edição MCP reversível de cena de teste;
10. Android ARM64 export;
11. Android físico: instalar, touch, fluxo completo, save e restart;
12. Windows export smoke;
13. comparação FPS/memória/temperatura/bateria;
14. remoção do plugin restaurando projeto limpo.

## Regra de decisão
`main_engine_version_change_authorized=false` permanece até **todos os gates = PASS**. Um único `FAIL` bloqueia a migração. Gate de aparelho físico `BLOCKED` também impede qualquer claim de release.

Mesmo se o experimento for excelente, o resultado preferido é **Godot AI como tooling opcional de desenvolvimento**, nunca dependência do runtime/shipping.

## Segurança / privacidade
- nenhuma credencial em Git;
- MCP local/configuração local não versionada;
- `GODOT_AI_DISABLE_TELEMETRY=true` recomendado para trabalho privado;
- sem segundo manager, sem nova autoridade de combate e sem alteração de schema de save para satisfazer o plugin.

## Estado atual
O contrato e o tooling estão implementados. Os gates que exigem Godot 4.7/editor real, export e aparelho físico permanecem `PENDING`; este PR não declara que esses testes já foram executados.

**Status:** draft/experimento isolado; não autoriza merge de migração do engine.