### PR TITLE
feat(ai): bounded Nex-N2.5 dialogue tools for Living NPCs

### DIFF
--- a/.github/workflows/nex-local-dialogue.yml
+++ b/.github/workflows/nex-local-dialogue.yml
@@ -1,0 +1,41 @@
+name: Nex Local Dialogue Gate
+
+on:
+  pull_request:
+    paths:
+      - "data/ai/local_ai_config_v01.json"
+      - "data/ai/nex_n25_dialogue_profile_v1.json"
+      - "src/autoloads/LocalAIManager.gd"
+      - "src/ai/LocalAIReadOnlyTools.gd"
+      - "tools/ai/validate_local_ai_nex_v1.py"
+      - "tests/test_local_ai_nex_v1.py"
+      - "docs/LOCAL_AI_ANDROID.md"
+      - ".github/workflows/nex-local-dialogue.yml"
+  push:
+    branches:
+      - "feat/living-npc-nex-dialogue-v1"
+    paths:
+      - "data/ai/local_ai_config_v01.json"
+      - "data/ai/nex_n25_dialogue_profile_v1.json"
+      - "src/autoloads/LocalAIManager.gd"
+      - "src/ai/LocalAIReadOnlyTools.gd"
+      - "tools/ai/validate_local_ai_nex_v1.py"
+      - "tests/test_local_ai_nex_v1.py"
+      - "docs/LOCAL_AI_ANDROID.md"
+      - ".github/workflows/nex-local-dialogue.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  contract:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Validate Nex dialogue contract
+        run: python tools/ai/validate_local_ai_nex_v1.py
+      - name: Test Nex dialogue contract
+        run: python -m unittest tests/test_local_ai_nex_v1.py

--- a/data/ai/local_ai_config_v01.json
+++ b/data/ai/local_ai_config_v01.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.0",
+  "version": "0.2.0",
   "language": "pt-BR",
   "runtime_policy": {
     "enabled_by_default": false,
@@ -25,6 +25,21 @@
       "max_tokens": 96,
       "temperature": 0.55,
       "top_p": 0.85
+    },
+    "nex_n25_ollama": {
+      "type": "ollama_http",
+      "description": "Nex-N2.5-mini GGUF Q4_K_M para dialogo agentic experimental em desktop/LAN. Desligado por padrao e nunca usado no combate.",
+      "desktop_url": "http://127.0.0.1:11434",
+      "android_emulator_url": "http://10.0.2.2:11434",
+      "model": "hf.co/abenzerps/Nex-N2.5-mini-GGUF:Q4_K_M",
+      "timeout_seconds": 30.0,
+      "max_tokens": 128,
+      "temperature": 0.35,
+      "top_p": 0.9,
+      "num_ctx": 8192,
+      "supports_tools": true,
+      "max_tool_rounds": 3,
+      "profile_path": "res://data/ai/nex_n25_dialogue_profile_v1.json"
     },
     "llama_cpp_server": {
       "type": "openai_compatible",
@@ -59,6 +74,16 @@
       "license": "Apache-2.0",
       "tier": "desktop_forte",
       "production_note": "Nao e o modelo padrao do Android por custo de memoria e bateria."
+    },
+    {
+      "hub_id": "abenzerps/Nex-N2.5-mini-GGUF",
+      "base_model": "nex-agi/Nex-N2.5-mini",
+      "role": "dialogo agentic limitado com tool calling read-only e verificacao canonica",
+      "license": "Apache-2.0",
+      "tier": "desktop_muito_forte",
+      "adoption_status": "experimental_optional_dialogue_only",
+      "profile_path": "res://data/ai/nex_n25_dialogue_profile_v1.json",
+      "production_note": "Q4_K_M externo ao APK; backend manual, fallback obrigatorio e nenhuma autoridade sobre gameplay/canon."
     }
   ],
   "prompt_rules": {
@@ -68,6 +93,12 @@
     "forbid_combat_instruction": true,
     "forbid_new_major_lore": true,
     "fallback_on_timeout": true,
-    "fallback_on_invalid_json": true
+    "fallback_on_invalid_json": true,
+    "forbidden_output_fragments": [
+      "caio ravel",
+      "ruan cria",
+      "os aleluiados",
+      "nós tem o molho"
+    ]
   }
 }

--- a/data/ai/nex_n25_dialogue_profile_v1.json
+++ b/data/ai/nex_n25_dialogue_profile_v1.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "cria_nex_n25_dialogue_profile_v1",
+  "version": "1.0.0",
+  "status": "EXPERIMENTAL_OPTIONAL_DIALOGUE",
+  "audited_at": "2026-09-12",
+  "runtime_authority": false,
+  "shipping": false,
+  "critical_gameplay_dependency": false,
+  "network_default": false,
+  "base_model": {
+    "id": "nex-agi/Nex-N2.5-mini",
+    "architecture": "qwen3_5_moe",
+    "parameters_total_m": 35107.2,
+    "license": "Apache-2.0",
+    "context_max_tokens": 262144,
+    "capabilities": [
+      "text",
+      "multimodal",
+      "tool_calling"
+    ]
+  },
+  "quantized_runtime": {
+    "id": "abenzerps/Nex-N2.5-mini-GGUF",
+    "revision": "52debb74f4e7cc54f4ac1146b20b0ebb205a8933",
+    "quantization": "Q4_K_M",
+    "model_reference": "hf.co/abenzerps/Nex-N2.5-mini-GGUF:Q4_K_M",
+    "artifact_size_display": "21.17 GB",
+    "artifact_sha256": "dd296f683c798a3e4058fb1ef8c462e6a4cc8b89cd196742a8e5a3da4057fbb3",
+    "mmproj_f16_optional": {
+      "artifact_size_display": "899 MB",
+      "artifact_sha256": "4734f7323dfc0e8dcd5c7c408991aad438021aeab761d223aec0b38a4457ca83",
+      "used_by_this_slice": false
+    },
+    "license": "Apache-2.0"
+  },
+  "integration": {
+    "backend_id": "nex_n25_ollama",
+    "transport": "Ollama /api/chat",
+    "default_num_ctx": 8192,
+    "text_only_in_this_slice": true,
+    "tool_policy": "read_only_allowlist",
+    "allowed_tools": [
+      "canon_lookup",
+      "scene_state_get",
+      "progression_summary_get"
+    ],
+    "max_tool_rounds": 3,
+    "fallback": "data/dialogues/ai_fallbacks_v01.json",
+    "state_mutation_by_model": false,
+    "combat_use": false
+  },
+  "canon_precedence": [
+    "data/production/canon_contract_v4_1.json",
+    "active canonical runtime data from DataRegistry",
+    "non-conflicting public fields from data/brand/canon_lock.json"
+  ],
+  "known_constraints": [
+    "The 262144-token model maximum is not a hardware promise; this profile starts at 8192 tokens.",
+    "The Q4_K_M model remains external to the APK and must never become a required Android download.",
+    "Tool calling quality depends on the local Ollama build/chat template and must pass the dedicated smoke before broader NPC rollout.",
+    "This slice does not implement persistent NPC fact/belief memory; that remains tracked by issue #112."
+  ],
+  "sources": [
+    "https://huggingface.co/nex-agi/Nex-N2.5-mini",
+    "https://huggingface.co/abenzerps/Nex-N2.5-mini-GGUF"
+  ]
+}

--- a/docs/LOCAL_AI_ANDROID.md
+++ b/docs/LOCAL_AI_ANDROID.md
@@ -73,6 +73,53 @@ Fluxo inválido para release:
 - Suporte explícito a português entre os idiomas do modelo.
 - Recomendado para prototipação no desktop, não como padrão de aparelho intermediário.
 
+### Nex-N2.5-mini — diálogo agentic experimental
+
+O Nex entra apenas como **backend opcional de desenvolvimento** para fala episódica. O modelo não recebe autoridade sobre `WorldState`, `ProgressionOS`, combate, save ou cânone.
+
+Perfil auditado:
+
+- base: `nex-agi/Nex-N2.5-mini`, Apache-2.0, arquitetura `qwen3_5_moe`;
+- runtime testado por contrato: `abenzerps/Nex-N2.5-mini-GGUF`, Q4_K_M;
+- revisão GGUF pinada: `52debb74f4e7cc54f4ac1146b20b0ebb205a8933`;
+- Q4_K_M registrado com SHA-256 `dd296f683c798a3e4058fb1ef8c462e6a4cc8b89cd196742a8e5a3da4057fbb3`;
+- tamanho observado do Q4_K_M: aproximadamente 21,17 GB;
+- contexto do perfil CRIA começa em **8K**, não em 262K, para manter o custo local limitado;
+- multimodal permanece fora deste slice; a integração atual é texto + tool calling read-only.
+
+Instalação/teste manual:
+
+```bash
+ollama run hf.co/abenzerps/Nex-N2.5-mini-GGUF:Q4_K_M
+```
+
+Ativação no desenvolvimento:
+
+```gdscript
+LocalAIManager.configure_backend("nex_n25_ollama")
+```
+
+No celular físico, informe o IP LAN do servidor:
+
+```gdscript
+LocalAIManager.configure_backend(
+    "nex_n25_ollama",
+    "http://192.168.1.50:11434"
+)
+```
+
+### Ferramentas permitidas ao Nex
+
+A allowlist atual é deliberadamente pequena:
+
+- `canon_lookup` — fatos públicos, com precedência para `canon_contract_v4_1.json`;
+- `scene_state_get` — apenas localização/cena e relógio público;
+- `progression_summary_get` — somente `respect` e XP social agregados.
+
+Todas são read-only. O modelo não recebe tool de escrita. Em especial, não existe tool para `record_event`, combate, save, unlock, dinheiro ou reputação.
+
+Há um conflito legado conhecido em `data/brand/canon_lock.json`: nomes antigos de facção ainda aparecem nesse arquivo. A projeção fornecida à IA **não usa esse campo bruto**; facções vêm do contrato v4.1, onde `ALE = Os Aleluiado` e `NTM = Nós Tem Um Molho`.
+
 ## Backend nativo Android futuro
 
 Uma versão realmente on-device exige uma destas rotas:
@@ -145,7 +192,9 @@ LocalAIManager.configure_backend(
 - timeout vira fallback;
 - JSON inválido vira fallback;
 - rede desligada por padrão;
-- nenhuma chave OpenAI ou Hugging Face dentro do APK.
+- nenhuma chave OpenAI ou Hugging Face dentro do APK;
+- tool calling, quando habilitado, usa allowlist read-only e limite de rodadas;
+- variações legadas conhecidas de nomes canônicos são rejeitadas antes de chegar ao jogador.
 
 ## Testes obrigatórios
 
@@ -157,6 +206,10 @@ LocalAIManager.configure_backend(
 6. Dois NPCs pedindo fala: fila sequencial sem mistura.
 7. Combate durante falha de IA generativa: zero impacto no loop.
 8. Fechar e reabrir o jogo: nenhuma dependência de servidor.
+9. Nex pede `canon_lookup`: somente a allowlist read-only é executada.
+10. Nex excede `max_tool_rounds`: fallback é acionado.
+11. Nex tenta usar tool desconhecida: `tool_not_allowed`.
+12. Resposta contém nome canônico legado bloqueado: fallback é acionado.
 
 ## Definition of Done da IA generativa
 
@@ -168,3 +221,5 @@ A feature só pode ser chamada de pronta quando:
 - o Android físico foi testado;
 - RAM, bateria, temperatura e latência estão documentadas;
 - nenhuma promessa de "IA dentro do APK" depende de um servidor escondido na rede.
+
+O slice Nex v1 é apenas **experimental e opcional** até que os gates acima e o escopo de memória social da issue #112 sejam concluídos.

--- a/src/ai/LocalAIReadOnlyTools.gd
+++ b/src/ai/LocalAIReadOnlyTools.gd
@@ -1,0 +1,252 @@
+extends RefCounted
+
+# Read-only projection layer for optional generative dialogue.
+# It intentionally exposes a small public view of canon/runtime state.
+# LLM output never writes back through this object.
+
+const CANON_CONTRACT_PATH := "res://data/production/canon_contract_v4_1.json"
+const BRAND_CANON_PATH := "res://data/brand/canon_lock.json"
+
+func definitions() -> Array:
+	return [
+		{
+			"type": "function",
+			"function": {
+				"name": "canon_lookup",
+				"description": "Consulta somente fatos publicos e canonicos do Cria do Tatame. Use antes de afirmar lore, personagens, faccoes ou geografia.",
+				"parameters": {
+					"type": "object",
+					"properties": {
+						"query": {"type": "string", "description": "Pergunta factual curta."},
+						"entity_id": {"type": "string", "description": "ID canonico opcional de personagem ou faccao."}
+					},
+					"required": ["query"]
+				}
+			}
+		},
+		{
+			"type": "function",
+			"function": {
+				"name": "scene_state_get",
+				"description": "Retorna somente estado publico da cena atual, sem flags secretas e sem capacidade de escrita.",
+				"parameters": {
+					"type": "object",
+					"properties": {}
+				}
+			}
+		},
+		{
+			"type": "function",
+			"function": {
+				"name": "progression_summary_get",
+				"description": "Retorna um resumo publico e agregado da progressao social do jogador, sem ledger detalhado.",
+				"parameters": {
+					"type": "object",
+					"properties": {}
+				}
+			}
+		}
+	]
+
+func execute(tool_name: String, arguments: Dictionary, request_context: Dictionary = {}) -> Dictionary:
+	match tool_name:
+		"canon_lookup":
+			return _canon_lookup(arguments)
+		"scene_state_get":
+			return _scene_state_get(request_context)
+		"progression_summary_get":
+			return _progression_summary_get()
+		_:
+			return {
+				"ok": false,
+				"status": "tool_not_allowed",
+				"tool": tool_name
+			}
+
+func _canon_lookup(arguments: Dictionary) -> Dictionary:
+	var query := str(arguments.get("query", "")).strip_edges().to_lower()
+	var entity_id := str(arguments.get("entity_id", "")).strip_edges()
+	if query == "" and entity_id == "":
+		return {"ok": false, "status": "invalid_query"}
+
+	var canon_contract := _load_json(CANON_CONTRACT_PATH)
+	var brand_canon := _load_json(BRAND_CANON_PATH)
+	var matches: Array = []
+
+	if entity_id != "":
+		var explicit := _lookup_entity(entity_id, canon_contract)
+		if not explicit.is_empty():
+			matches.append(explicit)
+
+	if matches.is_empty():
+		for faction_value in canon_contract.get("active_factions_future_domain", []):
+			if not (faction_value is Dictionary):
+				continue
+			var faction: Dictionary = faction_value
+			var searchable := "%s %s" % [
+				str(faction.get("id", "")),
+				str(faction.get("display_name", ""))
+			]
+			if _query_matches(query, searchable):
+				matches.append({
+					"type": "faction",
+					"id": str(faction.get("id", "")),
+					"display_name": str(faction.get("display_name", "")),
+					"legacy_ids": faction.get("legacy_ids", []).duplicate()
+				})
+
+	if matches.is_empty():
+		var data_registry := _root_node("DataRegistry")
+		if data_registry != null:
+			var characters_value = data_registry.get("characters")
+			if characters_value is Dictionary:
+				for character_id_value in characters_value.keys():
+					var character_id := str(character_id_value)
+					var character: Dictionary = characters_value[character_id]
+					if character.get("canon", false) != true:
+						continue
+					var public_character := _public_character(character_id, character)
+					var searchable := JSON.stringify(public_character).to_lower()
+					if _query_matches(query, searchable):
+						matches.append(public_character)
+						if matches.size() >= 4:
+							break
+
+	var public_world := {
+		"core_phrase": str(brand_canon.get("tese", "")),
+		"region": str(brand_canon.get("setting", {}).get("regiao", "")),
+		"hub": str(brand_canon.get("setting", {}).get("hub", "")),
+		"symbol": str(brand_canon.get("simbolo", ""))
+	}
+	if matches.is_empty() and _query_matches(
+		query,
+		"%s %s %s %s itubera baixo sul bahia mundo local regiao simbolo frase" % [
+			public_world["core_phrase"],
+			public_world["region"],
+			public_world["hub"],
+			public_world["symbol"]
+		]
+	):
+		matches.append({"type": "world", "public": public_world})
+
+	if matches.is_empty():
+		return {
+			"ok": false,
+			"status": "unknown_public_canon",
+			"message": "Nenhum fato publico canonico foi localizado para esta consulta."
+		}
+
+	return {
+		"ok": true,
+		"status": "found",
+		"authority": "canon_contract_v4_1 + active_runtime_data",
+		"matches": matches
+	}
+
+func _lookup_entity(entity_id: String, canon_contract: Dictionary) -> Dictionary:
+	for faction_value in canon_contract.get("active_factions_future_domain", []):
+		if not (faction_value is Dictionary):
+			continue
+		var faction: Dictionary = faction_value
+		if str(faction.get("id", "")) == entity_id or faction.get("legacy_ids", []).has(entity_id):
+			return {
+				"type": "faction",
+				"id": str(faction.get("id", "")),
+				"display_name": str(faction.get("display_name", "")),
+				"legacy_ids": faction.get("legacy_ids", []).duplicate()
+			}
+
+	var data_registry := _root_node("DataRegistry")
+	if data_registry == null:
+		return {}
+	var character_value = data_registry.call("get_character", entity_id)
+	if not (character_value is Dictionary):
+		return {}
+	var character: Dictionary = character_value
+	if character.is_empty() or character.get("canon", false) != true:
+		return {}
+	return _public_character(entity_id, character)
+
+func _public_character(character_id: String, character: Dictionary) -> Dictionary:
+	var output := {
+		"type": "character",
+		"id": character_id
+	}
+	for key in ["name", "role", "origin", "style", "narrative_function"]:
+		if character.has(key):
+			output[key] = character[key]
+	return output
+
+func _scene_state_get(request_context: Dictionary) -> Dictionary:
+	var public_state := {
+		"scene_id": str(request_context.get("scene_id", "")),
+		"location": str(request_context.get("location", "")),
+		"category": str(request_context.get("category", "default"))
+	}
+	var world_state := _root_node("WorldState")
+	if world_state != null:
+		public_state["current_hub"] = str(world_state.get("current_hub"))
+		public_state["week"] = int(world_state.get("week"))
+		public_state["day"] = str(world_state.get("current_day"))
+		public_state["act"] = int(world_state.get("act"))
+	return {
+		"ok": true,
+		"status": "public_scene_state",
+		"data": public_state
+	}
+
+func _progression_summary_get() -> Dictionary:
+	var progression := _root_node("ProgressionOS")
+	if progression == null:
+		return {
+			"ok": true,
+			"status": "progression_unavailable",
+			"data": {}
+		}
+	var social_xp := 0.0
+	if progression.has_method("get_domain_xp"):
+		social_xp = float(progression.call("get_domain_xp", "social"))
+	return {
+		"ok": true,
+		"status": "public_progression_summary",
+		"data": {
+			"respect": int(progression.get("respect")),
+			"social_xp": social_xp
+		}
+	}
+
+func _query_matches(query: String, searchable: String) -> bool:
+	if query == "":
+		return false
+	var normalized_searchable := searchable.to_lower()
+	if normalized_searchable.find(query) >= 0:
+		return true
+	var ignored := {
+		"quem": true, "qual": true, "quais": true, "como": true, "onde": true,
+		"que": true, "de": true, "do": true, "da": true, "dos": true, "das": true,
+		"um": true, "uma": true, "o": true, "a": true, "os": true, "as": true,
+		"e": true, "é": true, "eh": true, "no": true, "na": true
+	}
+	for raw_token in query.split(" "):
+		var token := raw_token.strip_edges()
+		if token.length() < 3 or ignored.has(token):
+			continue
+		if normalized_searchable.find(token) >= 0:
+			return true
+	return false
+
+func _root_node(name: String):
+	var loop = Engine.get_main_loop()
+	if loop == null or not (loop is SceneTree):
+		return null
+	return loop.root.get_node_or_null("/root/%s" % name)
+
+func _load_json(path: String) -> Dictionary:
+	if not FileAccess.file_exists(path):
+		return {}
+	var file := FileAccess.open(path, FileAccess.READ)
+	if file == null:
+		return {}
+	var parsed = JSON.parse_string(file.get_as_text())
+	file.close()
+	return parsed if parsed is Dictionary else {}

--- a/src/autoloads/LocalAIManager.gd
+++ b/src/autoloads/LocalAIManager.gd
@@ -5,6 +5,8 @@ signal dialogue_failed(request_id: int, npc_id: String, reason: String)
 
 enum BackendType { DISABLED, OLLAMA_HTTP, OPENAI_COMPATIBLE }
 
+const LocalAIReadOnlyTools := preload("res://src/ai/LocalAIReadOnlyTools.gd")
+
 var backend_id: String = "disabled"
 var backend_type: int = BackendType.DISABLED
 var base_url: String = ""
@@ -14,6 +16,9 @@ var timeout_seconds: float = 8.0
 var max_tokens: int = 96
 var temperature: float = 0.55
 var top_p: float = 0.85
+var num_ctx: int = 0
+var supports_tools: bool = false
+var max_tool_rounds: int = 0
 var max_response_chars: int = 420
 var max_history_messages: int = 6
 
@@ -22,6 +27,7 @@ var _queue: Array[Dictionary] = []
 var _active: Dictionary = {}
 var _next_request_id: int = 1
 var _history_by_npc: Dictionary = {}
+var _read_only_tools = LocalAIReadOnlyTools.new()
 
 func _ready() -> void:
 	_http = HTTPRequest.new()
@@ -53,6 +59,9 @@ func configure_backend(p_backend_id: String, override_url: String = "") -> bool:
 	max_tokens = int(backend_config.get("max_tokens", 96))
 	temperature = float(backend_config.get("temperature", 0.55))
 	top_p = float(backend_config.get("top_p", 0.85))
+	num_ctx = maxi(0, int(backend_config.get("num_ctx", 0)))
+	supports_tools = bool(backend_config.get("supports_tools", false))
+	max_tool_rounds = clampi(int(backend_config.get("max_tool_rounds", 0)), 0, 4)
 	chat_path = str(backend_config.get("chat_path", ""))
 	if override_url != "":
 		base_url = override_url.trim_suffix("/")
@@ -83,7 +92,9 @@ func request_dialogue(npc_id: String, user_message: String, context: Dictionary 
 		"npc_id": npc_id,
 		"user_message": clean_message,
 		"context": context.duplicate(true),
-		"fallback": fallback
+		"fallback": fallback,
+		"messages": [],
+		"tool_rounds": 0
 	}
 	if not is_network_backend_enabled():
 		call_deferred("_emit_fallback", item, "fallback_offline")
@@ -96,6 +107,23 @@ func _pump_queue() -> void:
 	if not _active.is_empty() or _queue.is_empty():
 		return
 	_active = _queue.pop_front()
+	_active["messages"] = _build_messages(_active)
+	_active["tool_rounds"] = 0
+	_dispatch_active_request()
+
+func _build_messages(item: Dictionary) -> Array:
+	var npc_id := str(item.get("npc_id", "npc"))
+	var messages: Array = [
+		{"role": "system", "content": _system_prompt_for(npc_id, item.get("context", {}))}
+	]
+	for historic_message in _history_by_npc.get(npc_id, []):
+		messages.append(historic_message)
+	messages.append({"role": "user", "content": str(item.get("user_message", ""))})
+	return messages
+
+func _dispatch_active_request() -> void:
+	if _active.is_empty():
+		return
 	var payload := _build_payload(_active)
 	var url := _build_chat_url()
 	if url == "":
@@ -115,31 +143,35 @@ func _build_chat_url() -> String:
 	return ""
 
 func _build_payload(item: Dictionary) -> Dictionary:
-	var npc_id := str(item.get("npc_id", "npc"))
-	var messages: Array = [{"role": "system", "content": _system_prompt_for(npc_id, item.get("context", {}))}]
-	for historic_message in _history_by_npc.get(npc_id, []):
-		messages.append(historic_message)
-	messages.append({"role": "user", "content": str(item.get("user_message", ""))})
+	var messages: Array = item.get("messages", [])
+	var payload: Dictionary
 	if backend_type == BackendType.OLLAMA_HTTP:
-		return {
+		var options := {
+			"temperature": temperature,
+			"top_p": top_p,
+			"num_predict": max_tokens,
+			"seed": int(item.get("request_id", 0))
+		}
+		if num_ctx > 0:
+			options["num_ctx"] = num_ctx
+		payload = {
 			"model": model_name,
 			"messages": messages,
 			"stream": false,
-			"options": {
-				"temperature": temperature,
-				"top_p": top_p,
-				"num_predict": max_tokens,
-				"seed": int(item.get("request_id", 0))
-			}
+			"options": options
 		}
-	return {
-		"model": model_name,
-		"messages": messages,
-		"stream": false,
-		"temperature": temperature,
-		"top_p": top_p,
-		"max_tokens": max_tokens
-	}
+	else:
+		payload = {
+			"model": model_name,
+			"messages": messages,
+			"stream": false,
+			"temperature": temperature,
+			"top_p": top_p,
+			"max_tokens": max_tokens
+		}
+	if supports_tools and max_tool_rounds > 0:
+		payload["tools"] = _read_only_tools.definitions()
+	return payload
 
 func _system_prompt_for(npc_id: String, context: Dictionary) -> String:
 	var character: Dictionary = DataRegistry.get_character(npc_id)
@@ -147,13 +179,20 @@ func _system_prompt_for(npc_id: String, context: Dictionary) -> String:
 	var role := str(character.get("role", "personagem"))
 	var origin := str(character.get("origin", "Baixo Sul da Bahia"))
 	var location := str(context.get("location", WorldState.current_hub))
+	var tool_rule := ""
+	if supports_tools:
+		tool_rule = """
+Quando a resposta depender de fato de lore, personagem, faccao, geografia ou estado atual que nao esteja explicitamente acima, use as ferramentas read-only antes de afirmar.
+canon_lookup e a autoridade factual publica para este dialogo. Se ela nao encontrar o fato, o personagem deve admitir que nao sabe.
+As ferramentas apenas consultam; nunca trate uma sugestao sua como mudanca de estado."""
 	return """Voce interpreta %s, personagem do jogo Cria do Tatame.
 Papel: %s. Origem: %s. Local atual: %s.
 Responda em portugues brasileiro, em no maximo tres frases curtas.
 Mantenha o canon de Ruan Macacao, Mestre Dende, Tinker Bell e do Baixo Sul da Bahia.
 Nao invente personagem principal, faccao, morte, parentesco ou evento canonico novo.
 Nao forneca instrucao real para machucar, lesionar ou finalizar uma pessoa.
-Fale como personagem, sem explicar que voce e uma IA.""" % [display_name, role, origin, location]
+Fale como personagem, sem explicar que voce e uma IA.
+A fala pode variar. O fato canonico nao.%s""" % [display_name, role, origin, location, tool_rule]
 
 func _on_request_completed(result: int, response_code: int, _headers: PackedStringArray, body: PackedByteArray) -> void:
 	if _active.is_empty():
@@ -165,8 +204,13 @@ func _on_request_completed(result: int, response_code: int, _headers: PackedStri
 	if typeof(parsed) != TYPE_DICTIONARY:
 		_finish_with_fallback("invalid_json")
 		return
-	var text := _extract_response_text(parsed)
-	text = _sanitize_response(text)
+	var message := _extract_response_message(parsed)
+	if message.is_empty():
+		_finish_with_fallback("missing_message")
+		return
+	if _continue_with_tool_calls(message):
+		return
+	var text := _sanitize_response(str(message.get("content", "")))
 	if text == "" or not _passes_safety_filter(text):
 		_finish_with_fallback("unsafe_or_empty_response")
 		return
@@ -174,17 +218,69 @@ func _on_request_completed(result: int, response_code: int, _headers: PackedStri
 	_append_history(npc_id, str(_active.get("user_message", "")), text)
 	var request_id := int(_active.get("request_id", 0))
 	var source := "ollama" if backend_type == BackendType.OLLAMA_HTTP else "openai_compatible_local"
+	if backend_id == "nex_n25_ollama":
+		source = "nex_n25_ollama"
 	_active = {}
 	dialogue_ready.emit(request_id, npc_id, text, source)
 	_pump_queue()
 
-func _extract_response_text(parsed: Dictionary) -> String:
+func _extract_response_message(parsed: Dictionary) -> Dictionary:
 	if backend_type == BackendType.OLLAMA_HTTP:
-		return str(parsed.get("message", {}).get("content", ""))
+		var ollama_message = parsed.get("message", {})
+		return ollama_message if ollama_message is Dictionary else {}
 	var choices: Array = parsed.get("choices", [])
-	if choices.is_empty() or typeof(choices[0]) != TYPE_DICTIONARY:
-		return ""
-	return str(choices[0].get("message", {}).get("content", ""))
+	if choices.is_empty() or not (choices[0] is Dictionary):
+		return {}
+	var openai_message = choices[0].get("message", {})
+	return openai_message if openai_message is Dictionary else {}
+
+func _continue_with_tool_calls(message: Dictionary) -> bool:
+	if not supports_tools or max_tool_rounds <= 0:
+		return false
+	var tool_calls: Array = message.get("tool_calls", [])
+	if tool_calls.is_empty():
+		return false
+	var rounds := int(_active.get("tool_rounds", 0))
+	if rounds >= max_tool_rounds:
+		_finish_with_fallback("tool_round_limit")
+		return true
+
+	var messages: Array = _active.get("messages", [])
+	messages.append({
+		"role": "assistant",
+		"content": str(message.get("content", "")),
+		"tool_calls": tool_calls.duplicate(true)
+	})
+
+	var request_context: Dictionary = _active.get("context", {})
+	for tool_call_value in tool_calls:
+		if not (tool_call_value is Dictionary):
+			continue
+		var tool_call: Dictionary = tool_call_value
+		var function_data = tool_call.get("function", {})
+		if not (function_data is Dictionary):
+			continue
+		var tool_name := str(function_data.get("name", ""))
+		var arguments = function_data.get("arguments", {})
+		if arguments is String:
+			var decoded = JSON.parse_string(arguments)
+			arguments = decoded if decoded is Dictionary else {}
+		elif not (arguments is Dictionary):
+			arguments = {}
+		var tool_result := _read_only_tools.execute(tool_name, arguments, request_context)
+		var tool_message := {
+			"role": "tool",
+			"content": JSON.stringify(tool_result),
+			"tool_name": tool_name
+		}
+		if tool_call.has("id"):
+			tool_message["tool_call_id"] = str(tool_call.get("id", ""))
+		messages.append(tool_message)
+
+	_active["messages"] = messages
+	_active["tool_rounds"] = rounds + 1
+	call_deferred("_dispatch_active_request")
+	return true
 
 func _append_history(npc_id: String, user_message: String, assistant_message: String) -> void:
 	var history: Array = _history_by_npc.get(npc_id, [])
@@ -250,5 +346,9 @@ func _passes_safety_filter(text: String) -> bool:
 	]
 	for phrase in blocked_phrases:
 		if lower.find(phrase) >= 0:
+			return false
+	for forbidden_value in DataRegistry.local_ai_config.get("prompt_rules", {}).get("forbidden_output_fragments", []):
+		var forbidden := str(forbidden_value).to_lower()
+		if forbidden != "" and lower.find(forbidden) >= 0:
 			return false
 	return true

--- a/tests/test_local_ai_nex_v1.py
+++ b/tests/test_local_ai_nex_v1.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+VALIDATOR = ROOT / "tools/ai/validate_local_ai_nex_v1.py"
+PROFILE = ROOT / "data/ai/nex_n25_dialogue_profile_v1.json"
+CONFIG = ROOT / "data/ai/local_ai_config_v01.json"
+
+
+class LocalAINexContractTests(unittest.TestCase):
+    def test_validator_passes(self) -> None:
+        result = subprocess.run(
+            [sys.executable, str(VALIDATOR)],
+            cwd=ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_nex_is_optional_and_bounded(self) -> None:
+        profile = json.loads(PROFILE.read_text(encoding="utf-8"))
+        config = json.loads(CONFIG.read_text(encoding="utf-8"))
+        backend = config["backends"]["nex_n25_ollama"]
+
+        self.assertFalse(profile["shipping"])
+        self.assertFalse(profile["runtime_authority"])
+        self.assertFalse(profile["critical_gameplay_dependency"])
+        self.assertTrue(backend["supports_tools"])
+        self.assertLessEqual(backend["max_tool_rounds"], 4)
+        self.assertLessEqual(backend["num_ctx"], 32768)
+
+    def test_tool_allowlist_is_read_only_slice(self) -> None:
+        profile = json.loads(PROFILE.read_text(encoding="utf-8"))
+        self.assertEqual(
+            profile["integration"]["allowed_tools"],
+            ["canon_lookup", "scene_state_get", "progression_summary_get"],
+        )
+        self.assertFalse(profile["integration"]["state_mutation_by_model"])
+        self.assertFalse(profile["integration"]["combat_use"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/ai/validate_local_ai_nex_v1.py
+++ b/tools/ai/validate_local_ai_nex_v1.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Fail-closed contract gate for the optional Nex-N2.5 local dialogue slice."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+CONFIG = ROOT / "data/ai/local_ai_config_v01.json"
+PROFILE = ROOT / "data/ai/nex_n25_dialogue_profile_v1.json"
+CANON = ROOT / "data/production/canon_contract_v4_1.json"
+MANAGER = ROOT / "src/autoloads/LocalAIManager.gd"
+TOOLS = ROOT / "src/ai/LocalAIReadOnlyTools.gd"
+DOC = ROOT / "docs/LOCAL_AI_ANDROID.md"
+
+HEX40 = re.compile(r"^[0-9a-f]{40}$")
+HEX64 = re.compile(r"^[0-9a-f]{64}$")
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"{path.relative_to(ROOT)} root must be object")
+    return value
+
+
+def require(condition: bool, message: str, errors: list[str]) -> None:
+    if not condition:
+        errors.append(message)
+
+
+def main() -> int:
+    errors: list[str] = []
+    for path in (CONFIG, PROFILE, CANON, MANAGER, TOOLS, DOC):
+        if not path.is_file():
+            errors.append(f"missing required file: {path.relative_to(ROOT)}")
+    if errors:
+        print(json.dumps({"ok": False, "errors": errors}, ensure_ascii=False, indent=2))
+        return 1
+
+    config = read_json(CONFIG)
+    profile = read_json(PROFILE)
+    canon = read_json(CANON)
+    manager = MANAGER.read_text(encoding="utf-8")
+    tools = TOOLS.read_text(encoding="utf-8")
+    doc = DOC.read_text(encoding="utf-8")
+
+    policy = config.get("runtime_policy", {})
+    require(policy.get("enabled_by_default") is False, "network AI must remain disabled by default", errors)
+    require(policy.get("combat_llm_allowed") is False, "LLM must remain forbidden in combat", errors)
+    require(policy.get("apk_requires_llm") is False, "APK must not require LLM", errors)
+    require(policy.get("fallback_required") is True, "offline fallback must remain mandatory", errors)
+    require(policy.get("network_default") is False, "network must remain opt-in", errors)
+
+    backend = config.get("backends", {}).get("nex_n25_ollama", {})
+    require(backend.get("type") == "ollama_http", "Nex backend must use ollama_http", errors)
+    require(
+        backend.get("model") == "hf.co/abenzerps/Nex-N2.5-mini-GGUF:Q4_K_M",
+        "Nex backend model reference changed",
+        errors,
+    )
+    require(backend.get("supports_tools") is True, "Nex backend must declare tool support", errors)
+    require(1 <= int(backend.get("max_tool_rounds", 0)) <= 4, "tool rounds must be bounded to 1..4", errors)
+    require(0 < int(backend.get("num_ctx", 0)) <= 32768, "default Nex context must be explicitly bounded", errors)
+
+    require(profile.get("runtime_authority") is False, "Nex cannot be runtime authority", errors)
+    require(profile.get("shipping") is False, "Nex profile cannot be shipping by default", errors)
+    require(profile.get("critical_gameplay_dependency") is False, "Nex cannot be a critical gameplay dependency", errors)
+    quant = profile.get("quantized_runtime", {})
+    require(quant.get("license") == "Apache-2.0", "quantized runtime license must be Apache-2.0", errors)
+    require(bool(HEX40.fullmatch(str(quant.get("revision", "")))), "quantized revision must be immutable SHA", errors)
+    require(bool(HEX64.fullmatch(str(quant.get("artifact_sha256", "")))), "Q4_K_M artifact SHA-256 invalid", errors)
+
+    allowed = set(profile.get("integration", {}).get("allowed_tools", []))
+    require(
+        allowed == {"canon_lookup", "scene_state_get", "progression_summary_get"},
+        f"unexpected Nex tool allowlist: {sorted(allowed)}",
+        errors,
+    )
+    require(profile.get("integration", {}).get("state_mutation_by_model") is False, "model state mutation must remain false", errors)
+    require(profile.get("integration", {}).get("combat_use") is False, "Nex combat use must remain false", errors)
+
+    factions = {
+        str(item.get("id", "")): str(item.get("display_name", ""))
+        for item in canon.get("active_factions_future_domain", [])
+        if isinstance(item, dict)
+    }
+    require(factions.get("ALE") == "Os Aleluiado", "ALE display name must follow D10", errors)
+    require(factions.get("NTM") == "Nós Tem Um Molho", "NTM display name must follow canon v4.1", errors)
+
+    for required_fragment in (
+        'preload("res://src/ai/LocalAIReadOnlyTools.gd")',
+        '"tool_calls"',
+        '"tool_name"',
+        'payload["tools"]',
+        "max_tool_rounds",
+        "tool_round_limit",
+    ):
+        require(required_fragment in manager, f"LocalAIManager missing tool-call contract: {required_fragment}", errors)
+
+    for required_fragment in (
+        'CANON_CONTRACT_PATH := "res://data/production/canon_contract_v4_1.json"',
+        '"canon_lookup"',
+        '"scene_state_get"',
+        '"progression_summary_get"',
+        '"active_factions_future_domain"',
+    ):
+        require(required_fragment in tools, f"read-only tool layer missing: {required_fragment}", errors)
+
+    forbidden_mutation_fragments = (
+        "record_event(",
+        "save_game(",
+        "change_scene",
+        ".emit(",
+        "apply_player_action",
+        "finish_combat(",
+        "skill_points =",
+        "money =",
+        "reputation =",
+    )
+    for fragment in forbidden_mutation_fragments:
+        require(fragment not in tools, f"read-only tool layer contains mutation primitive: {fragment}", errors)
+
+    stale_fragments = set(config.get("prompt_rules", {}).get("forbidden_output_fragments", []))
+    require("os aleluiados" in stale_fragments, "stale ALE output must be rejected", errors)
+    require("nós tem o molho" in stale_fragments, "stale NTM output must be rejected", errors)
+
+    require(
+        "ollama run hf.co/abenzerps/Nex-N2.5-mini-GGUF:Q4_K_M" in doc,
+        "Nex operator command missing from LOCAL_AI_ANDROID.md",
+        errors,
+    )
+    require(
+        'configure_backend("nex_n25_ollama")' in doc,
+        "Nex activation example missing from LOCAL_AI_ANDROID.md",
+        errors,
+    )
+
+    result = {"ok": not errors, "errors": errors, "checked_files": 6}
+    print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0 if not errors else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Objetivo

Primeiro lote vertical da issue #112 para experimentar `Nex-N2.5-mini` como **realizador de diálogo opcional**, sem criar segundo gateway/runtime e sem transferir autoridade de estado ou cânone para LLM.

## Dependência / ordem de merge

PR empilhado sobre **#131** (`integrate/p0-world-progression-20260912`).

Ordem pretendida:

1. #131 reconcilia P0 + living world + ProgressionOS sobre `main`;
2. este PR integra o backend Nex e a projeção read-only;
3. lotes posteriores da #112 implementam memória `fact != belief != claim`, perception/reveal e save.

Não deve ser retargetado/mergeado isoladamente em `main` enquanto a dependência não estiver reconciliada.

## Implementado

- perfil auditado `data/ai/nex_n25_dialogue_profile_v1.json`;
- backend `nex_n25_ollama` no `LocalAIManager`, desligado por padrão;
- GGUF Q4_K_M pinado no commit `52debb74f4e7cc54f4ac1146b20b0ebb205a8933` e SHA-256 do artefato registrado;
- contexto padrão limitado a 8K, timeout e `max_tool_rounds=3`;
- loop real de tool calling para Ollama `/api/chat`;
- allowlist read-only em `LocalAIReadOnlyTools.gd`:
  - `canon_lookup`;
  - `scene_state_get`;
  - `progression_summary_get`;
- nenhuma tool de escrita, combate, save, unlock, dinheiro ou reputação;
- precedência canônica para facções via `canon_contract_v4_1.json`, evitando promover nomes antigos ainda existentes em `data/brand/canon_lock.json`;
- filtro determinístico para variantes canônicas antigas conhecidas;
- fallback offline existente preservado;
- validator fail-closed + unittest + workflow dedicado;
- documentação operacional para PC, emulador e Android via LAN.

## Autoridades preservadas

- Combate: `CombatManager` / reducer determinístico;
- estado e reputação: `WorldState`;
- ledger/progressão: `ProgressionOS`;
- cânone: contratos/dados canônicos;
- LLM: **somente linguagem e consultas read-only**.

## Fora do escopo

- memória social persistente;
- relação/suspeita/belief model;
- writes via LLM;
- computer use/multimodal no runtime;
- modelo dentro do APK;
- uso de LLM no combate;
- rollout para todos os NPCs.

## Gates

O workflow `Nex Local Dialogue Gate` exige:

- backend/rede desativados por padrão;
- LLM proibida no combate;
- fallback obrigatório;
- revisão e SHA-256 da quantização registrados;
- tool allowlist exatamente read-only;
- `max_tool_rounds` limitado;
- contexto local explicitamente limitado;
- D10 (`ALE = Os Aleluiado`) e nome canônico NTM preservados;
- ausência de primitivas de mutação na camada de tools.

## Teste manual pendente

O CI não baixa ~21 GB de pesos. A prova funcional com modelo exige, em máquina de desenvolvimento:

```bash
ollama run hf.co/abenzerps/Nex-N2.5-mini-GGUF:Q4_K_M
```

E ativação explícita:

```gdscript
LocalAIManager.configure_backend("nex_n25_ollama")
```

O backend `disabled` continua sendo o modo oficial/default.

Refs #112
