### PR TITLE
chore(art): register PixelLab MCP for CRIA Sprite Forge

### DIFF
--- a/data/production/external_tool_registry_v1.json
+++ b/data/production/external_tool_registry_v1.json
@@ -26,6 +26,52 @@
       "notes": "Already integrated through qwen_pixel_art_profile_v1. Training dataset provenance is not disclosed, therefore generation never implies shipping rights."
     },
     {
+      "id": "pixellab_mcp",
+      "kind": "remote_mcp_service",
+      "source": "https://api.pixellab.ai/mcp",
+      "revision": "docs-audited-2026-09-12_terms-2025-11-23",
+      "license_status": "SERVICE_TERMS_COMMERCIAL_OUTPUT_ALLOWED_NO_MODEL_TRAINING",
+      "adoption": "ADOPTED_EXTERNAL_AUTHORING_PROVIDER",
+      "direct_code_reuse": false,
+      "direct_asset_reuse": false,
+      "runtime_dependency": false,
+      "shipping_default": false,
+      "canon_authority": false,
+      "authentication": {
+        "scheme": "bearer",
+        "secret_policy": "environment_or_secret_store_only",
+        "forbid_repository_token": true
+      },
+      "output_policy": {
+        "generated_outputs_may_be_commercial_candidates": true,
+        "automatic_shipping": false,
+        "human_visual_review_required": true,
+        "asset_sidecar_and_provenance_required": true,
+        "model_training_reuse_without_written_permission": false
+      },
+      "cria_roles": [
+        "pixel_art_candidate_generation",
+        "character_identity_candidate",
+        "directional_character_views",
+        "locomotion_animation_candidate",
+        "non_authoritative_action_animation_candidate",
+        "tileset_candidate_generation",
+        "map_prop_candidate_generation",
+        "vehicle_sprite_candidate_generation",
+        "ui_icon_candidate_generation",
+        "reference_conditioned_generation",
+        "background_removal_and_editing"
+      ],
+      "blocked_roles": [
+        "canon_authority",
+        "bjj_legality_authority",
+        "combat_scoring_authority",
+        "runtime_required_generation",
+        "automatic_shipping_promotion"
+      ],
+      "notes": "Official PixelLab remote MCP authoring endpoint. Use only as an interchangeable CRIA Sprite Forge candidate generator. PixelLab documentation advertises character, animation, tileset, UI and pixel-art generation; terms dated 2025-11-23 allow commercial use of generated creations while forbidding training new models on generated images without explicit written permission. Never commit bearer tokens. Outputs remain shipping=false until CRIA provenance, identity, visual, rights, BJJ-when-applicable and Godot runtime gates pass."
+    },
+    {
       "id": "claude_code_game_studios",
       "kind": "github_repo",
       "source": "Donchitos/Claude-Code-Game-Studios",

--- a/data/visual/pixellab_mcp_profile_v1.json
+++ b/data/visual/pixellab_mcp_profile_v1.json
@@ -1,0 +1,112 @@
+{
+  "$schema": "cria.pixellab_mcp_profile.v1",
+  "version": "1.0.0",
+  "provider_id": "pixellab_mcp",
+  "status": "AUTHORING_PROVIDER_CANDIDATE",
+  "shipping": false,
+  "runtime_dependency": false,
+  "canon_authority": false,
+  "bjj_authority": false,
+  "endpoint": "https://api.pixellab.ai/mcp",
+  "transport": "remote_http_mcp",
+  "authentication": {
+    "scheme": "bearer",
+    "token_env": "PIXELLAB_API_TOKEN",
+    "token_must_never_be_committed": true,
+    "token_must_never_be_written_to_asset_sidecars": true
+  },
+  "official_docs": {
+    "ways_to_use": "https://www.pixellab.ai/docs/ways-to-use-pixellab",
+    "api_docs": "https://api.pixellab.ai/v2/docs",
+    "terms": "https://www.pixellab.ai/termsofservice",
+    "audited_at": "2026-09-12"
+  },
+  "documented_capabilities": [
+    "pixel_art_image_generation",
+    "reference_conditioned_generation",
+    "character_generation",
+    "directional_character_views",
+    "text_driven_animation",
+    "tileset_generation",
+    "ui_asset_generation",
+    "image_editing",
+    "background_removal"
+  ],
+  "preferred_cria_uses": [
+    "character_identity_candidates_after_identity_spec_exists",
+    "directional_world_sprites",
+    "idle_walk_run_and_nonsemantic_locomotion_candidates",
+    "vehicle_sprite_candidates_including_kombi",
+    "world_props_and_resource_icons",
+    "map_tileset_candidates",
+    "hud_and_ui_icon_candidates",
+    "arena_prop_candidates"
+  ],
+  "conditional_uses": [
+    {
+      "use": "combat_animation_candidate",
+      "condition": "only_after_cria_combat_intelligence_and_grappling_motion_lab_define_technique_phases_contacts_roles_and_legality"
+    },
+    {
+      "use": "paired_bjj_sprite_candidate",
+      "condition": "must_follow_authoritative_technique_id_sync_map_pivots_contact_contract_and_human_biomechanical_review"
+    }
+  ],
+  "forbidden_uses": [
+    "define_canon",
+    "invent_bjj_technique",
+    "decide_bjj_legality",
+    "decide_combat_score",
+    "replace_authoritative_motion_contract",
+    "automatic_shipping_promotion",
+    "runtime_required_asset_generation",
+    "train_new_models_on_pixellab_outputs_without_written_permission"
+  ],
+  "sprite_forge_handoff": {
+    "candidate_only": true,
+    "required_metadata": [
+      "provider_id",
+      "generation_tool",
+      "prompt_or_instruction_hash",
+      "reference_asset_ids",
+      "generation_timestamp",
+      "output_sha256",
+      "terms_audit_date",
+      "human_reviewer",
+      "qa_profile"
+    ],
+    "required_gates": [
+      "identity_lock",
+      "palette_and_style",
+      "content_bounds",
+      "pivot_and_scale",
+      "alpha_cleanup",
+      "visual_artifact_review",
+      "rights_and_provenance",
+      "bjj_semantics_when_applicable",
+      "godot_preview",
+      "human_approval"
+    ],
+    "normalized_gameplay_frame": {
+      "width": 128,
+      "height": 128,
+      "pivot": [64, 96],
+      "resampling": "nearest_neighbor",
+      "integer_scale_only": true
+    }
+  },
+  "work_batch_policy": {
+    "default_batch_size": 10,
+    "one_asset_per_output_file": true,
+    "no_collage_for_runtime_assets": true,
+    "qa_before_next_batch": true,
+    "raw_outputs_remain_candidates": true
+  },
+  "commercial_output_policy": {
+    "terms_snapshot": "2025-11-23",
+    "commercial_use_reported_allowed": true,
+    "user_responsible_for_third_party_rights": true,
+    "model_training_on_outputs_without_written_permission": false,
+    "automatic_rights_clearance": false
+  }
+}

--- a/docs/production/PIXELLAB_MCP_SPRITE_FORGE_V1.md
+++ b/docs/production/PIXELLAB_MCP_SPRITE_FORGE_V1.md
@@ -1,0 +1,197 @@
+# PixelLab MCP → CRIA Sprite Forge v1
+
+**Status:** authoring-provider candidate  
+**Runtime dependency:** no  
+**Shipping default:** false  
+**Provider id:** `pixellab_mcp`
+
+## Purpose
+
+PixelLab is registered as an **external authoring provider** for CRIA DO TATAME. It may generate or edit pixel-art candidates for characters, directional sprites, locomotion, vehicles, props, tilesets and UI. It is not canon authority, BJJ authority, combat authority, release authority or a runtime dependency.
+
+The endpoint is:
+
+```text
+https://api.pixellab.ai/mcp
+```
+
+Authentication uses a bearer token supplied by the execution environment. Never commit a PixelLab token, paste it into tracked JSON/Markdown, or write it into asset sidecars.
+
+Recommended secret name:
+
+```text
+PIXELLAB_API_TOKEN
+```
+
+## Integration boundary
+
+```text
+CRIA requirement
+    ↓
+canon + art direction + identity lock
+    ↓
+PixelLab MCP generation/editing
+    ↓
+RAW CANDIDATE (shipping=false)
+    ↓
+CRIA Sprite Forge v2
+    ↓
+normalize / crop / content bounds / pivot / alpha / palette
+    ↓
+BJJ semantic gate when applicable
+    ↓
+Godot preview
+    ↓
+human visual approval + provenance/rights review
+    ↓
+registry + runtime evidence
+    ↓
+shipping candidate
+```
+
+PixelLab never promotes its own outputs.
+
+## Best uses in CRIA
+
+### Characters
+
+Use after an identity specification or approved master exists:
+
+- turnaround candidates;
+- front/back/side directional views;
+- world locomotion;
+- idle/walk/run;
+- portraits and controlled expressions;
+- clothing variants that preserve identity.
+
+Reference conditioning should always start from the approved identity master. A fresh text-only generation is not allowed to silently redefine a canonical fighter.
+
+### Kombi and vehicles
+
+High-value use for the vehicle exploration system:
+
+- Kombi rear view;
+- rear 3/4 left/right;
+- side views;
+- lean/turn states;
+- headlight and taillight variants;
+- damage-state candidates;
+- motorcycles and fictional regional traffic sprites;
+- road props.
+
+The vehicle gameplay contract remains authoritative. PixelLab only renders candidates.
+
+### World and map
+
+Good candidates:
+
+- cacao, piaçava, fishing and plant icons;
+- mangrove and tropical vegetation props;
+- bridges, piers, stalls, fences and colonial facade pieces;
+- tilesets;
+- route markers and HUD icons;
+- arena/environment props.
+
+A generated flat environment is never accepted as navigation/collision truth. World collision, walkability, routes and node state remain data-driven in Godot.
+
+### BJJ / combat
+
+PixelLab may render **only after** Combat Intelligence / Motion Lab provides:
+
+- technique id;
+- source and target positions;
+- attacker/defender roles;
+- GI/NO-GI modality;
+- six motion phases;
+- pivots;
+- contact points;
+- sync map;
+- legal/illegal semantics.
+
+Do not prompt PixelLab with generic requests such as `make a cool grappling attack` and treat the result as a valid technique.
+
+## Production policy
+
+For production assets:
+
+```text
+1 requirement
+→ 1 generated asset/file
+→ QA
+→ sidecar
+→ registry
+→ next asset
+```
+
+Default CRIA batch size for controlled production is **10 assets**, but each output remains an individual file. Collages/sheets are allowed only when the requirement itself is a presentation/reference sheet or authored sprite sheet.
+
+Raw provider outputs stay outside final runtime paths until approved.
+
+## Sprite Forge normalization
+
+Gameplay character frames continue to use the CRIA contract:
+
+- 128×128 RGBA normalized frame;
+- pivot `[64,96]` for upright fighters;
+- nearest-neighbor resampling;
+- integer scaling;
+- clean alpha;
+- detached FX separate from body sprites;
+- no text/watermark hallucination;
+- identity-lock comparison before approval.
+
+The high-resolution PixelLab output may be retained as source/provenance material, while the normalized runtime derivative is generated deterministically by CRIA tooling.
+
+## Asset metadata
+
+Every accepted candidate should record at minimum:
+
+```json
+{
+  "provider_id": "pixellab_mcp",
+  "generation_tool": "<tool returned by MCP>",
+  "reference_asset_ids": [],
+  "output_sha256": "<sha256>",
+  "terms_audit_date": "2026-09-12",
+  "qa_profile": "<profile>",
+  "shipping": false
+}
+```
+
+Do not record API tokens, authorization headers or private account identifiers.
+
+## Legal / output policy snapshot
+
+The PixelLab terms audited on 2026-09-12 state that generated creations may be used commercially and that users retain rights in their creations, subject to responsibility for third-party rights. The same terms prohibit using PixelLab-generated images to train new models without explicit written permission.
+
+This is **not** automatic clearance for every output. CRIA still applies its own rights/provenance and human-review gates before shipping.
+
+## Connection checklist for ChatGPT Work / Codex
+
+When the execution environment supports adding a remote MCP server:
+
+1. add the endpoint `https://api.pixellab.ai/mcp`;
+2. provide the bearer token through the environment/secret store;
+3. keep the token outside the repository;
+4. confirm the MCP tool inventory before generating assets;
+5. use `data/visual/pixellab_mcp_profile_v1.json` as the provider policy;
+6. use `.agents/skills/cria-sprite-forge/SKILL.md` for manufacturing/QA;
+7. use `.agents/skills/cria-art-direction/SKILL.md` for visual direction;
+8. apply Combat Intelligence + Motion Lab before any BJJ animation generation.
+
+## First recommended production slice
+
+Do not start by generating the whole roster. Validate the adapter on a narrow set:
+
+1. Kombi rear master;
+2. Kombi rear 3/4 left;
+3. Kombi rear 3/4 right;
+4. cacao resource icon;
+5. piaçava resource icon;
+6. fishing resource icon;
+7. Ruan world idle candidate from approved identity reference;
+8. Davi world idle candidate from approved identity reference;
+9. Terreiro modular prop;
+10. road-side Baixo Sul vegetation prop.
+
+If identity/style/alpha/scale QA passes consistently, expand to the next controlled batch.

--- a/tools/ci/validate_external_tool_registry_v1.py
+++ b/tools/ci/validate_external_tool_registry_v1.py
@@ -123,6 +123,25 @@ def main() -> int:
         if sid == "claude_code_game_studios":
             if license_status != "CLEAR_MIT" or adoption != "PORT_SELECTED_PATTERNS":
                 errors.append("Claude Code Game Studios must remain selected-pattern port only under MIT")
+        elif sid == "pixellab_mcp":
+            if entry.get("kind") != "remote_mcp_service":
+                errors.append("PixelLab must remain a remote MCP authoring service")
+            if entry.get("source") != "https://api.pixellab.ai/mcp":
+                errors.append("PixelLab MCP endpoint must remain the audited official endpoint")
+            if adoption != "ADOPTED_EXTERNAL_AUTHORING_PROVIDER":
+                errors.append("PixelLab must remain an external authoring provider")
+            if direct_code or direct_asset:
+                errors.append("PixelLab registry entry must not imply direct upstream code/asset reuse")
+            if entry.get("runtime_dependency") is not False or entry.get("shipping_default") is not False or entry.get("canon_authority") is not False:
+                errors.append("PixelLab must remain non-runtime, shipping=false and non-canonical")
+            auth = entry.get("authentication", {})
+            if auth.get("scheme") != "bearer" or auth.get("forbid_repository_token") is not True:
+                errors.append("PixelLab bearer token must be secret-store/environment only")
+            output_policy = entry.get("output_policy", {})
+            if output_policy.get("automatic_shipping") is not False or output_policy.get("human_visual_review_required") is not True:
+                errors.append("PixelLab outputs must remain candidate-only and human-reviewed")
+            if output_policy.get("model_training_reuse_without_written_permission") is not False:
+                errors.append("PixelLab outputs must not be authorized for model training without written permission")
         elif sid == "wolfcha":
             if direct_code or license_status != "CONFLICT_README_MIT_LICENSE_FILE_APACHE_2_0":
                 errors.append("Wolfcha must remain no-copy while README/LICENSE discrepancy is unresolved")
@@ -141,6 +160,7 @@ def main() -> int:
 
     required = {
         "qwen_2512_pixel_art_lora",
+        "pixellab_mcp",
         "claude_code_game_studios",
         "wolfcha",
         "cline_qwen_snes_engine",


### PR DESCRIPTION
## Objetivo

Registrar o endpoint oficial do PixelLab MCP como **provider externo de authoring** do CRIA Sprite Forge, sem transformá-lo em dependência de runtime, autoridade de cânone ou mecanismo de promoção automática de assets.

## Mudanças

- registra `pixellab_mcp` em `data/production/external_tool_registry_v1.json`;
- adiciona `data/visual/pixellab_mcp_profile_v1.json` com política machine-readable;
- adiciona `docs/production/PIXELLAB_MCP_SPRITE_FORGE_V1.md` com workflow para ChatGPT Work/Codex;
- reforça `tools/ci/validate_external_tool_registry_v1.py` para impedir drift do endpoint, token no repo, runtime dependency, auto-shipping ou uso para treinamento de modelos sem autorização escrita.

## Política adotada

- endpoint: `https://api.pixellab.ai/mcp`;
- bearer token somente via environment/secret store;
- token nunca entra no Git;
- outputs nascem `shipping=false`;
- PixelLab é gerador/editor de candidatos, não autoridade visual final;
- BJJ só pode ser renderizado depois de Combat Intelligence/Motion Lab definirem técnica, fases, contatos, pivôs e sync map;
- nenhum gameplay crítico depende do serviço remoto;
- uso comercial de outputs tratado conforme snapshot dos termos auditado em 2026-09-12, ainda sujeito a provenance/rights review do CRIA;
- proibido reutilizar outputs para treinar modelos sem autorização escrita do provedor.

## Primeiro lote recomendado após conexão

1. Kombi rear master;
2. Kombi rear 3/4 left;
3. Kombi rear 3/4 right;
4. ícone cacau;
5. ícone piaçava;
6. ícone pesca;
7. Ruan world idle;
8. Davi world idle;
9. prop modular do Terreiro;
10. vegetação lateral de estrada do Baixo Sul.

Todos como arquivos individuais e candidatos, com QA antes do próximo lote.

## Segurança

Nenhum segredo ou token foi versionado. Este PR não altera `project.godot`, autoloads, combate, save ou runtime.
